### PR TITLE
Added simple 'document' module example

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -39,6 +39,7 @@ Python and reload.</p>
         <a href="#" id="codeexample5">5</a>
         <a href="#" id="codeexample6">6</a>
         <a href="#" id="codeexample7">7</a>.
+        <a href="#" id="codeexample8">8</a>.
         Ctrl-Enter to run.
     </p>
 

--- a/doc/static/env/editor.js
+++ b/doc/static/env/editor.js
@@ -33,6 +33,7 @@ $(document).ready(function() {
     exampleCode('#codeexample5', "print \"%s:%r:%d:%x\\n%#-+37.34o\" % (\n        \"dog\",\n        \"cat\",\n        23456,\n        999999999999L,\n        0123456702345670123456701234567L)");
     exampleCode('#codeexample6', "def genr(n):\n    i = 0\n    while i < n:\n        yield i\n        i += 1\n\nprint list(genr(12))\n");
     exampleCode('#codeexample7', "# obscure C3 MRO example from Python docs\nclass O(object): pass\nclass A(O): pass\nclass B(O): pass\nclass C(O): pass\nclass D(O): pass\nclass E(O): pass\nclass K1(A,B,C): pass\nclass K2(D,B,E): pass\nclass K3(D,A): pass\nclass Z(K1,K2,K3): pass\nprint Z.__mro__\n");
+    exampleCode('#codeexample8', "import document\n\npre = document.getElementById('edoutput')\npre.innerHTML = '''\n<h1> Skulpt can also access DOM! </h1>\n''' \n");
 
     $('#clearoutput').click(function(e)
             {


### PR DESCRIPTION
In #50 we discussed that it might be worth showing off in the examples that skulpt is also capable of accessing DOM.

This pull request adds a simple example.
