### PR TITLE
math module test portability (t440.py)

### DIFF
--- a/test/run/t440.py
+++ b/test/run/t440.py
@@ -1,5 +1,8 @@
 import math
 
+def isCloseTo(expected, actual, precision):
+  return math.fabs(expected - actual) < (math.pow(10, -precision) / 2)
+
 print "\nmath.acos(x)"
 print math.acos(1.0)
 print math.acos(0.5)
@@ -45,8 +48,7 @@ print math.sin(1)
 
 print "\nmath.tan(x)"
 print math.tan(0.0)
-print math.tan(math.pi/2.0)
-print math.tan(math.pi)
+print isCloseTo(0, math.tan(math.pi), 15)
 print math.tan(1)
 
 print "\nmath.degrees(x)"

--- a/test/run/t440.py.real
+++ b/test/run/t440.py.real
@@ -44,8 +44,7 @@ math.sin(x)
 
 math.tan(x)
 0.0
-1.63312393532e+16
--1.22464679915e-16
+True
 1.55740772465
 
 math.degrees(x)

--- a/test/run/t440.py.real.force
+++ b/test/run/t440.py.real.force
@@ -44,8 +44,7 @@ math.sin(x)
 
 math.tan(x)
 0.0
-1.63312393532e+16
--1.22464679915e-16
+True
 1.55740772465
 
 math.degrees(x)


### PR DESCRIPTION
t440.py fails on my machine (Linux on ThinkPad) in trying to correctly compute the tangent of pi/2 and pi. This appears to be due to implementation details in math coprocessors rather than an error in the Skulpt Python math module wrapper. I tried to retain as many of the existing math.tan tests as possible by implementing a function isCloseTo(expected, actual, precision). The tan(pi/2) test was lost and the tan(pi) test was retained with this approximate test.
