### PR TITLE
Made skulpt.py host port customizable (default left at 20710)

### DIFF
--- a/skulpt.py
+++ b/skulpt.py
@@ -851,10 +851,9 @@ class HttpHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         else:
             SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)
 
-def host():
+def host(PORT = 20710):
     """simple http host from root of dir for testing"""
     import SocketServer
-    PORT = 20710
     httpd = SocketServer.TCPServer(("", PORT), HttpHandler)
     print "serving at port", PORT
     httpd.serve_forever()
@@ -878,7 +877,7 @@ Commands:
     regentests       Regenerate all of the above
 
     help             Display help information about Skulpt
-    host             Start a simple HTTP server for testing
+    host [PORT]      Start a simple HTTP server for testing. Default port: 20710
     upload           Run appcfg.py to upload doc to live GAE site
     doctest          Run the GAE development server for doc testing
     nrt              Generate a file for a new test case
@@ -981,7 +980,14 @@ def main():
     elif cmd == "vfs":
         buildVFS()
     elif cmd == "host":
-        host()
+        if len(sys.argv) < 3:
+            host()
+        else:
+            try:
+                host(int(sys.argv[2]))
+            except ValueError:
+                print "Port must be an integer"
+                sys.exit(2)
     elif cmd == "shell":
         shell(sys.argv[2]);
     elif cmd == "repl":


### PR DESCRIPTION
This is needed for some cloud IDEs and other dev setups with limited port access.  Does not alter behavior of `./m host` - but if there are arguments will take the first argument and pass it to the server to override the default port.  Catches errors from non-integer inputs.  Updated the usageString too.

Another contender for tiniest pull request evar.