### PR TITLE
Fixes type() by passing in real python objects

### DIFF
--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1000,13 +1000,30 @@ Sk.misceval.buildClass = function (globals, func, name, bases) {
     var locals = {};
 
     // init the dict for the class
-    //print("CALLING", func);
     func(globals, locals, []);
+    // ToDo: check if func contains the __meta__ attribute
+    // or if the bases contain __meta__
+    // new Syntax would be different
 
     // file's __name__ is class's __module__
     locals.__module__ = globals["__name__"];
+    var _name = Sk.builtin.str(name);
+    var _bases = Sk.builtin.tuple(bases);
+    var _locals = [];
+    var key;
 
-    klass = Sk.misceval.callsim(meta, name, bases, locals);
+    // build array for python dict
+    for (key in locals) {
+        if (!locals.hasOwnProperty(key)) {
+            //The current property key not a direct property of p
+            continue;
+        }
+        _locals.push(Sk.builtin.str(key)); // push key
+        _locals.push(locals[key]); // push associated value
+    }
+    _locals = Sk.builtin.dict(_locals);
+
+    klass = Sk.misceval.callsim(meta, _name, _bases, _locals);
     return klass;
 };
 goog.exportSymbol("Sk.misceval.buildClass", Sk.misceval.buildClass);

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1007,8 +1007,8 @@ Sk.misceval.buildClass = function (globals, func, name, bases) {
 
     // file's __name__ is class's __module__
     locals.__module__ = globals["__name__"];
-    var _name = Sk.builtin.str(name);
-    var _bases = Sk.builtin.tuple(bases);
+    var _name = new Sk.builtin.str(name);
+    var _bases = new Sk.builtin.tuple(bases);
     var _locals = [];
     var key;
 
@@ -1018,10 +1018,10 @@ Sk.misceval.buildClass = function (globals, func, name, bases) {
             //The current property key not a direct property of p
             continue;
         }
-        _locals.push(Sk.builtin.str(key)); // push key
+        _locals.push(new Sk.builtin.str(key)); // push key
         _locals.push(locals[key]); // push associated value
     }
-    _locals = Sk.builtin.dict(_locals);
+    _locals = new Sk.builtin.dict(_locals);
 
     klass = Sk.misceval.callsim(meta, _name, _bases, _locals);
     return klass;

--- a/src/type.js
+++ b/src/type.js
@@ -38,20 +38,18 @@ Sk.builtin.type = function (name, bases, dict) {
     }
     else {
 
-        // this checks if the dict has been already successfully unwrapped
-        // in case of creating classes with class keyword, skulpt automatically
-        // unwrap the arguments and sets the module in the buildClass function
-        if(!dict["tp$name"] && dict["tp$name"] !== "dict") {
+        // argument dict must be of type dict
+        if(dict.tp$name !== "dict") {
             throw new Sk.builtin.TypeError("type() argument 3 must be dict, not " + Sk.abstr.typeName(dict));
         }
 
-        // checks if name is builtin type of js object
+        // checks if name must be string
         if(!Sk.builtin.checkString(name)) {
             throw new Sk.builtin.TypeError("type() argument 1 must be str, not " + Sk.abstr.typeName(name));
         }
 
-        // unwrap bases if required
-        if(!bases["tp$name"] && bases["tp$name"] !== "tuple") {
+        // argument bases must be of type tuple
+        if(bases.tp$name !== "tuple") {
             throw new Sk.builtin.TypeError("type() argument 2 must be tuple, not " + Sk.abstr.typeName(bases));
         }
 
@@ -101,8 +99,9 @@ Sk.builtin.type = function (name, bases, dict) {
         };
 
         // set __module__ if not present (required by direct type(name, bases, dict) calls)
-        if(dict.mp$lookup(Sk.builtin.str("__module__")) === undefined) {
-            dict.mp$ass_subscript(Sk.builtin.str("__module__"), Sk.globals["__name__"]);
+        var module_lk = new Sk.builtin.str("__module__");
+        if(dict.mp$lookup(module_lk) === undefined) {
+            dict.mp$ass_subscript(module_lk, Sk.globals["__name__"]);
         }
 
         // copy properties into our klass object
@@ -133,7 +132,7 @@ Sk.builtin.type = function (name, bases, dict) {
             if (reprf !== undefined) {
                 return Sk.misceval.apply(reprf, undefined, undefined, undefined, []);
             }
-            mod = dict.mp$subscript(Sk.builtin.str("__module__")); // lookup __module__
+            mod = dict.mp$subscript(module_lk); // lookup __module__
             cname = "";
             if (mod) {
                 cname = mod.v + ".";

--- a/test/run/t520.py.real
+++ b/test/run/t520.py.real
@@ -3,5 +3,5 @@ True <type 'bool'>
 True <type 'bool'>
 1 <type 'int'>
 0 <type 'int'>
-115 <type 'int'>
+120 <type 'int'>
 False <type 'bool'>

--- a/test/run/t520.py.real.force
+++ b/test/run/t520.py.real.force
@@ -3,5 +3,5 @@ True <type 'bool'>
 True <type 'bool'>
 1 <type 'int'>
 0 <type 'int'>
-115 <type 'int'>
+120 <type 'int'>
 False <type 'bool'>


### PR DESCRIPTION
Targets #97:

- ```Sk.misceval.buildClass``` now passes python objects to ```Sk.builtin.type```
- ```Sk.builtin.type``` now checks for arguments and unpacks
- Adds ```__module__``` if not set

Currently a ```t520``` fails due to another returned hash value - I am not sure why.
 