### PR TITLE
Add .gitattributes for test outputs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Mark python files as text ending with lf
+*.py             text eol=lf
+
+# Mark test outputs as non-text, to prevent line-ending normalization
+/test/**/*.expect         -text
+/test/**/*.trans          -text
+/test/**/*.py.symtab      -text
+/test/**/*.py.real        -text
+/test/**/*.py.real.alt    -text


### PR DESCRIPTION
Marks test files as non-text in .gitattributes, to prevent line-ending
normalisation on them when checked out on Windows with autocrlf enabled.

Also, mark all .py files as lf-only, as this is what the parser expects (in
particular, for triple quoted strings).

- [x] windows
- [x] mac
- [x] linux
