### PR TITLE
Removes special treatment of SystemExit

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -927,7 +927,7 @@ Compiler.prototype.outputSuspensionHelpers = function (unit) {
         }
     }
 
-    output +=  "try { $ret=susp.child.resume(); } catch(err) { if (!(err instanceof Sk.builtin.Exception)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if($exc.length>0) { $err=err; $blk=$exc.pop(); } else { throw err; } }" +
+    output +=  "try { $ret=susp.child.resume(); } catch(err) { if (!(err instanceof Sk.builtin.BaseException)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if($exc.length>0) { $err=err; $blk=$exc.pop(); } else { throw err; } }" +
                 "};";
 
     output += "var $saveSuspension = function(child, filename, lineno, colno) {" +
@@ -1586,7 +1586,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     this.u.switchCode = "while(true){try{"
     this.u.switchCode += this.outputInterruptTest();
     this.u.switchCode += "switch($blk){";
-    this.u.suffixCode = "} }catch(err){ if (!(err instanceof Sk.builtin.Exception)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} }});";
+    this.u.suffixCode = "} }catch(err){ if (!(err instanceof Sk.builtin.BaseException)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} }});";
 
     //
     // jump back to the handler so it can do the main actual work of the
@@ -2225,8 +2225,6 @@ Compiler.prototype.cmod = function (mod) {
         this.u.varDeclsCode += "if (typeof Sk.lastYield === 'undefined') {Sk.lastYield = new Date()}";
     }
 
-    this.u.varDeclsCode += "try {";
-
     this.u.varDeclsCode += "if ("+modf+".wakingSuspension!==undefined) { $wakeFromSuspension(); }" +
         "if (Sk.retainGlobals) {" +
         "    if (Sk.globals) { $gbl = Sk.globals; Sk.globals = $gbl; $loc = $gbl; }" +
