### PR TITLE
remove tmp.js after using it

### DIFF
--- a/skulpt.py
+++ b/skulpt.py
@@ -505,7 +505,9 @@ def dist(options):
 
         size = os.path.getsize("{0}/tmp.js.gz".format(DIST_DIR))
         os.unlink("{0}/tmp.js.gz".format(DIST_DIR))
+        os.unlink("{0}/tmp.js".format(DIST_DIR))
     else:
+        os.unlink("{0}/tmp.js".format(DIST_DIR))
         print "No gzip executable, can't get final size"
 
     with open(builtinfn, "w") as f:


### PR DESCRIPTION
I saw a rogue tmp.js file on the dist repo. This makes sure it won’t be added again.