### PR TITLE
add brun command to run a file in the browser

### DIFF
--- a/skulpt.py
+++ b/skulpt.py
@@ -543,6 +543,7 @@ def run_in_browser(fn, options):
     make_skulpt_js(options,RUN_DIR)
     docbi(options,RUN_DIR)
     shutil.copy("support/jsbeautify/beautify.js","{0}/beautify.js".format(RUN_DIR))
+    shutil.copy("support/closure-library/closure/goog/deps.js","{0}/deps.js".format(RUN_DIR))
     #
     with open (fn,'r') as runfile:
         prog = runfile.read()
@@ -904,6 +905,7 @@ def usageString(program):
 Commands:
 
     run              Run a Python file using Skulpt
+    brun             Run a Python file using Skulpt but in your browser
     test             Run all test cases
     dist             Build core and library distribution files
     docbi            Build library distribution file only and copy to doc/static

--- a/skulpt.py
+++ b/skulpt.py
@@ -45,7 +45,7 @@ def bowerProperty(name):
 # Symbolic constants for the project structure.
 DIST_DIR        = 'dist'
 TEST_DIR        = 'test'
-RUN_DIR         = 'run'
+RUN_DIR         = 'support/tmp'
 
 # Symbolic constants for the naming of distribution files.
 STANDARD_NAMING = True
@@ -540,17 +540,19 @@ def make_skulpt_js(options,dest):
 def run_in_browser(fn, options):
     shutil.rmtree(RUN_DIR, ignore_errors=True)
     if not os.path.exists(RUN_DIR): os.mkdir(RUN_DIR)
-    make_skulpt_js(options,RUN_DIR)
     docbi(options,RUN_DIR)
-    shutil.copy("support/jsbeautify/beautify.js","{0}/beautify.js".format(RUN_DIR))
-    shutil.copy("support/closure-library/closure/goog/deps.js","{0}/deps.js".format(RUN_DIR))
-    #
+    scripts = []
+    for f in getFileList(FILE_TYPE_TEST):
+        scripts.append('<script type="text/javascript" src="%s"></script>' %
+                os.path.join('../..', f))
+    scripts = "\n".join(scripts)
+
     with open (fn,'r') as runfile:
         prog = runfile.read()
 
     with open('support/run_template.html') as tpfile:
         page = tpfile.read()
-        page = page % dict(code=prog)
+        page = page % dict(code=prog,scripts=scripts)
 
     with open("{0}/run.html".format(RUN_DIR),"w") as htmlfile:
         htmlfile.write(page)
@@ -559,6 +561,8 @@ def run_in_browser(fn, options):
         os.system("open {0}/run.html".format(RUN_DIR))
     elif sys.platform == "linux2":
         os.system("xdg-open {0}/run.html".format(RUN_DIR))
+    elif sys.platform == "win32":
+        os.system("start {0}/run.html".format(RUN_DIR))
     else:
         print("open or refresh {0}/run.html in your browser to test/debug".format(RUN_DIR))
 

--- a/support/run_template.html
+++ b/support/run_template.html
@@ -4,6 +4,7 @@
     <title></title>
     <script src="skulpt.js" type="text/javascript"></script>
     <script src="skulpt-stdlib.js" type="text/javascript"></script>
+    <script src="beautify.js" type="text/javascript"></script>
 
 </head>
 <body>
@@ -14,6 +15,12 @@ function outf(text) {
    var mypre = document.getElementById(Sk.pre);
    mypre.innerHTML = mypre.innerHTML + text;
 }
