### PR TITLE
Fix if constant handling

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -922,16 +922,23 @@ Compiler.prototype.cif = function (s) {
     }
     else {
         end = this.newBlock("end of if");
-        next = this.newBlock("next branch of if");
+        if (s.orelse && s.orelse.length > 0) {
+            next = this.newBlock("next branch of if");
+        }
 
         test = this.vexpr(s.test);
-        this._jumpfalse(test, next);
-        this.vseqstmt(s.body);
-        this._jump(end);
 
-        this.setBlock(next);
         if (s.orelse && s.orelse.length > 0) {
+            this._jumpfalse(test, next);
+            this.vseqstmt(s.body);
+            this._jump(end);
+
+            this.setBlock(next);
             this.vseqstmt(s.orelse);
+        }
+        else {
+            this._jumpfalse(test, end);
+            this.vseqstmt(s.body);
         }
         this._jump(end);
         this.setBlock(end);


### PR DESCRIPTION
Slightly more optimal if compilation, including a fix for always true/false constants (which was failing due to the strict comparison), and better handling of empty else.
