### PR TITLE
Check return code on rununits subprocesses

### DIFF
--- a/skulpt.py
+++ b/skulpt.py
@@ -724,6 +724,8 @@ Sk.importMain("%s", false);
                 getFileList(FILE_TYPE_TEST))), shell=True, stdout=PIPE, stderr=PIPE)
 
         outs, errs = p.communicate()
+        if p.returncode != 0:
+            failTot += 1
         print outs
         if errs:
             print errs

--- a/skulpt.py
+++ b/skulpt.py
@@ -724,8 +724,11 @@ Sk.importMain("%s", false);
                 getFileList(FILE_TYPE_TEST))), shell=True, stdout=PIPE, stderr=PIPE)
 
         outs, errs = p.communicate()
+
         if p.returncode != 0:
             failTot += 1
+            print "{} exited with error code {}".format(fn,p.returncode)
+
         print outs
         if errs:
             print errs


### PR DESCRIPTION
OK, this is pretty simple, and should be accepted quickly as this plugs a hole in the new unittests.

By not checking the returncode of the subprocess we miss out on the fact that sometimes we get an error just loading up the code for a particular unittest which goes uncounted as a failure.  

If the test file exists then it better work or should cause the tests to fail.  I caught this in my own code a few days ago, and then I saw the problem again looking at @waywaaard's complex branch:

```
test/unit/test_complex.py
src/float.js:128: TypeError: a float is required at <unknown>
        throw new Sk.builtin.TypeError("a float is required");
```

This did not count as a fail and wrongly made it look like all unittests had passed.
