### PR TITLE
Add optional uncaughtException handler to Sk.configure

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -84,7 +84,8 @@ goog.exportSymbol("Sk.configure", Sk.configure);
  */
 Sk.uncaughtException = function(err) {
     throw err;
-}
+};
+goog.exportSymbol("Sk.uncaughtException", Sk.uncaughtException);
 
 /*
  *	Replaceable message for message timeouts

--- a/src/env.js
+++ b/src/env.js
@@ -27,6 +27,9 @@ Sk.configure = function (options) {
     Sk.debugout = options["debugout"] || Sk.debugout;
     goog.asserts.assert(typeof Sk.debugout === "function");
 
+    Sk.uncaughtException = options["uncaughtException"] || Sk.uncaughtException;
+    goog.asserts.assert(typeof Sk.uncaughtException === "function");
+
     Sk.read = options["read"] || Sk.read;
     goog.asserts.assert(typeof Sk.read === "function");
 
@@ -75,6 +78,13 @@ Sk.configure = function (options) {
     Sk.misceval.softspace_ = false;
 };
 goog.exportSymbol("Sk.configure", Sk.configure);
+
+ /*
+ * Replaceable handler for uncaught exceptions
+ */
+Sk.uncaughtException = function(err) {
+    throw err;
+}
 
 /*
  *	Replaceable message for message timeouts

--- a/src/env.js
+++ b/src/env.js
@@ -79,7 +79,7 @@ Sk.configure = function (options) {
 };
 goog.exportSymbol("Sk.configure", Sk.configure);
 
- /*
+/*
  * Replaceable handler for uncaught exceptions
  */
 Sk.uncaughtException = function(err) {

--- a/src/lib/processing.js
+++ b/src/lib/processing.js
@@ -1551,8 +1551,13 @@ var $builtinmodule = function (name) {
 
                 mod.frameCount = processing.frameCount;
                 if (Sk.globals["draw"]) {
-                    Sk.misceval.callsim(Sk.globals["draw"]);
-		}
+                	try {
+                   	    Sk.misceval.callsim(Sk.globals["draw"]);
+                    }
+                    catch(e) {
+                        Sk.uncaughtException(e);
+                    }
+				}
             };
 
             var callBacks = ["setup", "mouseMoved", "mouseClicked", "mouseDragged", "mouseMoved", "mouseOut",
@@ -1560,7 +1565,7 @@ var $builtinmodule = function (name) {
             ];
             for (var cb in callBacks) {
                 if (Sk.globals[callBacks[cb]]) {
-                    processing[callBacks[cb]] = new Function("Sk.misceval.callsim(Sk.globals['" + callBacks[cb] + "']);");
+                    processing[callBacks[cb]] = new Function("try {Sk.misceval.callsim(Sk.globals['" + callBacks[cb] + "']);} catch(e) {Sk.uncaughtException(e);}");
                 }
             }
         }

--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -1982,7 +1982,7 @@ function generateTurtleModule(_target) {
             }
             return Sk.misceval.applyAsync(
                 undefined, pyValue, undefined, undefined, undefined, argsPy
-            );
+            ).catch(Sk.uncaughtException);
         };
     }
 


### PR DESCRIPTION
Any event driven skulpt callbacks can result in uncaught exceptions.
This PR adds the ability to specify an uncaughtException handler when setting up Skulpt
which will allow the implementer to surface those errors to the end user.

This method must be called explicitly in whatever js library is generating the suspensions.
See the changes in turtle.js of this PR for an example of how it can be used.

```python
import turtle

def click():
  pass

s = turtle.Screen()
t = turtle.Turtle()
t.shape('turtle')
s.onclick(click)
```

If the page implementer specifies an Sk.uncaughtException handler,
the error thrown in the above example will be sent to the handler.

Fixes #455 