### PR TITLE
Rework ffi towards a cleaner API.

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -1,83 +1,216 @@
 Sk.ffi = Sk.ffi || {};
 
-/**
- * maps from Javascript Object/Array/string to Python dict/list/str.
- *
- * only works on basic objects that are being used as storage, doesn't handle
- * functions, etc.
- */
-Sk.ffi.remapToPy = function(obj)
+Sk.ffi.remapBooleanToPy = function(valueJs)
 {
-    if (Object.prototype.toString.call(obj) === "[object Array]")
+    var t = typeof valueJs;
+    if (t === 'boolean')
     {
-        var arr = [];
-        for (var i = 0; i < obj.length; ++i)
-            arr.push(Sk.ffi.remapToPy(obj[i]));
-        return new Sk.builtin.list(arr);
+        return valueJs ? Sk.builtin.bool.true$ : Sk.builtin.bool.false$;
     }
-    else if (typeof obj === "object")
+    else if (t === 'object' && valueJs === null)
     {
-        var kvs = [];
-        for (var k in obj)
+        return Sk.builtin.none.none$;
+    }
+    else
+    {
+        goog.asserts.fail("Argument has type " + t + ", expecting 'boolean'.");
+    }
+}
+goog.exportSymbol("Sk.ffi.remapBooleanToPy", Sk.ffi.remapBooleanToPy);
+
+Sk.ffi.remapNumberToFloatPy = function(valueJs)
+{
+    var t = typeof valueJs;
+    if (t === 'number')
+    {
+        return new Sk.builtin.nmber(valueJs, Sk.builtin.nmber.float$);
+    }
+    else if (t === 'object' && valueJs === null)
+    {
+        return Sk.builtin.none.none$;
+    }
+    else
+    {
+        goog.asserts.fail("Argument has type " + t + ", expecting 'number'.");
+    }
+}
+goog.exportSymbol("Sk.ffi.remapNumberToFloatPy", Sk.ffi.remapNumberToFloatPy);
+
+Sk.ffi.remapNumberToIntPy = function(valueJs)
+{
+    var t = typeof valueJs;
+    if (t === 'number')
+    {
+        return new Sk.builtin.nmber(valueJs, Sk.builtin.nmber.int$);
+    }
+    else if (t === 'object' && valueJs === null)
+    {
+        return Sk.builtin.none.none$;
+    }
+    else
+    {
+        goog.asserts.fail("Argument has type " + t + ", expecting 'number'.");
+    }
+}
+goog.exportSymbol("Sk.ffi.remapNumberToIntPy", Sk.ffi.remapNumberToIntPy);
+
+Sk.ffi.remapStringToPy = function(valueJs)
+{
+    var t = typeof valueJs;
+    if (t === 'string')
+    {
+        return new Sk.builtin.str(valueJs);
+    }
+    else if (t === 'object' && valueJs === null)
+    {
+        return Sk.builtin.none.none$;
+    }
+    else
+    {
+        goog.asserts.fail("Argument has type " + t + ", expecting 'string'.");
+    }
+}
+goog.exportSymbol("Sk.ffi.remapStringToPy", Sk.ffi.remapStringToPy);
+
+Sk.ffi.remapToPy = function(valueJs, tp$name)
+{
+    var t = typeof valueJs;
+    if (t === 'object') {
+        if (Object.prototype.toString.call(valueJs) === "[object Array]")
         {
-            kvs.push(Sk.ffi.remapToPy(k));
-            kvs.push(Sk.ffi.remapToPy(obj[k]));
+            var arr = [];
+            for (var i = 0; i < valueJs.length; ++i) {
+                arr.push(Sk.ffi.remapToPy(valueJs[i], undefined));
+            }
+            return new Sk.builtin.list(arr);
         }
-        return new Sk.builtin.dict(kvs);
+        else if (typeof tp$name === 'string')
+        {
+            return {"v": valueJs, "tp$name": tp$name};
+        }
+        else if (t === 'object' && valueJs === null)
+        {
+            return Sk.builtin.none.none$;
+        }
+        else
+        {
+            var kvs = [];
+            for (var k in valueJs)
+            {
+                kvs.push(Sk.ffi.remapToPy(k, undefined));
+                kvs.push(Sk.ffi.remapToPy(valueJs[k], undefined));
+            }
+            return new Sk.builtin.dict(kvs);
+        }
     }
-    else if (typeof obj === "string")
-        return new Sk.builtin.str(obj);
-    else if (typeof obj === "number")
-		return new Sk.builtin.nmber(obj, undefined);
-	else if (typeof obj === "boolean")
-        return obj;
-    goog.asserts.fail("unhandled remap type " + typeof(obj));
+    else if (t === 'string')
+    {
+        return Sk.ffi.remapStringToPy(valueJs);
+    }
+    else if (t === 'number')
+    {
+        return Sk.ffi.remapNumberToFloatPy(valueJs);
+    }
+    else if (t === 'boolean')
+    {
+        return Sk.ffi.remapBooleanToPy(valueJs);
+    }
+    else
+    {
+        goog.asserts.fail("unhandled remapToPy type " + t);
+    }
 };
 goog.exportSymbol("Sk.ffi.remapToPy", Sk.ffi.remapToPy);
 
 /**
- * maps from Python dict/list/str to Javascript Object/Array/string.
+ * Usage:
+ *
+ * valueJs = Sk.ffi.remapBooleanToJs(valuePy, "foo must be a <type 'bool'>");
  */
