### PR TITLE
Fixing Special Lookups and Inheritance

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -43,7 +43,8 @@ Sk.abstr.boNameToSlotFuncLhs_ = function (obj, name) {
     case "Add":
         return obj.nb$add ? obj.nb$add : obj["__add__"];
     case "Sub":
-        return obj.nb$subtract ? obj.nb$subtract : obj["__sub__"];
+        //return obj.nb$subtract ? obj.nb$subtract : Sk.builtin.object.PyObject_LookupSpecial_(obj,"__sub__");
+        return Sk.builtin.object.PyObject_LookupSpecial_(obj,"__sub__");
     case "Mult":
         return obj.nb$multiply ? obj.nb$multiply : obj["__mul__"];
     case "Div":

--- a/src/number.js
+++ b/src/number.js
@@ -245,7 +245,7 @@ Sk.builtin.nmber.prototype.nb$subtract = function (other) {
 };
 
 Sk.builtin.nmber.prototype["__sub__"] = new Sk.builtin.func(function (self, other) {
-    print("using this one")
+    print("using the wrapped nb$subtract")
     Sk.builtin.pyCheckArgs("__sub__", arguments, 1, 2, false, true);
     return Sk.builtin.nmber.prototype.nb$subtract.call(self,other);
 });

--- a/src/number.js
+++ b/src/number.js
@@ -244,10 +244,10 @@ Sk.builtin.nmber.prototype.nb$subtract = function (other) {
     return undefined;
 };
 
-Sk.builtin.dict.prototype["__sub__"] = new Sk.builtin.func(function (self, other) {
+Sk.builtin.nmber.prototype["__sub__"] = new Sk.builtin.func(function (self, other) {
     print("using this one")
-    Sk.builtin.pyCheckArgs("__sub__", arguments, 2, 2, false, true);
-    return Sk.builtin.nmbr.prototype.nb$subtract.call(self,other);
+    Sk.builtin.pyCheckArgs("__sub__", arguments, 1, 2, false, true);
+    return Sk.builtin.nmber.prototype.nb$subtract.call(self,other);
 });
 
 

--- a/src/number.js
+++ b/src/number.js
@@ -244,6 +244,13 @@ Sk.builtin.nmber.prototype.nb$subtract = function (other) {
     return undefined;
 };
 
+Sk.builtin.dict.prototype["__sub__"] = new Sk.builtin.func(function (self, other) {
+    print("using this one")
+    Sk.builtin.pyCheckArgs("__sub__", arguments, 2, 2, false, true);
+    return Sk.builtin.nmbr.prototype.nb$subtract.call(self,other);
+});
+
+
 Sk.builtin.nmber.prototype.nb$multiply = function (other) {
     var thisAsLong;
     var result;

--- a/src/object.js
+++ b/src/object.js
@@ -24,14 +24,13 @@ Sk.builtin.object.PyObject_LookupSpecial_ = function(op, str) {
         return null;
     }
     if (op[str]) {
-        print("found it here")
+        print("found it for the object")
         return op[str]
     }
     if (op.ob$type) {
-         res = Sk.builtin.type.typeLookup(op.ob$type, str);
-        print("checking type for res = " + res)
+        res = Sk.builtin.type.typeLookup(op.ob$type, str);
+        print("checking using type and res  = " + res)
     }
-    print('nope')
     return res
 };
 

--- a/src/object.js
+++ b/src/object.js
@@ -23,8 +23,16 @@ Sk.builtin.object.PyObject_LookupSpecial_ = function(op, str) {
     if (op == null) {
         return null;
     }
-
-    return Sk.builtin.type.typeLookup(op, str);
+    if (op[str]) {
+        print("found it here")
+        return op[str]
+    }
+    if (op.ob$type) {
+         res = Sk.builtin.type.typeLookup(op.ob$type, str);
+        print("checking type for res = " + res)
+    }
+    print('nope')
+    return res
 };
 
 /**


### PR DESCRIPTION
OK, so I created a branch just to experiment with this lookup issue. 
@rixner @waywaaard 

Here is the example program that now works with the few changes on this branch.

```
class Foo:
    def __init__(self):
        self.a = "a"
        self.c = 100

    def frob(self):
        print "boo"

    def __sub__(self, other):
         return self.c - other

class Bar(Foo):
    def __init__(self):
        Foo.__init__(self)
        self.b = "b"

b = Bar()
b.frob()
print 5 - 1

print b - 1
```