### PR TITLE
Add a getProperty() method for document element.

### DIFF
--- a/src/lib/document/__init__.js
+++ b/src/lib/document/__init__.js
@@ -131,6 +131,14 @@ var $builtinmodule = function(name) {
                 self.v.setAttribute(attr.v,value.v)
         });
             
+        $loc.getProperty = new Sk.builtin.func(function(self,key) {
+            var res = self.v[key.v]
+            if (res) {
+                return new Sk.builtin.str(res)
+            } else {
+                return Sk.builtin.none.none$;
+            }
+        });
 
         $loc.__str__ = new Sk.builtin.func(function(self) {
             console.log(self.v.tagName);


### PR DESCRIPTION
So we don't need to setup a hardcoded height and width for the canvas when working with processing.
For example:

``` python
from processing import *

def setup():
    canvas = document.getElementById('mycanvas')
    canvasWidth = int(canvas.getProperty('clientWidth'))
    canvasHeight = int(canvas.getProperty('clientHeight'))
    size(canvasWidth, canvasHeight)
    # ...
```