-Sk.ffi.remapToJs = function(obj)
+Sk.ffi.remapBooleanToJs = function(valuePy, message)
 {
-    if (obj instanceof Sk.builtin.dict)
+    if (valuePy === Sk.builtin.bool.true$)
+    {
+        return true;
+    }
+    else if (valuePy === Sk.builtin.bool.false$)
+    {
+        return false;
+    }
+    else
+    {
+        throw new Sk.builtin.AssertionError(message);
+    }
+}
+goog.exportSymbol("Sk.ffi.remapBooleanToPy", Sk.ffi.remapBooleanToPy);
+
+/**
+ * Usage:
+ *
+ * valueJs = Sk.ffi.remapToJs(valuePy);
+ */
+Sk.ffi.remapToJs = function(valuePy)
+{
+    if (typeof valuePy === 'undefined')
+    {
+        // TODO: Probably should ultimately be an assertion since Python has no concept of undefined.
+        return valuePy;
+    }
+    else if (valuePy instanceof Sk.builtin.dict)
     {
         var ret = {};
-        for (var iter = obj.tp$iter(), k = iter.tp$iternext();
-                k !== undefined;
-                k = iter.tp$iternext())
+        for (var iter = valuePy.tp$iter(), k = iter.tp$iternext(); k !== undefined; k = iter.tp$iternext())
         {
-            var v = obj.mp$subscript(k);
-            if (v === undefined)
+            var v = valuePy.mp$subscript(k);
+            if (v === undefined) {
                 v = null;
+            }
             var kAsJs = Sk.ffi.remapToJs(k);
-            // todo; assert that this is a reasonble lhs?
             ret[kAsJs] = Sk.ffi.remapToJs(v);
         }
         return ret;
     }
-    else if (obj instanceof Sk.builtin.list)
+    else if (valuePy instanceof Sk.builtin.list)
     {
         var ret = [];
-        for (var i = 0; i < obj.v.length; ++i)
-            ret.push(Sk.ffi.remapToJs(obj.v[i]));
+        for (var i = 0; i < valuePy.v.length; ++i)
+        {
+            ret.push(Sk.ffi.remapToJs(valuePy.v[i]));
+        }
         return ret;
     }
-	else if (obj instanceof Sk.builtin.nmber)
-	{
-		return Sk.builtin.asnum$(obj);
-	}
-	else if (obj instanceof Sk.builtin.lng)
-	{
-		return Sk.builtin.asnum$(obj);
-	}
-    else if (typeof obj === "number" || typeof obj === "boolean")
-        return obj;
+    else if (valuePy instanceof Sk.builtin.nmber)
+    {
+        return Sk.builtin.asnum$(valuePy);
+    }
+    else if (valuePy instanceof Sk.builtin.lng)
+    {
+        return Sk.builtin.asnum$(valuePy);
+    }
+    else if (valuePy === Sk.builtin.bool.true$)
+    {
+        return true;
+    }
+    else if (valuePy === Sk.builtin.bool.false$)
+    {
+        return false;
+    }
+    else if (typeof valuePy.v !== 'undefined')
+    {
+        // TODO: This is being exercised, but we should assert the tp$name.
+        // I think the pattern here suggests that we have a Sk.builtin.something
+        return valuePy.v;
+    }
     else
-        return obj.v;
+    {
+        // The following statement is provided because the proper representation of Python types in Skulpt is 'incorrect'.
+        // You might see JavaScript 'boolean' and 'string' values stored in the 'v' property.
+        return valuePy.v;
+    }
 };
 goog.exportSymbol("Sk.ffi.remapToJs", Sk.ffi.remapToJs);
 
