### PR TITLE
Provide stack traces for exceptions

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -726,3 +726,13 @@ Build the distribution files for skulpt:
 
 * skulpt.min.js  -- This is a minified version of the core interpreter files.
 * skulpt-stdlib.js  -- This is an unminified version of library functions.  This file may contain javascript that implements a module, such as turtle or math, or it may contain pure python.
+
+
+
+
+Getting stack traces from an exception
+--------------------------------------
+
+Sk.builtin.Exception objects have a property called 'traceback'. This property contains an Array of objects with 'filename', 'lineno' and (optionally) 'colno' properties, each representing a stack frame. The array is ordered from innermost to outermost frame.
+
+If an object that is not an instance of Sk.builtin.Exception is thrown from within a Skulpt function (typically as part of an external piece of Javascript), it is wrapped in an Sk.builtin.ExternalError. The original object thrown is stringified (so the exception can be manipulated in Python), but a reference to the original is also saved in the ExternalError's 'nativeError' property so it can be inspected from Javascript.

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -397,7 +397,7 @@ Sk.builtin.zip = function zip () {
             iters.push(arguments[i].tp$iter());
         }
         else {
-            throw "TypeError: argument " + i + " must support iteration";
+            throw new Sk.builtin.TypeError("argument " + i + " must support iteration");
         }
     }
     res = [];
@@ -859,7 +859,7 @@ Sk.builtin.map = function map (fun, seq) {
          item = iter.tp$iternext()) {
         if (fun === Sk.builtin.none.none$) {
             if (item instanceof Array) {
-                // With None function and multiple sequences, 
+                // With None function and multiple sequences,
                 // map should return a list of tuples
                 item = new Sk.builtin.tuple(item);
             }

--- a/src/compile.js
+++ b/src/compile.js
@@ -105,8 +105,7 @@ Compiler.prototype.annotateSource = function (ast) {
         }
         out("^\n//\n");
 
-        out("\nSk.currLineNo = ", lineno, ";\nSk.currColNo = ", col_offset, "\n\n");	//	Added by RNL
-        out("\nSk.currFilename = '", this.filename, "';\n\n");	//	Added by RNL
+        out("currLineNo = ", lineno, ";\ncurrColNo = ", col_offset, "\n\n");
     }
 };
 
@@ -273,7 +272,7 @@ Compiler.prototype.outputInterruptTest = function () { // Added by RNL
     }
     if (Sk.yieldLimit !== null && this.u.canSuspend) {
         output += "if (new Date() - Sk.lastYield > Sk.yieldLimit) {";
-        output += "var $susp = $saveSuspension({data: {type: 'Sk.yield'}, resume: function() {}}, '"+this.filename+"',Sk.currLineNo,Sk.currColNo);";
+        output += "var $susp = $saveSuspension({data: {type: 'Sk.yield'}, resume: function() {}}, '"+this.filename+"',currLineNo,currColNo);";
         output += "$susp.$blk = $blk;";
         output += "$susp.optional = true;";
         output += "return $susp;";
@@ -313,7 +312,7 @@ Compiler.prototype.ctuplelistorset = function(e, data, tuporlist) {
             this.vexpr(e.elts[i], "Sk.abstr.objectGetItem(" + data + "," + i + ")");
         }
     }
