### PR TITLE
Fixes turtle.circle() when steps != None

### DIFF
--- a/src/lib/turtle/__init__.js
+++ b/src/lib/turtle/__init__.js
@@ -767,7 +767,7 @@ function generateTurtleModule(_target) {
             }
             w  = extent / steps;
             w2 = 0.5 * w;
-            l  = radius * Math.sin(w/self._fullCircle*Turtle.RADIANS);
+            l  = 2 * radius * Math.sin(w*Math.PI/self._fullCircle);
 
             if (radius < 0) {
                 l = -l;


### PR DESCRIPTION
calling turtle.circle with the steps argument should create a polygon that fills
a circle of the radius specified.  This PR fixes the length calculation to appropriately
size the sides of the polygon.