@@ -2245,8 +2243,8 @@ Compiler.prototype.cmod = function (mod) {
     this.u.switchCode = "while(true){try{";
     this.u.switchCode += this.outputInterruptTest();
     this.u.switchCode += "switch($blk){";
-    this.u.suffixCode = "} }catch(err){ if (!(err instanceof Sk.builtin.Exception)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} }" +
-        " }catch(err){ if (err instanceof Sk.builtin.SystemExit && !Sk.throwSystemExit) { Sk.misceval.print_(err.toString() + '\\n'); return $loc; } else { throw err; } } });";
+    this.u.suffixCode = "}"
+    this.u.suffixCode += "}catch(err){ if (!(err instanceof Sk.builtin.BaseException)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} } });";
 
     // Note - this change may need to be adjusted for all the other instances of
     // switchCode and suffixCode in this file.  Not knowing how to test those

--- a/src/env.js
+++ b/src/env.js
@@ -46,11 +46,8 @@ Sk.configure = function (options) {
     Sk.inputfun = options["inputfun"] || Sk.inputfun;
     goog.asserts.assert(typeof Sk.inputfun === "function");
 
-    Sk.throwSystemExit = options["systemexit"] || false;
-    goog.asserts.assert(typeof Sk.throwSystemExit === "boolean");
-
     Sk.retainGlobals = options["retainglobals"] || false;
-    goog.asserts.assert(typeof Sk.throwSystemExit === "boolean");
+    goog.asserts.assert(typeof Sk.retainGlobals === "boolean");
 
     Sk.debugging = options["debugging"] || false;
     goog.asserts.assert(typeof Sk.debugging === "boolean");

--- a/src/errors.js
+++ b/src/errors.js
@@ -12,11 +12,11 @@
  * @constructor
  * @param {...Object|null} args
  */
-Sk.builtin.Exception = function (args) {
+Sk.builtin.BaseException = function (args) {
     var i, o;
 
-    if (!(this instanceof Sk.builtin.Exception)) {
-        o = Object.create(Sk.builtin.Exception.prototype);
+    if (!(this instanceof Sk.builtin.BaseException)) {
+        o = Object.create(Sk.builtin.BaseException.prototype);
         o.constructor.apply(o, arguments);
         return o;
     }
@@ -42,9 +42,9 @@ Sk.builtin.Exception = function (args) {
                              filename: this.args.v[1].v || "<unknown>"});
     }
 };
-Sk.builtin.Exception.prototype.tp$name = "Exception";
+Sk.builtin.BaseException.prototype.tp$name = "BaseException";
 
-Sk.builtin.Exception.prototype.tp$str = function () {
+Sk.builtin.BaseException.prototype.tp$str = function () {
     var i;
     var ret = "";
 
@@ -76,15 +76,51 @@ Sk.builtin.Exception.prototype.tp$str = function () {
     return new Sk.builtin.str(ret);
 };
 
-Sk.builtin.Exception.prototype.toString = function () {
+Sk.builtin.BaseException.prototype.toString = function () {
     return this.tp$str().v;
 };
 
-goog.exportSymbol("Sk.builtin.Exception", Sk.builtin.Exception);
+goog.exportSymbol("Sk.builtin.BaseException", Sk.builtin.BaseException);
 
 /**
  * @constructor
  * @extends Sk.builtin.Exception
+ * @param {...*} args
+ */
+Sk.builtin.Exception = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.Exception)) {
+        o = Object.create(Sk.builtin.Exception.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.BaseException.apply(this, arguments);
+};
+goog.inherits(Sk.builtin.Exception, Sk.builtin.BaseException);
+Sk.builtin.Exception.prototype.tp$name = "Exception";
+goog.exportSymbol("Sk.builtin.Exception", Sk.builtin.Exception);
+
+/**
+ * @constructor
+ * @extends Sk.builtin.StandardError
+ * @param {...*} args
+ */
+Sk.builtin.StandardError = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.StandardError)) {
+        o = Object.create(Sk.builtin.StandardError.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.Exception.apply(this, arguments);
+};
+goog.inherits(Sk.builtin.StandardError, Sk.builtin.Exception);
+Sk.builtin.StandardError.prototype.tp$name = "StandardError";
+goog.exportSymbol("Sk.builtin.StandardError", Sk.builtin.StandardError);
+
+/**
+ * @constructor
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.AssertionError = function (args) {
@@ -94,15 +130,15 @@ Sk.builtin.AssertionError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.AssertionError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.AssertionError, Sk.builtin.StandardError);
 Sk.builtin.AssertionError.prototype.tp$name = "AssertionError";
 goog.exportSymbol("Sk.builtin.AssertionError", Sk.builtin.AssertionError);
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.AttributeError = function (args) {
@@ -112,14 +148,14 @@ Sk.builtin.AttributeError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.AttributeError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.AttributeError, Sk.builtin.StandardError);
 Sk.builtin.AttributeError.prototype.tp$name = "AttributeError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.ImportError = function (args) {
@@ -129,14 +165,14 @@ Sk.builtin.ImportError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.ImportError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.ImportError, Sk.builtin.StandardError);
 Sk.builtin.ImportError.prototype.tp$name = "ImportError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.IndentationError = function (args) {
@@ -146,14 +182,14 @@ Sk.builtin.IndentationError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.IndentationError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.IndentationError, Sk.builtin.StandardError);
 Sk.builtin.IndentationError.prototype.tp$name = "IndentationError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.IndexError = function (args) {
@@ -163,14 +199,14 @@ Sk.builtin.IndexError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.IndexError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.IndexError, Sk.builtin.StandardError);
 Sk.builtin.IndexError.prototype.tp$name = "IndexError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.KeyError = function (args) {
@@ -180,14 +216,14 @@ Sk.builtin.KeyError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.KeyError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.KeyError, Sk.builtin.StandardError);
 Sk.builtin.KeyError.prototype.tp$name = "KeyError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.NameError = function (args) {
@@ -197,14 +233,14 @@ Sk.builtin.NameError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.NameError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.NameError, Sk.builtin.StandardError);
 Sk.builtin.NameError.prototype.tp$name = "NameError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.UnboundLocalError = function (args) {
@@ -214,14 +250,14 @@ Sk.builtin.UnboundLocalError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.UnboundLocalError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.UnboundLocalError, Sk.builtin.StandardError);
 Sk.builtin.UnboundLocalError.prototype.tp$name = "UnboundLocalError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.OverflowError = function (args) {
@@ -231,15 +267,15 @@ Sk.builtin.OverflowError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.OverflowError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.OverflowError, Sk.builtin.StandardError);
 Sk.builtin.OverflowError.prototype.tp$name = "OverflowError";
 
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.ParseError = function (args) {
@@ -249,15 +285,15 @@ Sk.builtin.ParseError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.ParseError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.ParseError, Sk.builtin.StandardError);
 Sk.builtin.ParseError.prototype.tp$name = "ParseError";
 
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.SuspensionError = function (args) {
@@ -267,16 +303,16 @@ Sk.builtin.SuspensionError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.SuspensionError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.SuspensionError, Sk.builtin.StandardError);
 Sk.builtin.SuspensionError.prototype.tp$name = "SuspensionError";
 goog.exportSymbol("Sk.builtin.SuspensionError", Sk.builtin.SuspensionError);
 
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.BaseException
  * @param {...*} args
  */
 Sk.builtin.SystemExit = function (args) {
@@ -286,16 +322,16 @@ Sk.builtin.SystemExit = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.BaseException.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.SystemExit, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.SystemExit, Sk.builtin.BaseException);
 Sk.builtin.SystemExit.prototype.tp$name = "SystemExit";
 goog.exportSymbol("Sk.builtin.SystemExit", Sk.builtin.SystemExit);
 
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.SyntaxError = function (args) {
@@ -305,14 +341,14 @@ Sk.builtin.SyntaxError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.SyntaxError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.SyntaxError, Sk.builtin.StandardError);
 Sk.builtin.SyntaxError.prototype.tp$name = "SyntaxError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.TokenError = function (args) {
@@ -322,14 +358,14 @@ Sk.builtin.TokenError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.TokenError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.TokenError, Sk.builtin.StandardError);
 Sk.builtin.TokenError.prototype.tp$name = "TokenError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.TypeError = function (args) {
@@ -339,14 +375,14 @@ Sk.builtin.TypeError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.TypeError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.TypeError, Sk.builtin.StandardError);
 Sk.builtin.TypeError.prototype.tp$name = "TypeError";
 goog.exportSymbol("Sk.builtin.TypeError", Sk.builtin.TypeError);
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.ValueError = function (args) {
@@ -356,15 +392,15 @@ Sk.builtin.ValueError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.ValueError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.ValueError, Sk.builtin.StandardError);
 Sk.builtin.ValueError.prototype.tp$name = "ValueError";
 goog.exportSymbol("Sk.builtin.ValueError", Sk.builtin.ValueError);
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.ZeroDivisionError = function (args) {
@@ -374,14 +410,14 @@ Sk.builtin.ZeroDivisionError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.ZeroDivisionError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.ZeroDivisionError, Sk.builtin.StandardError);
 Sk.builtin.ZeroDivisionError.prototype.tp$name = "ZeroDivisionError";
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.TimeLimitError = function (args) {
@@ -391,15 +427,15 @@ Sk.builtin.TimeLimitError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.TimeLimitError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.TimeLimitError, Sk.builtin.StandardError);
 Sk.builtin.TimeLimitError.prototype.tp$name = "TimeLimitError";
 goog.exportSymbol("Sk.builtin.TimeLimitError", Sk.builtin.TimeLimitError);
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.IOError = function (args) {
@@ -409,16 +445,16 @@ Sk.builtin.IOError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.IOError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.IOError, Sk.builtin.StandardError);
 Sk.builtin.IOError.prototype.tp$name = "IOError";
 goog.exportSymbol("Sk.builtin.IOError", Sk.builtin.IOError);
 
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.NotImplementedError = function (args) {
@@ -428,15 +464,15 @@ Sk.builtin.NotImplementedError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.NotImplementedError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.NotImplementedError, Sk.builtin.StandardError);
 Sk.builtin.NotImplementedError.prototype.tp$name = "NotImplementedError";
 goog.exportSymbol("Sk.builtin.NotImplementedError", Sk.builtin.NotImplementedError);
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.NegativePowerError = function (args) {
@@ -446,15 +482,15 @@ Sk.builtin.NegativePowerError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.NegativePowerError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.NegativePowerError, Sk.builtin.StandardError);
 Sk.builtin.NegativePowerError.prototype.tp$name = "NegativePowerError";
 goog.exportSymbol("Sk.builtin.NegativePowerError", Sk.builtin.NegativePowerError);
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {*} nativeError
  * @param {...*} args
  */
@@ -470,15 +506,15 @@ Sk.builtin.ExternalError = function (nativeError, args) {
     args = Array.prototype.slice.call(arguments);
     this.nativeError = args[0];
     args[0] = ""+args[0];
-    Sk.builtin.Exception.apply(this, args);
+    Sk.builtin.StandardError.apply(this, args);
 };
-goog.inherits(Sk.builtin.ExternalError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.ExternalError, Sk.builtin.StandardError);
 Sk.builtin.ExternalError.prototype.tp$name = "ExternalError";
 goog.exportSymbol("Sk.builtin.ExternalError", Sk.builtin.ExternalError);
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.OperationError = function (args) {
@@ -488,15 +524,15 @@ Sk.builtin.OperationError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.OperationError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.OperationError, Sk.builtin.StandardError);
 Sk.builtin.OperationError.prototype.tp$name = "OperationError";
 goog.exportSymbol("Sk.builtin.OperationError", Sk.builtin.OperationError);
 
 /**
  * @constructor
- * @extends Sk.builtin.Exception
+ * @extends Sk.builtin.StandardError
  * @param {...*} args
  */
 Sk.builtin.SystemError = function (args) {
@@ -506,9 +542,9 @@ Sk.builtin.SystemError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.SystemError, Sk.builtin.Exception);
+goog.inherits(Sk.builtin.SystemError, Sk.builtin.StandardError);
 Sk.builtin.SystemError.prototype.tp$name = "SystemError";
 goog.exportSymbol("Sk.builtin.SystemError", Sk.builtin.SystemError);
 

--- a/src/lib/unittest/__init__.py
+++ b/src/lib/unittest/__init__.py
@@ -45,11 +45,11 @@ class TestCase:
                     self.numPassed += 1
                 else:
                     self.numFailed += 1
-                    if self.verbose:
-                        print 'Tests failed in %s ' % self.cleanName(func)
-            except:
-                self.appendResult('Error',None,None,None)
+                    print 'Tests failed in %s ' % self.cleanName(func)
+            except Exception as e:
+                self.assertFailed += 1
                 self.numFailed += 1
+                print 'Test threw exception in %s (%s)' % (self.cleanName(func), e)
         self.showSummary()
 
     def assertEqual(self, actual, expected, feedback=""):
@@ -125,15 +125,21 @@ class TestCase:
         self.appendResult(res,str(a)+' to be less than or equal to ',b,feedback)
 
     def appendResult(self,res,actual,expected,feedback):
-        if res == 'Error':
-            msg = 'Error'
-        elif res:
+        if res:
             msg = 'Pass'
             self.assertPassed += 1
         else:
             msg = 'Fail: expected %s  %s ' % (str(actual),str(expected)) + feedback
             print msg
             self.assertFailed += 1
+
+    def fail(self, msg=None):
+        if msg is None:
+            msg = 'Fail'
+        else:
+            msg = 'Fail: ' + msg
+        print msg
+        self.assertFailed += 1
 
     def showSummary(self):
         pct = self.numPassed / (self.numPassed+self.numFailed) * 100

--- a/test/test.js
+++ b/test/test.js
@@ -228,7 +228,11 @@ function testRun(name, nocatch, debugMode)
     if (!nocatch)
     {
         promise = promise.then(null, function(e) {
-            if (e.name !== undefined)
+            if (e instanceof Sk.builtin.SystemExit) {
+                // SystemExit isn't a failing exception, so treat it specially
+                got += e.toString() + "\n";
+            }
+            else if (e.name !== undefined)
             {
                 // js exception, currently happens for del'd objects. shouldn't
                 // really though.

--- a/test/unit/exiting_module.py
+++ b/test/unit/exiting_module.py
@@ -1,0 +1,5 @@
+__author__ = "leszek"
+
+if __name__ != "__main__":
+    # Exit when this module is imported 
+    exit()

--- a/test/unit/test_exit.py
+++ b/test/unit/test_exit.py
@@ -1,0 +1,45 @@
+__author__ = "leszek"
+
+import unittest
+
+class ExitTest(unittest.TestCase):
+    def test_exit(self):
+        try:
+            exit()
+            self.fail("Should not reach line after exit")
+        except SystemExit as e:
+            return
+        self.fail("Test should have returned")
+
+    def test_exit_not_exception(self):
+        try:
+            try:
+                exit()
+            except Exception as e:
+                self.fail("except Exception should not catch SystemExit")
+            self.fail("Should not reach line after exit")
+        except SystemExit as e:
+            return
+        self.fail("Test should have returned")
+
+    def test_exit_in_func(self):
+        try:
+            def foo():
+                exit()
+            exit()
+            self.fail("Should not reach line after exit")
+        except SystemExit as e:
+            return
+        self.fail("Test should have returned")
+
+    def test_import_exit(self):
+        try:
+            import exiting_module
+            self.fail("Should not reach line after import")
+        except SystemExit as e:
+            return
+        self.fail("Test should have returned")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Previously, `SystemExit` exceptions were being caught at the module level,
presumably to not crash an interpreter which did not expect this
exception. However, this had several problems:

  1. Importing a module which calls `exit()` in its body would not
     correctly exit the importing module.

  2. The additional `try`-`catch` logic required for the special treatment
     of `SystemExit` had a noticeable performance penalty.

  3. Special casing `SystemExit` on a module level is inconsistent with
     Python's behaviour, which treats it like any other exception, and
     where it is up to the interpreter (not the module) to catch this
     exception and deal with it as desired.

  4. Additionally, `SystemExit` was incorrectly set to inherit from
     `Exception` (instead of `BaseException`), which meant that except
     blocks catching `Exception` would also catch `SystemExit`

This patch fixes the above issues by:

  1. Removing the special check for `SystemExit`

  2. Changing `SystemExit` to inherit from `BaseException` (and, while I was
     at it, change other exceptions to inherit from `SystemError`)

  3. Updating the tests to special case `SystemExit` as required

  4. Adding new-style unit tests for testing the above issues