### PR TITLE
fix counting method for tests

### DIFF
--- a/skulpt.py
+++ b/skulpt.py
@@ -726,10 +726,12 @@ Sk.importMain("%s", false);
         print outs
         if errs:
             print errs
-        g = re.match(r'.*\n.*passed: (\d+) failed: (\d+)',outs,flags=re.MULTILINE)
-        if g:
-            passTot += int(g.group(1))
-            failTot += int(g.group(2))
+        outlines = outs.split('\n')
+        for ol in outlines:
+            g = re.match(r'Ran.*passed:\s+(\d+)\s+failed:\s+(\d+)',ol)
+            if g:
+                passTot += int(g.group(1))
+                failTot += int(g.group(2))
 
     print "Summary"
     print "Passed: %5d Failed %5d" % (passTot, failTot)

--- a/src/lib/unittest/__init__.py
+++ b/src/lib/unittest/__init__.py
@@ -10,7 +10,9 @@ class TestCase:
     def __init__(self):
         self.numPassed = 0
         self.numFailed = 0
-
+        self.assertPassed = 0
+        self.assertFailed = 0
+        self.verbose = True
         self.tlist = []
         testNames = {}
         for name in dir(self):
@@ -23,14 +25,28 @@ class TestCase:
 
     def tearDown(self):
         pass
-
+    def cleanName(self,funcName):
+    # work around skulpts lack of an __name__ 
+        funcName = str(funcName)
+        funcName = funcName[13:]
+        funcName = funcName[:funcName.find('<')-3]
+        return funcName
+        
     def main(self):
 
         for func in self.tlist:
             try:
                 self.setup()
+                self.assertPassed = 0
+                self.assertFailed = 0
                 func()
                 self.tearDown()
+                if self.assertFailed == 0:
+                    self.numPassed += 1
+                else:
+                    self.numFailed += 1
+                    if self.verbose:
+                        print 'Tests failed in %s ' % self.cleanName(func)
             except:
                 self.appendResult('Error',None,None,None)
                 self.numFailed += 1
@@ -113,15 +129,15 @@ class TestCase:
             msg = 'Error'
         elif res:
             msg = 'Pass'
-            self.numPassed += 1
+            self.assertPassed += 1
         else:
             msg = 'Fail: expected %s  %s ' % (str(actual),str(expected)) + feedback
             print msg
-            self.numFailed += 1
+            self.assertFailed += 1
 
     def showSummary(self):
         pct = self.numPassed / (self.numPassed+self.numFailed) * 100
-        print "ran %d tests, passed: %d failed: %d\n" % (self.numPassed+self.numFailed,
+        print "Ran %d tests, passed: %d failed: %d\n" % (self.numPassed+self.numFailed,
                                                self.numPassed, self.numFailed)
 
 


### PR DESCRIPTION
unittest now just counts each test function rather than every assert.  It will also report the name of the function when a test fails.  -- this may be brittle as skulpt does not support the ``__name__`` attribute on function objects.