### PR TITLE
Operator Overloading

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -13,7 +13,7 @@ Sk.abstr = {};
 Sk.abstr.typeName = function(v) {
     var vtypename;
     if (v instanceof Sk.builtin.nmber) {
-	vtypename = v.skType;
+        vtypename = v.skType;
     } else if (v.tp$name !== undefined) {
         vtypename = v.tp$name;
     } else {
@@ -31,71 +31,84 @@ Sk.abstr.binop_type_error = function(v, w, name)
             + vtypename + "' and '" + wtypename + "'");
 };
 
-// this can't be a table for closure
-// bnm -- this seems like the most logical place to add support for user defined
-//        operators. (__xxx__ that I've defined in my own class)
-Sk.abstr.boNameToSlotFunc_ = function(obj, name)
-{
-    if (obj === null) {
-        return undefined;
-    };
-
-    switch (name)
-    {
-        case "Add": return obj.nb$add ? obj.nb$add : obj['__add__'];
-        case "Sub": return obj.nb$subtract ? obj.nb$subtract : obj['__sub__'];
-        case "Mult": return obj.nb$multiply ? obj.nb$multiply : obj['__mul__'];
-        case "Div": return obj.nb$divide ? obj.nb$divide : obj['__div__'];
-        case "FloorDiv": return obj.nb$floor_divide ? obj.nb$floor_divide : obj['__floordiv__'];
-        case "Mod": return obj.nb$remainder ? obj.nb$remainder : obj['__mod__'];
-        case "Pow": return obj.nb$power ? obj.nb$power : obj['__pow__'];
-        case "LShift": return obj.nb$lshift;
-        case "RShift": return obj.nb$rshift;
-        case "BitAnd": return obj.nb$and;
-        case "BitOr": return obj.nb$or;
-        case "BitXor": return obj.nb$xor;
-    }
+Sk.abstr.boNameToSlotFuncLhs_ = function(obj, name) {
+  if (obj === null) {
+    return undefined;
+  };
+  switch (name) {
+    case "Add":      return obj.nb$add          ? obj.nb$add :          obj['__add__'];
+    case "Sub":      return obj.nb$subtract     ? obj.nb$subtract :     obj['__sub__'];
+    case "Mult":     return obj.nb$multiply     ? obj.nb$multiply :     obj['__mul__'];
+    case "Div":      return obj.nb$divide       ? obj.nb$divide :       obj['__div__'];
+    case "FloorDiv": return obj.nb$floor_divide ? obj.nb$floor_divide : obj['__floordiv__'];
+    case "Mod":      return obj.nb$remainder    ? obj.nb$remainder :    obj['__mod__'];
+    case "Pow":      return obj.nb$power        ? obj.nb$power :        obj['__pow__'];
+    case "LShift":   return obj.nb$lshift       ? obj.nb$lshift :       obj['__lshift__'];
+    case "RShift":   return obj.nb$rshift       ? obj.nb$rshift :       obj['__rshift__'];
+    case "BitAnd":   return obj.nb$and          ? obj.nb$and :          obj['__and__'];
+    case "BitXor":   return obj.nb$xor          ? obj.nb$xor :          obj['__xor__'];
+    case "BitOr":    return obj.nb$or           ? obj.nb$or :           obj['__or__'];
+  }
 };
-Sk.abstr.iboNameToSlotFunc_ = function(obj, name)
-{
-    switch (name)
-    {
-        case "Add": return obj.nb$inplace_add;
-        case "Sub": return obj.nb$inplace_subtract;
-        case "Mult": return obj.nb$inplace_multiply;
-        case "Div": return obj.nb$inplace_divide;
-        case "FloorDiv": return obj.nb$inplace_floor_divide;
-        case "Mod": return obj.nb$inplace_remainder;
-        case "Pow": return obj.nb$inplace_power;
-        case "LShift": return obj.nb$inplace_lshift;
-        case "RShift": return obj.nb$inplace_rshift;
-        case "BitAnd": return obj.nb$inplace_and;
-        case "BitOr": return obj.nb$inplace_or;
-        case "BitXor": return obj.nb$inplace_xor;
-    }
+
+Sk.abstr.boNameToSlotFuncRhs_ = function(obj, name) {
+  if (obj === null) {
+    return undefined;
+  };
+  switch (name) {
+    case "Add":      return obj.nb$add          ? obj.nb$add :          obj['__radd__'];
+    case "Sub":      return obj.nb$subtract     ? obj.nb$subtract :     obj['__rsub__'];
+    case "Mult":     return obj.nb$multiply     ? obj.nb$multiply :     obj['__rmul__'];
+    case "Div":      return obj.nb$divide       ? obj.nb$divide :       obj['__rdiv__'];
+    case "FloorDiv": return obj.nb$floor_divide ? obj.nb$floor_divide : obj['__rfloordiv__'];
+    case "Mod":      return obj.nb$remainder    ? obj.nb$remainder :    obj['__rmod__'];
+    case "Pow":      return obj.nb$power        ? obj.nb$power :        obj['__rpow__'];
+    case "LShift":   return obj.nb$lshift       ? obj.nb$lshift :       obj['__rlshift__'];
+    case "RShift":   return obj.nb$rshift       ? obj.nb$rshift :       obj['__rrshift__'];
+    case "BitAnd":   return obj.nb$and          ? obj.nb$and :          obj['__rand__'];
+    case "BitXor":   return obj.nb$xor          ? obj.nb$xor :          obj['__rxor__'];
+    case "BitOr":    return obj.nb$or           ? obj.nb$or :           obj['__ror__'];
+  }
+};
+
+Sk.abstr.iboNameToSlotFunc_ = function(obj, name) {
+  switch (name) {
+    case "Add":      return obj.nb$inplace_add          ? obj.nb$inplace_add          : obj['__iadd__'];
+    case "Sub":      return obj.nb$inplace_subtract     ? obj.nb$inplace_subtract     : obj['__isub__'];
+    case "Mult":     return obj.nb$inplace_multiply     ? obj.nb$inplace_multiply     : obj['__imul__'];
+    case "Div":      return obj.nb$inplace_divide       ? obj.nb$inplace_divide       : obj['__idiv__'];
+    case "FloorDiv": return obj.nb$inplace_floor_divide ? obj.nb$inplace_floor_divide : obj['__ifloordiv__'];
+    case "Mod":      return obj.nb$inplace_remainder;
+    case "Pow":      return obj.nb$inplace_power;
+    case "LShift":   return obj.nb$inplace_lshift       ? obj.nb$inplace_lshift       : obj['__ilshift__'];
+    case "RShift":   return obj.nb$inplace_rshift       ? obj.nb$inplace_rshift       : obj['__irshift__'];
+    case "BitAnd":   return obj.nb$inplace_and;
+    case "BitOr":    return obj.nb$inplace_or;
+    case "BitXor":   return obj.nb$inplace_xor          ? obj.nb$inplace_xor          : obj['__ixor__'];
+  }
 };
 
 Sk.abstr.binary_op_ = function(v, w, opname)
 {
     var ret;
-    var vop = Sk.abstr.boNameToSlotFunc_(v, opname);
+    var vop = Sk.abstr.boNameToSlotFuncLhs_(v, opname);
     if (vop !== undefined)
-    {	
-		if (vop.call) {
-        	ret = vop.call(v, w);
-		} else {  // assume that vop is an __xxx__ type method
-			ret = Sk.misceval.callsim(vop,v,w)
-		}
+    {
+        if (vop.call) {
+            ret = vop.call(v, w);
+        } else {
+            ret = Sk.misceval.callsim(vop,v,w)
+        }
         if (ret !== undefined) return ret;
     }
-    var wop = Sk.abstr.boNameToSlotFunc_(w, opname);
+    var wop = Sk.abstr.boNameToSlotFuncRhs_(w, opname);
     if (wop !== undefined)
     {
-		if (wop.call) {
-        	ret = wop.call(w, v);
-		} else { // assume that wop is an __xxx__ type method
-			ret = Sk.misceval.callsim(wop,w,v)
-		}
+        if (wop.call) {
+            ret = wop.call(w, v);
+        } else {
+            ret = Sk.misceval.callsim(wop,w,v)
+        }
         if (ret !== undefined) return ret;
     }
     Sk.abstr.binop_type_error(v, w, opname);
@@ -107,21 +120,21 @@ Sk.abstr.binary_iop_ = function(v, w, opname)
     var vop = Sk.abstr.iboNameToSlotFunc_(v, opname);
     if (vop !== undefined)
     {
-	if (vop.call) {
+    if (vop.call) {
             ret = vop.call(v, w);
-	} else {  // assume that vop is an __xxx__ type method
-	    ret = Sk.misceval.callsim(vop,v,w);	//	added to be like not-in-place... is this okay?
-		}
+    } else {  // assume that vop is an __xxx__ type method
+        ret = Sk.misceval.callsim(vop,v,w); //  added to be like not-in-place... is this okay?
+        }
         if (ret !== undefined) return ret;
     }
     var wop = Sk.abstr.iboNameToSlotFunc_(w, opname);
     if (wop !== undefined)
     {
-	if (wop.call) {
+    if (wop.call) {
             ret = wop.call(w, v);
-	} else { // assume that wop is an __xxx__ type method
-	    ret = Sk.misceval.callsim(wop,w,v);	//	added to be like not-in-place... is this okay?
-		}
+    } else { // assume that wop is an __xxx__ type method
+        ret = Sk.misceval.callsim(wop,w,v); //  added to be like not-in-place... is this okay?
+        }
         if (ret !== undefined) return ret;
     }
     Sk.abstr.binop_type_error(v, w, opname);
@@ -139,32 +152,31 @@ Sk.abstr.numOpAndPromote = function(a, b, opfn)
     if (typeof a === "number" && typeof b === "number")
     {
         var ans = opfn(a, b);
-        // todo; handle float	Removed RNL (bugs in lng, and it should be a question of precision, not magnitude -- this was just wrong)
-        if ( (ans > Sk.builtin.lng.threshold$ || ans < -Sk.builtin.lng.threshold$)	// RNL
-        && Math.floor(ans) === ans)	{												// RNL
-            return [Sk.builtin.lng.fromInt$(a), Sk.builtin.lng.fromInt$(b)];		// RNL
-        } else																		// RNL
+        // todo; handle float   Removed RNL (bugs in lng, and it should be a question of precision, not magnitude -- this was just wrong)
+        if ( (ans > Sk.builtin.lng.threshold$ || ans < -Sk.builtin.lng.threshold$) && Math.floor(ans) === ans) {
+            return [Sk.builtin.lng.fromInt$(a), Sk.builtin.lng.fromInt$(b)];
+        } else
             return ans;
     }
-	else if (a === undefined || b === undefined) {
-		throw new Sk.builtin.NameError('Undefined variable in expression')
-	}
+    else if (a === undefined || b === undefined) {
+        throw new Sk.builtin.NameError('Undefined variable in expression')
+    }
 
-	if (a.constructor === Sk.builtin.lng) {
-//		if (b.constructor == Sk.builtin.nmber)
-//			if (b.skType == Sk.builtin.nmber.float$) {
-//				var tmp = new Sk.builtin.nmber(a.tp$str(), Sk.builtin.nmber.float$);
-//				return [tmp, b];
-//			} else
-//				return [a, b.v];
-		return [a, b];
-	} else if (a.constructor === Sk.builtin.nmber) {
-		return [a, b];
-	} else if (typeof a === "number") {
-		var tmp = new Sk.builtin.nmber(a, undefined);
-		return [tmp, b];
-	} else
-		return undefined;
+    if (a.constructor === Sk.builtin.lng) {
+//      if (b.constructor == Sk.builtin.nmber)
+//          if (b.skType == Sk.builtin.nmber.float$) {
+//              var tmp = new Sk.builtin.nmber(a.tp$str(), Sk.builtin.nmber.float$);
+//              return [tmp, b];
+//          } else
+//              return [a, b.v];
+        return [a, b];
+    } else if (a.constructor === Sk.builtin.nmber) {
+        return [a, b];
+    } else if (typeof a === "number") {
+        var tmp = new Sk.builtin.nmber(a, undefined);
+        return [tmp, b];
+    } else
+        return undefined;
 };
 
 Sk.abstr.boNumPromote_ = {
@@ -211,17 +223,17 @@ Sk.abstr.boNumPromote_ = {
         return m;
     },
     "LShift": function(a, b) { 
-	if (b < 0) {
-	    throw new Sk.builtin.ValueError("negative shift count");
-	}
-	var m = a << b;
-	if (m > a) {
-	    return m; 
-	}
-	else {
-	    // Fail, this will get recomputed with longs
-	    return a * Math.pow(2, b);
-	}
+    if (b < 0) {
+        throw new Sk.builtin.ValueError("negative shift count");
+    }
+    var m = a << b;
+    if (m > a) {
+        return m; 
+    }
+    else {
+        // Fail, this will get recomputed with longs
+        return a * Math.pow(2, b);
+    }
     },
     "RShift": function(a, b) { 
         if (b < 0) {
@@ -246,14 +258,14 @@ Sk.abstr.numberBinOp = function(v, w, op)
         {
             return tmp;
         }
-		else if (tmp !== undefined &&  tmp.constructor === Sk.builtin.nmber)
-		{
+        else if (tmp !== undefined &&  tmp.constructor === Sk.builtin.nmber)
+        {
             return tmp;
-		}
-		else if (tmp !== undefined && tmp.constructor === Sk.builtin.lng)
-		{
+        }
+        else if (tmp !== undefined && tmp.constructor === Sk.builtin.lng)
+        {
             return tmp;
-		}
+        }
         else if (tmp !== undefined)
         {
             v = tmp[0];
@@ -275,14 +287,14 @@ Sk.abstr.numberInplaceBinOp = function(v, w, op)
         {
             return tmp;
         }
-		else if (tmp !== undefined &&  tmp.constructor === Sk.builtin.nmber)
-		{
+        else if (tmp !== undefined &&  tmp.constructor === Sk.builtin.nmber)
+        {
             return tmp;
-		}
-		else if (tmp !== undefined && tmp.constructor === Sk.builtin.lng)
-		{
+        }
+        else if (tmp !== undefined && tmp.constructor === Sk.builtin.lng)
+        {
             return tmp;
-		}
+        }
         else if (tmp !== undefined)
         {
             v = tmp[0];
@@ -298,8 +310,8 @@ Sk.abstr.numberUnaryOp = function(v, op)
 {
     if (op === "Not") return Sk.misceval.isTrue(v) ? Sk.builtin.bool.false$ : Sk.builtin.bool.true$;
     else if (v instanceof Sk.builtin.nmber || v instanceof Sk.builtin.bool) {
-	var value = Sk.builtin.asnum$(v);
-	if (op === "USub") return new Sk.builtin.nmber(-value, value.skType);
+    var value = Sk.builtin.asnum$(v);
+    if (op === "USub") return new Sk.builtin.nmber(-value, value.skType);
         if (op === "UAdd") return new Sk.builtin.nmber(value, value.skType);
         if (op === "Invert") return new Sk.builtin.nmber(~value, value.skType);
     }
@@ -307,7 +319,7 @@ Sk.abstr.numberUnaryOp = function(v, op)
     {
         if (op === "USub" && v.nb$negative) return v.nb$negative();
         if (op === "UAdd" && v.nb$positive) return v.nb$positive();
-        //todo; if (op === "Invert" && v.nb$positive) return v.nb$invert();
+        if (op === "Invert" && v.nb$invert) return v.nb$invert();
     }
 
     var vtypename = Sk.abstr.typeName(v);
@@ -433,8 +445,6 @@ Sk.abstr.sequenceSetSlice = function(seq, i1, i2, x)
     }
 };
 
-
-
 //
 //
 //
@@ -497,8 +507,8 @@ Sk.abstr.objectSetItem = function(o, key, v)
             return o.mp$ass_subscript(key, v);
         else if (Sk.misceval.isIndex(key) && o.sq$ass_item)
             return Sk.abstr.sequenceSetItem(o, Sk.misceval.asIndex(key), v);
-	else if (o.tp$setitem)
-	    return o.tp$setitem(key, v);
+    else if (o.tp$setitem)
+        return o.tp$setitem(key, v);
     }
 
     var otypename = Sk.abstr.typeName(o);
@@ -529,7 +539,6 @@ Sk.abstr.gattr = function(obj, nameJS)
     }
  
     return ret;
-    
 };
 goog.exportSymbol("Sk.abstr.gattr", Sk.abstr.gattr);
 
@@ -547,7 +556,6 @@ Sk.abstr.sattr = function(obj, nameJS, data)
         throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + nameJS + "'");
     }
 };
-
 goog.exportSymbol("Sk.abstr.sattr", Sk.abstr.sattr);
 
 Sk.abstr.iter = function(obj)


### PR DESCRIPTION
Provide hooks for the majority of the special (double underscore) Python methods that supply the operator overloading feature. Also implement the "right hand side" and "in-place" features. No additional tests are provided in order to avoid polluting the core distribution.
This addresses #125.
Some additional minor "whitespace" changes to convert tabs, indent correctly. 
