### PR TITLE
Reassign $loc to $gbl if retainGlobals flag is set

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2222,7 +2222,7 @@ Compiler.prototype.cmod = function (mod) {
 
     this.u.varDeclsCode += "if ("+modf+".wakingSuspension!==undefined) { $wakeFromSuspension(); }" +
         "if (Sk.retainGlobals) {" +
-        "    if (Sk.globals) { $gbl = Sk.globals; Sk.globals = $gbl }" +
+        "    if (Sk.globals) { $gbl = Sk.globals; Sk.globals = $gbl; $loc = $gbl; }" +
         "    else { Sk.globals = $gbl; }" +
         "} else { Sk.globals = $gbl; }"
 


### PR DESCRIPTION
The retainglobals flag seems to have been broken by the introduction of suspensions. Before the breaking commit, $loc was being assigned to $gbl AFTER Sk.retainGlobals was checked and Sk.globals was applied. After the commit, this assignment no longer took place and $loc remained as an empty object. This commit simply adds the assignment of $loc back in the case of Sk.retainGlobals being true.