### PR TITLE
Unpack sequences

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -571,6 +571,37 @@ Sk.abstr.sequenceSetSlice = function (seq, i1, i2, x) {
     }
 };
 
+// seq - Python object to unpack
+// n   - JavaScript number of items to unpack
+Sk.abstr.sequenceUnpack = function (seq, n) {
+    var res = [];
+    var it, i;
+
+    if (!Sk.builtin.checkIterable(seq)) {
+        throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(seq) + "' object is not iterable");
+    }
+
+    for (it = seq.tp$iter(), i = it.tp$iternext(); 
+         (i !== undefined) && (res.length < n); 
+         i = it.tp$iternext()) {
+        res.push(i);
+    }
+
+    if (res.length < n) {
+        throw new Sk.builtin.ValueError("need more than " + res.length + " values to unpack");
+    }
+    if (i !== undefined) {
+        throw new Sk.builtin.ValueError("too many values to unpack");
+    }
+
+    // Return Javascript array of items
+    return res;
+};
+
+//
+// Object
+//
+
 Sk.abstr.objectFormat = function (obj, format_spec) {
     var meth; // PyObject
     var result; // PyObject
@@ -594,10 +625,6 @@ Sk.abstr.objectFormat = function (obj, format_spec) {
 
     return result;
 };
-
-//
-// Object
-//
 
 Sk.abstr.objectAdd = function (a, b) {
     var btypename;

--- a/src/compile.js
+++ b/src/compile.js
@@ -335,8 +335,9 @@ Compiler.prototype.ctuplelistorset = function(e, data, tuporlist) {
     var items;
     goog.asserts.assert(tuporlist === "tuple" || tuporlist === "list" || tuporlist === "set");
     if (e.ctx === Store) {
+        items = this._gr("items", "Sk.abstr.sequenceUnpack(" + data + "," + e.elts.length + ")");
         for (i = 0; i < e.elts.length; ++i) {
-            this.vexpr(e.elts[i], "Sk.abstr.objectGetItem(" + data + "," + i + ")");
+            this.vexpr(e.elts[i], items + "[" + i + "]");
         }
     }
     else if (e.ctx === Load || tuporlist === "set") { //because set's can't be assigned to.

--- a/test/unit/test_unpack.py
+++ b/test/unit/test_unpack.py
@@ -1,0 +1,111 @@
+# Unpack tests from CPython converted from doctest to unittest
+
+import unittest
+
+class UnpackTest(unittest.TestCase):
+
+    def test_basic(self):
+        t = (1, 2, 3)
+        a, b, c = t
+        self.assertEqual(a, 1)
+        self.assertEqual(b, 2)
+        self.assertEqual(c, 3)
+
+        l = [4, 5, 6]
+        a, b, c = l
+        self.assertEqual(a, 4)
+        self.assertEqual(b, 5)
+        self.assertEqual(c, 6)
+
+        a, b, c = 7, 8, 9
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 8)
+        self.assertEqual(c, 9)
+
+        s = 'one'
+        a, b, c = s
+        self.assertEqual(a, 'o')
+        self.assertEqual(b, 'n')
+        self.assertEqual(c, 'e')
+
+    def test_single(self):
+        st = (99,)
+        sl = [100]
+
+        a, = st
+        self.assertEqual(a, 99)
+
+        b, = sl
+        self.assertEqual(b, 100)
+        
+    def test_non_sequence(self):
+        def unpack():
+            a, b, c = 7
+        # Currently has incorrect message
+        self.assertRaises(TypeError, unpack)
+
+    def test_wrong_size(self):
+        def tup_too_big():
+            t = (1, 2, 3)
+            a, b = t
+        def list_too_big():
+            l = [4, 5, 6]
+            a, b = l
+        def tup_too_small():
+            t = (1, 2, 3)
+            a, b, c, d = t
+        def list_too_small():
+            l = [4, 5, 6]
+            a, b, c, d = l
+            
+        self.assertRaises(ValueError, tup_too_big)
+        self.assertRaises(ValueError, list_too_big)
+        self.assertRaises(ValueError, tup_too_small)
+        self.assertRaises(ValueError, list_too_small)
+
+    # def test_class(self):
+    #     class Seq:
+    #         def __getitem__(self, i):
+    #             if i >= 0 and i < 3: return i
+    #             raise IndexError
+    
+    #     a, b, c = Seq()
+    #     self.assertEqual(a, 0)
+    #     self.assertEqual(b, 1)
+    #     self.assertEqual(c, 2)
+
+    # def test_class_fail(self):
+    #     class Seq:
+    #         def __getitem__(self, i):
+    #             if i >= 0 and i < 3: return i
+    #             raise IndexError
+
+    #     def too_small():
+    #         a, b, c, d = Seq()
+    #     def too_big():
+    #         a, b = Seq()
+        
+    #     self.assertRaises(ValueError, too_small)
+    #     self.assertRaises(ValueError, too_big)
+
+    # def test_bad_class(self):
+    #     class BadSeq:
+    #         def __getitem__(self, i):
+    #             if i >=0 and i < 3:
+    #                 return i
+    #             elif i ==3:
+    #                 raise NameError
+    #             else:
+    #                 raise IndexError
+
+    #     def raise_bad_error1():
+    #         a, b, c, d, e = BadSeq()
+
+    #     def raise_bad_error2():
+    #         a, b, c = BadSeq()
+
+    #     self.assertRaises(NameError, raise_bad_error1)
+    #     self.assertRaises(NameError, raise_bad_error2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Use iteration at run time to unpack sequences to match CPython's behavior.

This does not currently work with user-defined classes that support iteration (#469).  However, if the solution to that preserves the internal iteration interface, then they should just work once that is resolved.  Those tests from CPython are in the ```test_unpack.py``` file, but are commented out.

Resolves #430 