+// TODO: Deprecate and/or rename to remapFunctionToPy?
 Sk.ffi.callback = function(fn)
 {
     if (fn === undefined) return fn;
@@ -87,42 +220,68 @@ Sk.ffi.callback = function(fn)
 };
 goog.exportSymbol("Sk.ffi.callback", Sk.ffi.callback);
 
-Sk.ffi.stdwrap = function(type, towrap)
+Sk.ffi.stdwrap = function(type, towrap, ignoreDeprecation)
 {
-    var inst = new type();
-    inst['v'] = towrap;
-    return inst;
+    if (ignoreDeprecation)
+    {
+        var inst = new type();
+        inst['v'] = towrap;
+        return inst;
+    }
+    else
+    {
+        goog.asserts.fail("Sk.ffi.stdwrap has been deprecated. Please use Sk.ffi.remapToPy(valueJs, tp$name) instead.");
+    }
 };
 goog.exportSymbol("Sk.ffi.stdwrap", Sk.ffi.stdwrap);
 
-/**
- * for when the return type might be one of a variety of basic types.
- * number|string, etc.
- */
-Sk.ffi.basicwrap = function(obj)
+Sk.ffi.basicwrap = function(obj, ignoreDeprecation)
 {
-	if (obj instanceof Sk.builtin.nmber)
-		return Sk.builtin.asnum$(obj);
-	if (obj instanceof Sk.builtin.lng)
-		return Sk.builtin.asnum$(obj);
-    if (typeof obj === "number" || typeof obj === "boolean")
-        return obj;
-    if (typeof obj === "string")
-        return new Sk.builtin.str(obj);
-    goog.asserts.fail("unexpected type for basicwrap");
+    if (ignoreDeprecation)
+    {
+        if (obj instanceof Sk.builtin.nmber)
+            return Sk.builtin.asnum$(obj);
+        if (obj instanceof Sk.builtin.lng)
+            return Sk.builtin.asnum$(obj);
+        if (typeof obj === "number" || typeof obj === "boolean")
+            return obj;
+        if (typeof obj === "string")
+        {
+            return new Sk.builtin.str(obj);
+        }
+        goog.asserts.fail("unexpected type for basicwrap");
+    }
+    else
+    {
+        goog.asserts.fail("Sk.ffi.basicwrap has been deprecated. Please use Sk.ffi.remapToPy instead.");
+    }
 };
 goog.exportSymbol("Sk.ffi.basicwrap", Sk.ffi.basicwrap);
 
-Sk.ffi.unwrapo = function(obj)
+Sk.ffi.unwrapo = function(obj, ignoreDeprecation)
 {
-    if (obj === undefined) return undefined;
-    return obj['v'];
+    if (ignoreDeprecation)
+    {
+        if (obj === undefined) return undefined;
+        return obj['v'];
+    }
+    else
+    {
+        goog.asserts.fail("Sk.ffi.unwrapo has been deprecated. Please use Sk.ffi.remapToJs instead.");
+    }
 };
 goog.exportSymbol("Sk.ffi.unwrapo", Sk.ffi.unwrapo);
 