-    else if (e.ctx === Load || tuporlist === "set") { //because set's can't be assigned to. 
+    else if (e.ctx === Load || tuporlist === "set") { //because set's can't be assigned to.
         items = [];
         for (i = 0; i < e.elts.length; ++i) {
             items.push(this._gr("elem", this.vexpr(e.elts[i])));
@@ -369,7 +368,7 @@ Compiler.prototype.ccompgen = function (type, tmpname, generators, genIndex, val
     var target;
     var nexti;
     var n;
-    
+
     this._jump(start);
     this.setBlock(start);
 
@@ -393,10 +392,10 @@ Compiler.prototype.ccompgen = function (type, tmpname, generators, genIndex, val
         if (type === "dict") {
             lkey = this.vexpr(key);
             out(tmpname, ".mp$ass_subscript(", lkey, ",", lvalue, ");");
-        } 
+        }
         else if (type === "list") {
             out(tmpname, ".v.push(", lvalue, ");"); // todo;
-        } 
+        }
         else if (type === "set") {
             out(tmpname, ".v.mp$ass_subscript(", lvalue, ", true);");
         }
@@ -885,7 +884,7 @@ Compiler.prototype.outputSuspensionHelpers = function (unit) {
     var output = "var $wakeFromSuspension = function() {" +
                     "var susp = "+unit.scopename+".wakingSuspension; delete "+unit.scopename+".wakingSuspension;" +
                     "$blk=susp.$blk; $loc=susp.$loc; $gbl=susp.$gbl; $exc=susp.$exc; $err=susp.$err;" +
-                    "Sk.lastYield=new Date();" +
+                    "currLineNo=susp.lineno; currColNo=susp.colno; Sk.lastYield=new Date();" +
                     (hasCell?"$cell=susp.$cell;":"");
 
     for (i = 0; i < localsToSave.length; i++) {
@@ -896,7 +895,7 @@ Compiler.prototype.outputSuspensionHelpers = function (unit) {
         }
     }
 
-    output +=  "try { $ret=susp.child.resume(); } catch(err) { if($exc.length>0) { $err=err; $blk=$exc.pop(); } else { throw err; } }" +
+    output +=  "try { $ret=susp.child.resume(); } catch(err) { if (!(err instanceof Sk.builtin.Exception)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if($exc.length>0) { $err=err; $blk=$exc.pop(); } else { throw err; } }" +
                 "};";
 
     output += "var $saveSuspension = function(child, filename, lineno, colno) {" +
@@ -1461,7 +1460,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
 
     // note special usage of 'this' to avoid having to slice globals into
     // all function invocations in call
-    this.u.varDeclsCode += "var $blk=" + entryBlock + ",$exc=[],$loc=" + locals + cells + ",$gbl=this,$err=undefined,$ret=undefined;";
+    this.u.varDeclsCode += "var $blk=" + entryBlock + ",$exc=[],$loc=" + locals + cells + ",$gbl=this,$err=undefined,$ret=undefined,currLineNo=undefined,currColNo=undefined;";
     if (Sk.execLimit !== null) {
         this.u.varDeclsCode += "if (typeof Sk.execStart === 'undefined') {Sk.execStart = new Date()}";
     }
@@ -1547,7 +1546,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     this.u.switchCode = "while(true){try{"
     this.u.switchCode += this.outputInterruptTest();
     this.u.switchCode += "switch($blk){";
-    this.u.suffixCode = "} }catch(err){if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} }});";
+    this.u.suffixCode = "} }catch(err){ if (!(err instanceof Sk.builtin.Exception)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} }});";
 
     //
     // jump back to the handler so it can do the main actual work of the
@@ -1778,7 +1777,7 @@ Compiler.prototype.cclass = function (s) {
 
     this.u.prefixCode = "var " + scopename + "=(function $" + s.name.v + "$class_outer($globals,$locals,$rest){var $gbl=$globals,$loc=$locals;";
     this.u.switchCode += "return(function " + s.name.v + "(){";
-    this.u.switchCode += "var $blk=" + entryBlock + ",$exc=[],$ret=undefined;"
+    this.u.switchCode += "var $blk=" + entryBlock + ",$exc=[],$ret=undefined,currLineNo=undefined,currColNo=undefined;"
     if (Sk.execLimit !== null) {
         this.u.switchCode += "if (typeof Sk.execStart === 'undefined') {Sk.execStart = new Date()}";
     }
@@ -2175,7 +2174,7 @@ Compiler.prototype.cmod = function (mod) {
 
     var entryBlock = this.newBlock("module entry");
     this.u.prefixCode = "var " + modf + "=(function($modname){";
-    this.u.varDeclsCode = "var $gbl = {}, $blk=" + entryBlock + ",$exc=[],$loc=$gbl,$err=undefined;$gbl.__name__=$modname,$ret=undefined;";
+    this.u.varDeclsCode = "var $gbl = {}, $blk=" + entryBlock + ",$exc=[],$loc=$gbl,$err=undefined;$gbl.__name__=$modname,$ret=undefined,currLineNo=undefined,currColNo=undefined;";
     if (Sk.execLimit !== null) {
         this.u.varDeclsCode += "if (typeof Sk.execStart === 'undefined') {Sk.execStart = new Date()}";
     }
@@ -2203,7 +2202,7 @@ Compiler.prototype.cmod = function (mod) {
     this.u.switchCode = "while(true){try{";
     this.u.switchCode += this.outputInterruptTest();
     this.u.switchCode += "switch($blk){";
-    this.u.suffixCode = "} }catch(err){if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} }" +
+    this.u.suffixCode = "} }catch(err){ if (!(err instanceof Sk.builtin.Exception)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} }" +
         " }catch(err){ if (err instanceof Sk.builtin.SystemExit && !Sk.throwSystemExit) { Sk.misceval.print_(err.toString() + '\\n'); return $loc; } else { throw err; } } });";
 
     // Note - this change may need to be adjusted for all the other instances of

--- a/src/compile.js
+++ b/src/compile.js
@@ -2026,7 +2026,7 @@ Compiler.prototype.nameop = function (name, ctx, dataToStore) {
                 case Load:
                 case Param:
                     // Need to check that it is bound!
-                    out("if (", mangled, " === undefined) { throw new Error('local variable \\\'", mangled, "\\\' referenced before assignment'); }\n");
+                    out("if (", mangled, " === undefined) { throw new Sk.builtin.UnboundLocalError('local variable \\\'", mangled, "\\\' referenced before assignment'); }\n");
                     return mangled;
                 case Store:
                     out(mangled, "=", dataToStore, ";");

--- a/src/errors.js
+++ b/src/errors.js
@@ -200,6 +200,23 @@ Sk.builtin.NameError.prototype.tp$name = "NameError";
  * @extends Sk.builtin.Exception
  * @param {...*} args
  */
+Sk.builtin.UnboundLocalError = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.UnboundLocalError)) {
+        o = Object.create(Sk.builtin.UnboundLocalError.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.Exception.apply(this, arguments);
+};
+goog.inherits(Sk.builtin.UnboundLocalError, Sk.builtin.Exception);
+Sk.builtin.UnboundLocalError.prototype.tp$name = "UnboundLocalError";
+
+/**
+ * @constructor
+ * @extends Sk.builtin.Exception
+ * @param {...*} args
+ */
 Sk.builtin.OverflowError = function (args) {
     var o;
     if (!(this instanceof Sk.builtin.OverflowError)) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -13,7 +13,14 @@
  * @param {...Object|null} args
  */
 Sk.builtin.Exception = function (args) {
-    var i;
+    var i, o;
+
+    if (!(this instanceof Sk.builtin.Exception)) {
+        o = Object.create(Sk.builtin.Exception.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+
     args = Array.prototype.slice.call(arguments);
     // hackage to allow shorter throws
     for (i = 0; i < args.length; ++i) {

--- a/src/str.js
+++ b/src/str.js
@@ -297,7 +297,7 @@ Sk.builtin.str.prototype["join"] = new Sk.builtin.func(function (self, seq) {
     arrOfStrs = [];
     for (it = seq.tp$iter(), i = it.tp$iternext(); i !== undefined; i = it.tp$iternext()) {
         if (i.constructor !== Sk.builtin.str) {
-            throw "TypeError: sequence item " + arrOfStrs.length + ": expected string, " + typeof i + " found";
+            throw new Sk.builtin.TypeError("TypeError: sequence item " + arrOfStrs.length + ": expected string, " + typeof i + " found");
         }
         arrOfStrs.push(i.v);
     }
@@ -337,7 +337,7 @@ Sk.builtin.str.prototype["split"] = new Sk.builtin.func(function (self, on, howm
         regex = new RegExp(s, "g");
     }
 
-    // This is almost identical to re.split, 
+    // This is almost identical to re.split,
     // except how the regexp is constructed
 
     result = [];

--- a/test/run/t523.py.real
+++ b/test/run/t523.py.real
@@ -1,2 +1,2 @@
-TypeError: __nonzero__ should return an int on line 3
-TypeError: __len__ should return an int on line 12
+TypeError: __nonzero__ should return an int on line 6
+TypeError: __len__ should return an int on line 15

--- a/test/run/t523.py.real.force
+++ b/test/run/t523.py.real.force
@@ -1,2 +1,2 @@
-TypeError: __nonzero__ should return an int on line 3
-TypeError: __len__ should return an int on line 12
+TypeError: __nonzero__ should return an int on line 6
+TypeError: __len__ should return an int on line 15


### PR DESCRIPTION
Replace the global Sk.curr{LineNo,ColNo,Filename} with local vars in each stack frame, allowing us to generate proper stack traces for exceptions.

This required modifying one test, as it relied on exceptions reporting incorrect line numbers.

This PR merges nicely with PR #324, and they can be applied in either order.