### PR TITLE
fixes turtle heading for negative radius turtle.circle() calls

### DIFF
--- a/src/lib/turtle/__init__.js
+++ b/src/lib/turtle/__init__.js
@@ -765,15 +765,19 @@ return (function() {
             w  = extent / steps;
             w2 = 0.5 * w;
             l  = radius * Math.sin(w/self._fullCircle*Turtle.RADIANS);
+
             if (radius < 0) {
                 l = -l;
                 w = -w;
                 w2 = -w2;
+                endAngle = angle - extent;
+            }
+            else {
+                endAngle = angle + extent;
             }
 
             promise = getFrameManager().willRenderNext() ? Promise.resolve() : new InstantPromise();
 
-            endAngle = angle + extent;
             angle += w2;
 
             for(i = 0; i < steps; i++) {


### PR DESCRIPTION
When a negative radius is sent to `turtle.circle()`, the final heading of the turtle was being improperly calculated.  This PR properly accounts for the negative value.
