### PR TITLE
Add CSS class to the unit test results DIV

### DIFF
--- a/src/lib/unittestgui/__init__.py
+++ b/src/lib/unittestgui/__init__.py
@@ -16,6 +16,7 @@ class unittest:
         else:
             self.resdiv = document.createElement('div')
             self.resdiv.setAttribute('id',self.divid+'_unit_results')
+            self.resdiv.setAttribute('class','unittest-results')
         self.mydiv.appendChild(self.resdiv)
 
         self.testlist = []


### PR DESCRIPTION
I've added a CSS class to the results div that the unit test module generates. This is to allow the div to be styled via CSS (specifically for the Runestone project but it seems like it would be useful for other users also).
