### PR TITLE
Optionally allow input methods to return promises

### DIFF
--- a/src/lib/turtle/__init__.js
+++ b/src/lib/turtle/__init__.js
@@ -765,16 +765,15 @@ return (function() {
             w  = extent / steps;
             w2 = 0.5 * w;
             l  = radius * Math.sin(w/self._fullCircle*Turtle.RADIANS);
-            endAngle = angle + extent;
             if (radius < 0) {
                 l = -l;
                 w = -w;
                 w2 = -w2;
-                endAngle = -endAngle;
             }
 
             promise = getFrameManager().willRenderNext() ? Promise.resolve() : new InstantPromise();
 
+            endAngle = angle + extent;
             angle += w2;
 
             for(i = 0; i < steps; i++) {


### PR DESCRIPTION
This PR allows the inputfun that is provided via the configuration to return a promise or a string value.  If a promise is returned, an Sk.misceval.Suspension is created and the script is delayed until the inputfun promise resolves.  This should let users create more UI-friendly input methods rather than browser prompts.  Will be a great addition for REPL mode in particular.
