### PR TITLE
KeyboardInterrupt Exception and Compiler Handling

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -287,6 +287,20 @@ Compiler.prototype.outputInterruptTest = function () { // Added by RNL
     return output;
 };
 
+/**
+ * Function to test if an interrupt should occur if external Sk.keyboardInterrupt flag has been set
+ * This function is executed at every test/branch operation.
+             if("keyboardInterrupt" in Sk && Sk.keyboardInterrupt === true) {
+                throw new Sk.builtin.KeyboardInterrupt("aborted execution");
+            }
+ */
+Compiler.prototype.keyboardInterrupt = function () {
+    var output = "";
+    output += "if (Sk.hasOwnProperty('keyboardInterrupt') && Sk.keyboardInterrupt === true) {throw new Sk.builtin.KeyboardInterrupt('aborted execution');}";
+
+    return output;
+};
+
 Compiler.prototype._jumpfalse = function (test, block) {
     var cond = this._gr("jfalse", "(", test, "===false||!Sk.misceval.isTrue(", test, "))");
     out("if(", cond, "){/*test failed */$blk=", block, ";continue;}");
@@ -1600,6 +1614,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     // New switch code to catch exceptions
     this.u.switchCode = "while(true){try{"
     this.u.switchCode += this.outputInterruptTest();
+    this.u.switchCode += this.keyboardInterrupt();
     this.u.switchCode += "switch($blk){";
     this.u.suffixCode = "} }catch(err){ if (!(err instanceof Sk.builtin.BaseException)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} }});";
 
@@ -1841,6 +1856,7 @@ Compiler.prototype.cclass = function (s) {
     }
     this.u.switchCode += "while(true){";
     this.u.switchCode += this.outputInterruptTest();
+    this.u.switchCode += this.keyboardInterrupt();
     this.u.switchCode += "switch($blk){";
     this.u.suffixCode = "}break;}}).apply(null,$rest);});";
 
@@ -2257,8 +2273,9 @@ Compiler.prototype.cmod = function (mod) {
     // New Code:
     this.u.switchCode = "while(true){try{";
     this.u.switchCode += this.outputInterruptTest();
+    this.u.switchCode += this.keyboardInterrupt();
     this.u.switchCode += "switch($blk){";
-    this.u.suffixCode = "}"
+    this.u.suffixCode = "}";
     this.u.suffixCode += "}catch(err){ if (!(err instanceof Sk.builtin.BaseException)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: currLineNo, colno: currColNo, filename: '"+this.filename+"'}); if ($exc.length>0) { $err = err; $blk=$exc.pop(); continue; } else { throw err; }} } });";
 
     // Note - this change may need to be adjusted for all the other instances of

--- a/src/errors.js
+++ b/src/errors.js
@@ -222,6 +222,27 @@ goog.inherits(Sk.builtin.KeyError, Sk.builtin.StandardError);
 Sk.builtin.KeyError.prototype.tp$name = "KeyError";
 
 /**
+ * Is thrown when the execution has been stopped by Ctrl+C or Del. The compiler
+ * checks for an Sk.keyboardinterrupt flag, if set the exeception is thrown.
+ * @constructor
+ * @extends Sk.builtin.BaseException
+ * @param {...*} args
+ *
+ */
+Sk.builtin.KeyboardInterrupt = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.KeyboardInterrupt)) {
+        o = Object.create(Sk.builtin.KeyboardInterrupt.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.BaseException.apply(this, arguments);
+};
+goog.inherits(Sk.builtin.KeyboardInterrupt, Sk.builtin.BaseException);
+Sk.builtin.KeyboardInterrupt.prototype.tp$name = "KeyboardInterrupt";
+goog.exportSymbol("Sk.builtin.KeyboardInterrupt", Sk.builtin.KeyboardInterrupt);
+
+/**
  * @constructor
  * @extends Sk.builtin.StandardError
  * @param {...*} args


### PR DESCRIPTION
With the addition of suspensions, long-running python programs or infinite loops cannot be terminated. I am using skulpt to program some virtual Arduino and need to terminate the execution of skulpt as most of the programs run in a loop.

Python has a KeyboardInterrupt Exception that is thrown when you press Ctrl+C or Del. This PR tries to mimic this behavior by adding the exception and a runtime check if the ```Sk.keyboardInterrupt``` flag has been set. When set it throws the KeyboardInterrupt Exception and, therefore, terminates the execution of the program.

I am currently using this code and it works pretty well with suspensions and promises. However, I am open for other approaches or solutions.