### PR TITLE
add change shape event to turtle module (#70)

### DIFF
--- a/src/lib/turtle/__init__.js
+++ b/src/lib/turtle/__init__.js
@@ -329,6 +329,9 @@ if (!TurtleGraphics) {
                             t.turtleCanvas.setSegmentLength(oper[2]);
                         }
                         break;
+                    case 'CS': // change shape
+                        t.currentShape = oper[1];
+                        break;
                     case 'NO':
                         break;
                     } //else {
@@ -1342,7 +1345,7 @@ if (!TurtleGraphics) {
     //
     Turtle.prototype.shape = function (s) {
         if (this.shapeStore[s]) {
-            this.currentShape = s;
+            this.addDrawingEvent(['CS', s]); // add a Change Shape event
         }
     };
     Turtle.prototype.drawturtle = function (pHeading, pos) {


### PR DESCRIPTION
Fixes #70.

Adds a change shape ("CS") event to turtles. 

[ On a side note, how do you go about testing the turtle module while developing locally? I was manually copying the generated skulpt into my local install of Runestone, running paver, then testing my changes by running an ActiveCode block. Is there any way to run turtle programs in Skulpt locally, without needing to have Runestone installed? ]