-Sk.ffi.unwrapn = function(obj)
+Sk.ffi.unwrapn = function(obj, ignoreDeprecation)
 {
-    if (obj === null) return null;
-    return obj['v'];
+    if (ignoreDeprecation)
+    {
+        if (obj === null) return null;
+        return obj['v'];
+    }
+    else
+    {
+        goog.asserts.fail("Sk.ffi.unwrapn has been deprecated. Please use Sk.ffi.remapToJs instead.");
+    }
 };
 goog.exportSymbol("Sk.ffi.unwrapn", Sk.ffi.unwrapn);

--- a/src/lib/re/__init__.js
+++ b/src/lib/re/__init__.js
@@ -72,9 +72,9 @@ var $builtinmodule = function(name)
             throw new Sk.builtin.TypeError("flags must be a number");
         };
 
-	maxsplit = Sk.builtin.asnum$(maxsplit);
-        var pat = Sk.ffi.unwrapo(pattern);
-        var str = Sk.ffi.unwrapo(string);
+        maxsplit = Sk.builtin.asnum$(maxsplit);
+        var pat = Sk.ffi.remapToJs(pattern);
+        var str = Sk.ffi.remapToJs(string);
         
         // Convert pat from Python to Javascript regex syntax
         pat = convert(pat);
@@ -131,8 +131,8 @@ var $builtinmodule = function(name)
             throw new Sk.builtin.TypeError("flags must be a number");
         };
 
-        var pat = Sk.ffi.unwrapo(pattern);
-        var str = Sk.ffi.unwrapo(string);
+        var pat = Sk.ffi.remapToJs(pattern);
+        var str = Sk.ffi.remapToJs(string);
         
         // Convert pat from Python to Javascript regex syntax
         pat = convert(pat);
@@ -144,10 +144,10 @@ var $builtinmodule = function(name)
 
         var regex = new RegExp(pat, jsflags);
 
-	var newline_at_end = new RegExp(/\n$/);
-	if (str.match(newline_at_end)) {
-	    str = str.slice(0,-1);
-	}
+    var newline_at_end = new RegExp(/\n$/);
+    if (str.match(newline_at_end)) {
+        str = str.slice(0,-1);
+    }
 
         var result = [];
         var match;
