### PR TITLE
Fixing situation when assert has no explanation

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -79,7 +79,7 @@ Sk.builtin.Exception.prototype.tp$str = function()
 
     ret += this.tp$name;
     if (this.args)
-        ret += ": " + this.args.v[0].v;
+        ret += ": " + (this.args.v.length > 0 ? this.args.v[0].v : '');
     ret += " on line " + this.lineno;
 
     if (this.args.v.length > 4)


### PR DESCRIPTION
I believe that this small change should fix the issue described in #8.

CPython handles this in a way that shows just 

```
AssertionError
```

whereas after applying this pull request skulpt will show

```
AssertionError:
```

What do you think about that? Is it worth changing?

---

Obviously, something like

```
assert 1 == 0, 'this should fail'
```

will result into

```
AssertionError: this should fail on line 1
```
