### PR TITLE
CRLF to LF This caused all tests to fail on windows.

### DIFF
--- a/m
+++ b/m
@@ -203,10 +203,12 @@ def buildVFS():
                     if ".swp" in f: continue
                     if ".pyc" in f: continue
                     data = open(f, "rb").read()
+                    data = data.replace("\r\n", "\n")
                     all.append("'%s': '%s'" % (f.replace("\\", "/"), data.encode("hex")))
         print >>out, ",\n".join(all)
         print >>out, "};"
         print >>out, """
+
 function readFromVFS(fn)
 {
     var hexToStr = function(str)


### PR DESCRIPTION
I don't know if you want to pull this. And I haven't tested this on my mac, but I don't think it'll hurt anything. I might get around to that tonight. Apparently reading files with python on windows converts all `\n` 's to `\r\n` 's.
