### PR TITLE
Allow ExternalError to be instantiated from Python

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -505,7 +505,9 @@ Sk.builtin.ExternalError = function (nativeError, args) {
     // but save a reference to the real thing for Javascript consumption
     args = Array.prototype.slice.call(arguments);
     this.nativeError = args[0];
-    args[0] = ""+args[0];
+    if (!(args[0] instanceof Sk.builtin.str)) {
+        args[0] = ""+args[0];
+    }
     Sk.builtin.StandardError.apply(this, args);
 };
 goog.inherits(Sk.builtin.ExternalError, Sk.builtin.StandardError);


### PR DESCRIPTION
Make ExternalError happy to be fed an Sk.builtin.str(). Among other things, this makes it produce nice output when constructed in Python