### PR TITLE
Continue in while loop if return is pressed

### DIFF
--- a/doc/static/repl.js
+++ b/doc/static/repl.js
@@ -83,7 +83,7 @@ $(function () {
 		try {
             //Evaluate
             if (!lines || /^\s*$/.test(lines)) {
-                continue
+                return;
             }
             else {
                 Sk.importMainWithBody("repl", false, lines.join('\n'));            

--- a/doc/static/repl.js
+++ b/doc/static/repl.js
@@ -82,8 +82,12 @@ $(function () {
 
 		try {
             //Evaluate
-            Sk.importMainWithBody("repl", false, lines.join('\n'));
-            //remove print statements when a block is created that doesn't define anything
+            if (!lines || /^\s*$/.test(lines)) {
+                continue
+            }
+            else {
+                Sk.importMainWithBody("repl", false, lines.join('\n'));            
+            }
         } catch (err) {
             repl.print(err);
 

--- a/repl/repl.js
+++ b/repl/repl.js
@@ -78,7 +78,12 @@ while (true) {
 
     try {
         //Evaluate
-        Sk.importMainWithBody("repl", false, lines.join('\n'));
+        if (!lines || /^\s*$/.test(lines)) {
+            continue
+        }
+        else {
+            Sk.importMainWithBody("repl", false, lines.join('\n'));            
+        }
     } catch (err) {
         if (err instanceof Sk.builtin.SystemExit) {
             quit();


### PR DESCRIPTION
Still behaviors in the repl that don't match Python's but this small fix will avoid a nasty error for a common behavior: pressing return on an empty prompt.