+
+function showjs(text) {
+   var mypre = document.getElementById("runbrowser_jsout");
+   mypre.innerHTML = mypre.innerHTML + text;
+}
+
 
 function builtinRead(x)
 {
@@ -39,10 +46,11 @@ function runit(myDiv) {
 
    Sk.pre = myDiv+"_pre";
    Sk.configure({output:outf,
-  	        read: builtinRead
+  	        read: builtinRead,
+            debugout: showjs,
               });
        var myPromise = Sk.misceval.asyncToPromise(function() {
-                return Sk.importMainWithBody("<stdin>",false,prog,true);
+                return Sk.importMainWithBody("<stdin>",true,prog,true);
        });
        myPromise.then(function(mod) {}, function(err) {
           console.log(err.toString());
@@ -58,10 +66,15 @@ function runit(myDiv) {
 <button onclick="runit('runbrowser')" type="button">Run</button>
 </form>
 
+<h2>Canvas</h2>
 <div id="runbrowser_canvas" height="500" width="800"
 	style="border-style: solid; display: none"></div>
 
-<pre id="runbrowser_pre"></pre>
+<h2>Output</h2>
+<pre id="runbrowser_pre" style="background-color: #dddddd"></pre>
+
+<h2>Compiled To Javascript</h2>
+<pre id="runbrowser_jsout"></pre>
 
 </div>
 </body>

--- a/support/run_template.html
+++ b/support/run_template.html
@@ -2,9 +2,8 @@
 <html>
 <head>
     <title></title>
-    <script src="skulpt.js" type="text/javascript"></script>
+    %(scripts)s
     <script src="skulpt-stdlib.js" type="text/javascript"></script>
-    <script src="beautify.js" type="text/javascript"></script>
 
 </head>
 <body>
@@ -55,7 +54,7 @@ function runit(myDiv) {
                 return Sk.importMainWithBody("<stdin>",true,prog,true);
        });
        myPromise.then(function(mod) {}, function(err) {
-          console.log(err.toString());
+           console.log(err.toString());
             });
 }
 </script>

--- a/support/run_template.html
+++ b/support/run_template.html
@@ -8,7 +8,9 @@
 
 </head>
 <body>
+<h1>In Browser Testing Page</h1>
 <p>Open the Javascript Console and click the run button.</p>
+<p>Remember that you can add a debugger statement to your Python below or in the Skulpt Javascript.</p>
 
 <script type="text/javascript">
 function outf(text) {
@@ -57,7 +59,7 @@ function runit(myDiv) {
             });
 }
 </script>
-<h3>Try This</h3>
+<h3>Test Code</h3>
 <div id="runbrowser">
 <form>
 <textarea edit_id="eta_5" id="runbrowser_code" cols="72" rows="15">
@@ -66,14 +68,14 @@ function runit(myDiv) {
 <button onclick="runit('runbrowser')" type="button">Run</button>
 </form>
 
-<h2>Canvas</h2>
+<h3>Canvas</h3>
 <div id="runbrowser_canvas" height="500" width="800"
 	style="border-style: solid; display: none"></div>
 
-<h2>Output</h2>
+<h3>Output</h3>
 <pre id="runbrowser_pre" style="background-color: #dddddd"></pre>
 
-<h2>Compiled To Javascript</h2>
+<h3>Compiled To Javascript</h3>
 <pre id="runbrowser_jsout"></pre>
 
 </div>

--- a/support/run_template.html
+++ b/support/run_template.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+    <script src="skulpt.js" type="text/javascript"></script>
+    <script src="skulpt-stdlib.js" type="text/javascript"></script>
+
+</head>
+<body>
+<p>Open the Javascript Console and click the run button.</p>
+
+<script type="text/javascript">
+function outf(text) {
+   var mypre = document.getElementById(Sk.pre);
+   mypre.innerHTML = mypre.innerHTML + text;
+}
+
+function builtinRead(x)
+{
+    if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined)
+        throw "File not found: '" + x + "'";
+    return Sk.builtinFiles["files"][x];
+}
+
+function runit(myDiv) {
+   var prog = document.getElementById(myDiv+"_code").value;
+   var mypre = document.getElementById(myDiv+"_pre");
+   mypre.innerHTML = '';
+   Sk.canvas = myDiv+"_canvas";
+    var can = document.getElementById(Sk.canvas);
+    can.style.display = 'block';
+    if (can) {
+        can.width = can.width;
+        if (Sk.tg) {
+            Sk.tg.canvasInit = false;
+            Sk.tg.turtleList = [];
+        }
+    }
+
+   Sk.pre = myDiv+"_pre";
+   Sk.configure({output:outf,
+  	        read: builtinRead
+              });
+       var myPromise = Sk.misceval.asyncToPromise(function() {
+                return Sk.importMainWithBody("<stdin>",false,prog,true);
+       });
+       myPromise.then(function(mod) {}, function(err) {
+          console.log(err.toString());
+            });
+}
+</script>
+<h3>Try This</h3>
+<div id="runbrowser">
+<form>
+<textarea edit_id="eta_5" id="runbrowser_code" cols="72" rows="15">
+%(code)s
+</textarea>
+<button onclick="runit('runbrowser')" type="button">Run</button>
+</form>
+
+<div id="runbrowser_canvas" height="500" width="800"
+	style="border-style: solid; display: none"></div>
+
+<pre id="runbrowser_pre"></pre>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
I suspect this is a workflow that many of us follow but is usually a pain.  So often I put up with the crappy command line debugger and waste time because its too much of a pain to make yet another test webpage.  So I fixed that.   Introducing `./skulpt.py brun myfile.py`

Did a wee bit of refactoring in skulpt.py to make the `brun` command.  It works just like `run` except it generates a simple webpage so you can run in the browser nearly as fast as running on the command line.  But without all the hassle and manual copying of files.

1. build an uncompressed skulpt.js  (no waiting for dist to complete)
2. build skulpt-stdlib.js
3. grab the file from the command line and throw it into a webpage template
4. open said page in browser (I don't know how to do this in Windows @albertjan)

Suggestions for improvements welcome.
