### PR TITLE
IE8 Fix, apply requires empty array

### DIFF
--- a/src/misceval.js
+++ b/src/misceval.js
@@ -528,7 +528,7 @@ Sk.misceval.buildClass = function(globals, func, name, bases)
 
     // init the dict for the class
     //print("CALLING", func);
-    func(globals, locals);
+    func(globals, locals, []);
 
     // file's __name__ is class's __module__
     locals.__module__ = globals['__name__'];


### PR DESCRIPTION
.apply does not work when called with (null,undefined) second parameter must be an array.