@@ -178,26 +178,26 @@ var $builtinmodule = function(name)
     var matchobj = function($gbl, $loc) {
         $loc.__init__ = new Sk.builtin.func(function(self,thematch, pattern, string) {
             self.thematch = thematch;
-	    self.re = pattern;
-	    self.string = string;
+        self.re = pattern;
+        self.string = string;
         });
 
-	$loc.groups = new Sk.builtin.func(function(self) {
-	    return new Sk.builtin.tuple(self.thematch.v.slice(1))
-	});
+    $loc.groups = new Sk.builtin.func(function(self) {
+        return new Sk.builtin.tuple(self.thematch.v.slice(1))
+    });
 
-	$loc.group = new Sk.builtin.func(function(self,grpnum) {
-	    if (grpnum === undefined) {
+    $loc.group = new Sk.builtin.func(function(self,grpnum) {
+        if (grpnum === undefined) {
                 grpnum = 0;
             }
             else {
                 grpnum = Sk.builtin.asnum$(grpnum);
             }
-	    if(grpnum >= self.thematch.v.length) {
-		throw new Sk.builtin.IndexError("Index out of range: " + grpnum);
-		}
-	    return self.thematch.v[grpnum]
-	});
+        if(grpnum >= self.thematch.v.length) {
+        throw new Sk.builtin.IndexError("Index out of range: " + grpnum);
+        }
+        return self.thematch.v[grpnum]
+    });
 
     }
 
@@ -206,12 +206,12 @@ var $builtinmodule = function(name)
     // Internal function to return a Python list of strings 
     // From a JS regular expression string
     mod._findre = function(res, string) {
-	res = res.replace(/([^\\]){,(?![^\[]*\])/g, '$1{0,');
+    res = res.replace(/([^\\]){,(?![^\[]*\])/g, '$1{0,');
         var re = eval(res);
-	var patt = new RegExp('\n$');
-	if (string.v.match(patt))
-	    var matches = string.v.slice(0,-1).match(re);
-	else
+    var patt = new RegExp('\n$');
+    if (string.v.match(patt))
+        var matches = string.v.slice(0,-1).match(re);
+    else
             var matches = string.v.match(re);
         retval = new Sk.builtin.list();
         if ( matches == null ) return retval;
@@ -223,14 +223,14 @@ var $builtinmodule = function(name)
     }
 
     mod.search = new Sk.builtin.func(function(pattern, string, flags) {
-	Sk.builtin.pyCheckArgs('search', arguments, 2, 3);
+    Sk.builtin.pyCheckArgs('search', arguments, 2, 3);
         if (!Sk.builtin.checkString(pattern)) {
             throw new Sk.builtin.TypeError("pattern must be a string");
         };
         if (!Sk.builtin.checkString(string)) {
             throw new Sk.builtin.TypeError("string must be a string");
         };
-	if (flags === undefined) {
+    if (flags === undefined) {
             flags = 0;
         };
         if (!Sk.builtin.checkNumber(flags)) {
@@ -244,14 +244,14 @@ var $builtinmodule = function(name)
     });
 
     mod.match = new Sk.builtin.func(function(pattern, string, flags) {
-	Sk.builtin.pyCheckArgs('match', arguments, 2, 3);
+    Sk.builtin.pyCheckArgs('match', arguments, 2, 3);
         if (!Sk.builtin.checkString(pattern)) {
             throw new Sk.builtin.TypeError("pattern must be a string");
         };
         if (!Sk.builtin.checkString(string)) {
             throw new Sk.builtin.TypeError("string must be a string");
         };
-	if (flags === undefined) {
+    if (flags === undefined) {
             flags = 0;
         };
         if (!Sk.builtin.checkNumber(flags)) {


### PR DESCRIPTION
Begin an on-going process to clean up the Foreign Function Interface (ffi.js). This is clearly going to take much more effort because it is clear from my testing that Boolean and String values are still being passed in the 'v' property. This refactoring incorporates a few ideas:

Sk.ffi.remapToJs and Sk.ffi.remapToPy should always work but will need hint parameters when mappings aren't 1:1

Sk.ffi.remapXyzToJs and Sk.ffi.remapXyzToPy functions for better performance and assertions when the types being mapped are known.

1) {'v': ?, 'tp$name': ?} protocol manifest in function to provide better reporting when a Python client mis-names the properties on an object.
2) #1 combined with remapToPy to support wrapping of JavaScript library classes.
3) message configurable in the 'incoming data' remapXyzToJs functions to support easy localizable validation.
4) assert message standard in the 'outgoing data' remapXyzToPy functions.
5) Identification of functions to be deprecated and ignoreDeprecation argument. This isn't exactly backwards compatible, but it seems to be the approach used in libraries like Three.JS. A client can at least test, add a few true arguments and postpone the inevitable migration. Is there a better way to send warning messages?
6) Modify Regular Expression module not to use deprecated functions.

TODO: Wrapping functions e.g. callbacks
TODO: Delegate deprecated functions to the permanent API.
TODO: General handling of Python values inside Skulpt (valuePy representation).
TODO: Schedule and removal of deprecated functions.
TODO: Modify more of the standard library to make use of the ffi API rather than ad-hoc entry points. This would provide the benefits of better testing, better example code, potential for optimizations that avoid object creation.
TODO: "Hint' metadata arguments when mappings aren't 1:1
TODO: We also need better testing because a lot of the conversion functions aren't exercised by the standard library.
