### PR TITLE
Make builtins subclassable

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -931,15 +931,8 @@ Sk.abstr.lookupSpecial = function(op, str) {
 };
 goog.exportSymbol("Sk.abstr.lookupSpecial", Sk.abstr.lookupSpecial);
 
-Sk.abstr.registerPythonFunctions = function (thisClass, funcNames) {
-    for (var i = 0; i < funcNames.length; i++) {
-        thisClass.prototype.pythonFunctions.push(funcNames[i]);
-    }
-};
-
 Sk.abstr.markUnhashable = function (thisClass) {
     var proto = thisClass.prototype;
-    proto.pythonFunctions.splice(proto.pythonFunctions.indexOf("__hash__"), 1);
     proto.__hash__ = Sk.builtin.none.none$;
     proto.tp$hash = Sk.builtin.none.none$;
 };
@@ -949,7 +942,6 @@ Sk.abstr.setUpInheritance = function (childName, child, parent) {
     child.prototype.tp$base = parent;
     child.prototype.tp$name = childName;
     child.prototype.ob$type = Sk.builtin.type.makeIntoTypeObj(childName, child);
-    child.prototype.pythonFunctions = parent.prototype.pythonFunctions.slice();
 };
 
 Sk.abstr.setUpObject = function (self) {

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -85,31 +85,31 @@ Sk.abstr.boNameToSlotFuncRhs_ = function (obj, name) {
 
     switch (name) {
     case "Add":
-        return obj.nb$add ? obj.nb$add : obj["__radd__"];
+        return obj.nb$reflected_add ? obj.nb$reflected_add : obj["__radd__"];
     case "Sub":
-        return obj.nb$subtract ? obj.nb$subtract : obj["__rsub__"];
+        return obj.nb$reflected_subtract ? obj.nb$reflected_subtract : obj["__rsub__"];
     case "Mult":
-        return obj.nb$multiply ? obj.nb$multiply : obj["__rmul__"];
+        return obj.nb$reflected_multiply ? obj.nb$reflected_multiply : obj["__rmul__"];
     case "Div":
-        return obj.nb$divide ? obj.nb$divide : obj["__rdiv__"];
+        return obj.nb$reflected_divide ? obj.nb$reflected_divide : obj["__rdiv__"];
     case "FloorDiv":
-        return obj.nb$floor_divide ? obj.nb$floor_divide : obj["__rfloordiv__"];
+        return obj.nb$reflected_floor_divide ? obj.nb$reflected_floor_divide : obj["__rfloordiv__"];
     case "Mod":
-        return obj.nb$remainder ? obj.nb$remainder : obj["__rmod__"];
+        return obj.nb$reflected_remainder ? obj.nb$reflected_remainder : obj["__rmod__"];
     case "DivMod":
-        return obj.nb$divmod ? obj.nb$divmod : obj["__rdivmod__"];
+        return obj.nb$reflected_divmod ? obj.nb$reflected_divmod : obj["__rdivmod__"];
     case "Pow":
-        return obj.nb$power ? obj.nb$power : obj["__rpow__"];
+        return obj.nb$reflected_power ? obj.nb$reflected_power : obj["__rpow__"];
     case "LShift":
-        return obj.nb$lshift ? obj.nb$lshift : obj["__rlshift__"];
+        return obj.nb$reflected_lshift ? obj.nb$reflected_lshift : obj["__rlshift__"];
     case "RShift":
-        return obj.nb$rshift ? obj.nb$rshift : obj["__rrshift__"];
+        return obj.nb$reflected_rshift ? obj.nb$reflected_rshift : obj["__rrshift__"];
     case "BitAnd":
-        return obj.nb$and ? obj.nb$and : obj["__rand__"];
+        return obj.nb$reflected_and ? obj.nb$reflected_and : obj["__rand__"];
     case "BitXor":
-        return obj.nb$xor ? obj.nb$xor : obj["__rxor__"];
+        return obj.nb$reflected_xor ? obj.nb$reflected_xor : obj["__rxor__"];
     case "BitOr":
-        return obj.nb$or ? obj.nb$or : obj["__ror__"];
+        return obj.nb$reflected_or ? obj.nb$reflected_or : obj["__ror__"];
     }
 };
 

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -944,15 +944,6 @@ Sk.abstr.setUpInheritance = function (childName, child, parent) {
     child.prototype.ob$type = Sk.builtin.type.makeIntoTypeObj(childName, child);
 };
 
-Sk.abstr.setUpObject = function (self) {
-    // Python builtin instances do not maintain an internal Python dictionary
-    // (this causes problems when calling the super constructor on a dict
-    // instance). Instead, they maintain a Javascript object.
-    self["$d"] = {
-        "Sk.builtin.object": true   // Indicates this is a builtin object
-    };
-};
-
 Sk.abstr.superConstructor = function (thisClass, self) {
     var argumentsForConstructor = Array.prototype.slice.call(arguments, 2);
     thisClass.prototype.tp$base.apply(self, argumentsForConstructor);

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -738,12 +738,12 @@ goog.exportSymbol("Sk.abstr.objectDelItem", Sk.abstr.objectDelItem);
 Sk.abstr.objectGetItem = function (o, key, canSuspend) {
     var otypename;
     if (o !== null) {
-        if (o.mp$subscript) {
+        if (o.tp$getitem) {
+            return o.tp$getitem(key, canSuspend);
+        } else if (o.mp$subscript) {
             return o.mp$subscript(key, canSuspend);
         } else if (Sk.misceval.isIndex(key) && o.sq$item) {
             return Sk.abstr.sequenceGetItem(o, Sk.misceval.asIndex(key), canSuspend);
-        } else if (o.tp$getitem) {
-            return o.tp$getitem(key, canSuspend);
         }
     }
 
@@ -755,12 +755,12 @@ goog.exportSymbol("Sk.abstr.objectGetItem", Sk.abstr.objectGetItem);
 Sk.abstr.objectSetItem = function (o, key, v, canSuspend) {
     var otypename;
     if (o !== null) {
-        if (o.mp$ass_subscript) {
+        if (o.tp$setitem) {
+            return o.tp$setitem(key, v, canSuspend);
+        } else if (o.mp$ass_subscript) {
             return o.mp$ass_subscript(key, v, canSuspend);
         } else if (Sk.misceval.isIndex(key) && o.sq$ass_item) {
             return Sk.abstr.sequenceSetItem(o, Sk.misceval.asIndex(key), v, canSuspend);
-        } else if (o.tp$setitem) {
-            return o.tp$setitem(key, v, canSuspend);
         }
     }
 

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -54,10 +54,10 @@ Sk.builtin.asnum$ = function (a) {
     if (a === null) {
         return a;
     }
-    if (a.constructor === Sk.builtin.none) {
+    if (a instanceof Sk.builtin.none) {
         return null;
     }
-    if (a.constructor === Sk.builtin.bool) {
+    if (a instanceof Sk.builtin.bool) {
         if (a.v) {
             return 1;
         }
@@ -69,13 +69,13 @@ Sk.builtin.asnum$ = function (a) {
     if (typeof a === "string") {
         return a;
     }
-    if (a.constructor === Sk.builtin.int_) {
+    if (a instanceof Sk.builtin.int_) {
         return a.v;
     }
-    if (a.constructor === Sk.builtin.float_) {
+    if (a instanceof Sk.builtin.float_) {
         return a.v;
     }
-    if (a.constructor === Sk.builtin.lng) {
+    if (a instanceof Sk.builtin.lng) {
         if (a.cantBeInt()) {
             return a.str$(10, true);
         }

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -530,7 +530,10 @@ Sk.builtin.dir = function dir (x) {
 
     getName = function (k) {
         var s = null;
-        var internal = ["__bases__", "__mro__", "__class__", "__name__"];
+        var internal = [
+            "__bases__", "__mro__", "__class__", "__name__", "GenericGetAttr",
+            "GenericSetAttr", "GenericPythonGetAttr", "GenericPythonSetAttr",
+            "pythonFunctions", "HashNotImplemented", "constructor"];
         if (internal.indexOf(k) !== -1) {
             return null;
         }
@@ -720,14 +723,14 @@ Sk.builtin.hash = function hash (value) {
         throw new Sk.builtin.TypeError(new Sk.builtin.str("unhashable type: '" + Sk.abstr.typeName(value) + "'"));
     }
 
-    if ((value instanceof Object) && (value.tp$hash !== undefined)) {
+    if ((value instanceof Object) && (value.__hash__ !== undefined)) {
+        return Sk.misceval.callsim(value.__hash__, value);
+    } else if ((value instanceof Object) && (value.tp$hash !== undefined)) {
         if (value.$savedHash_) {
             return value.$savedHash_;
         }
         value.$savedHash_ = value.tp$hash();
         return value.$savedHash_;
-    } else if ((value instanceof Object) && (value.__hash__ !== undefined)) {
-        return Sk.misceval.callsim(value.__hash__, value);
     } else if (value instanceof Sk.builtin.bool) {
         if (value.v) {
             return new Sk.builtin.int_(1);

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -723,9 +723,7 @@ Sk.builtin.hash = function hash (value) {
         throw new Sk.builtin.TypeError(new Sk.builtin.str("unhashable type: '" + Sk.abstr.typeName(value) + "'"));
     }
 
-    if ((value instanceof Object) && (value.__hash__ !== undefined)) {
-        return Sk.misceval.callsim(value.__hash__, value);
-    } else if ((value instanceof Object) && (value.tp$hash !== undefined)) {
+    if ((value instanceof Object) && (value.tp$hash !== undefined)) {
         if (value.$savedHash_) {
             return value.$savedHash_;
         }

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -49,6 +49,7 @@ Sk.builtins = {
     "NameError"          : Sk.builtin.NameError,
     "IOError"            : Sk.builtin.IOError,
     "NotImplementedError": Sk.builtin.NotImplementedError,
+    "StandardError"      : Sk.builtin.StandardError,
     "SystemExit"         : Sk.builtin.SystemExit,
     "OverflowError"      : Sk.builtin.OverflowError,
     "OperationError"     : Sk.builtin.OperationError,

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,11 +14,6 @@ Sk.builtin.bool.true$ = /** @type {Sk.builtin.bool} */ (Object.create(Sk.builtin
  */
 Sk.builtin.bool.false$ = /** @type {Sk.builtin.bool} */ (Object.create(Sk.builtin.bool.prototype, {v: {value: 0, enumerable: true}}));
 
-// Manually call super constructors on boolean singletons
-Sk.abstr.setUpObject(Sk.builtin.bool.true$);
-Sk.abstr.setUpObject(Sk.builtin.bool.false$);
-
-
 /* Constants used for kwargs */
 
 // Sk.builtin.int_

--- a/src/dict.js
+++ b/src/dict.js
@@ -218,12 +218,6 @@ Sk.builtin.dict.prototype.tp$iter = function () {
     return ret;
 };
 
-Sk.builtin.dict.prototype["__iter__"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__iter__", arguments, 1, 1);
-
-    return self.tp$iter();
-});
-
 Sk.builtin.dict.prototype["$r"] = function () {
     var v;
     var iter, k;
@@ -493,7 +487,7 @@ Sk.builtin.dict.prototype.__getattr__ = new Sk.builtin.func(function (self, attr
 Sk.builtin.dict.prototype.__iter__ = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, false, true);
 
-    return self.tp$iter();
+    return Sk.builtin.dict.prototype.tp$iter.call(self);
 });
 
 Sk.builtin.dict.prototype.__repr__ = new Sk.builtin.func(function (self) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -42,7 +42,7 @@ Sk.builtin.BaseException = function (args) {
                              filename: this.args.v[1].v || "<unknown>"});
     }
 };
-Sk.builtin.BaseException.prototype.tp$name = "BaseException";
+Sk.abstr.setUpInheritance("BaseException", Sk.builtin.BaseException, Sk.builtin.object);
 
 Sk.builtin.BaseException.prototype.tp$str = function () {
     var i;
@@ -96,8 +96,7 @@ Sk.builtin.Exception = function (args) {
     }
     Sk.builtin.BaseException.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.Exception, Sk.builtin.BaseException);
-Sk.builtin.Exception.prototype.tp$name = "Exception";
+Sk.abstr.setUpInheritance("Exception", Sk.builtin.Exception, Sk.builtin.BaseException);
 goog.exportSymbol("Sk.builtin.Exception", Sk.builtin.Exception);
 
 /**
@@ -114,8 +113,7 @@ Sk.builtin.StandardError = function (args) {
     }
     Sk.builtin.Exception.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.StandardError, Sk.builtin.Exception);
-Sk.builtin.StandardError.prototype.tp$name = "StandardError";
+Sk.abstr.setUpInheritance("StandardError", Sk.builtin.StandardError, Sk.builtin.Exception);
 goog.exportSymbol("Sk.builtin.StandardError", Sk.builtin.StandardError);
 
 /**
@@ -132,8 +130,7 @@ Sk.builtin.AssertionError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.AssertionError, Sk.builtin.StandardError);
-Sk.builtin.AssertionError.prototype.tp$name = "AssertionError";
+Sk.abstr.setUpInheritance("AssertionError", Sk.builtin.AssertionError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.AssertionError", Sk.builtin.AssertionError);
 
 /**
@@ -150,8 +147,7 @@ Sk.builtin.AttributeError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.AttributeError, Sk.builtin.StandardError);
-Sk.builtin.AttributeError.prototype.tp$name = "AttributeError";
+Sk.abstr.setUpInheritance("AttributeError", Sk.builtin.AttributeError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -167,8 +163,7 @@ Sk.builtin.ImportError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.ImportError, Sk.builtin.StandardError);
-Sk.builtin.ImportError.prototype.tp$name = "ImportError";
+Sk.abstr.setUpInheritance("ImportError", Sk.builtin.ImportError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -184,8 +179,7 @@ Sk.builtin.IndentationError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.IndentationError, Sk.builtin.StandardError);
-Sk.builtin.IndentationError.prototype.tp$name = "IndentationError";
+Sk.abstr.setUpInheritance("IndentationError", Sk.builtin.IndentationError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -201,8 +195,7 @@ Sk.builtin.IndexError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.IndexError, Sk.builtin.StandardError);
-Sk.builtin.IndexError.prototype.tp$name = "IndexError";
+Sk.abstr.setUpInheritance("IndexError", Sk.builtin.IndexError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -218,8 +211,7 @@ Sk.builtin.KeyError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.KeyError, Sk.builtin.StandardError);
-Sk.builtin.KeyError.prototype.tp$name = "KeyError";
+Sk.abstr.setUpInheritance("KeyError", Sk.builtin.KeyError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -235,8 +227,7 @@ Sk.builtin.NameError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.NameError, Sk.builtin.StandardError);
-Sk.builtin.NameError.prototype.tp$name = "NameError";
+Sk.abstr.setUpInheritance("NameError", Sk.builtin.NameError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -252,8 +243,7 @@ Sk.builtin.UnboundLocalError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.UnboundLocalError, Sk.builtin.StandardError);
-Sk.builtin.UnboundLocalError.prototype.tp$name = "UnboundLocalError";
+Sk.abstr.setUpInheritance("UnboundLocalError", Sk.builtin.UnboundLocalError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -269,8 +259,7 @@ Sk.builtin.OverflowError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.OverflowError, Sk.builtin.StandardError);
-Sk.builtin.OverflowError.prototype.tp$name = "OverflowError";
+Sk.abstr.setUpInheritance("OverflowError", Sk.builtin.OverflowError, Sk.builtin.StandardError);
 
 
 /**
@@ -287,8 +276,7 @@ Sk.builtin.ParseError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.ParseError, Sk.builtin.StandardError);
-Sk.builtin.ParseError.prototype.tp$name = "ParseError";
+Sk.abstr.setUpInheritance("ParseError", Sk.builtin.ParseError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -304,8 +292,7 @@ Sk.builtin.RuntimeError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.RuntimeError, Sk.builtin.StandardError);
-Sk.builtin.AssertionError.prototype.tp$name = "RuntimeError";
+Sk.abstr.setUpInheritance("RuntimeError", Sk.builtin.RuntimeError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.RuntimeError", Sk.builtin.RuntimeError);
 
 
@@ -323,8 +310,7 @@ Sk.builtin.SuspensionError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.SuspensionError, Sk.builtin.StandardError);
-Sk.builtin.SuspensionError.prototype.tp$name = "SuspensionError";
+Sk.abstr.setUpInheritance("SuspensionError", Sk.builtin.SuspensionError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.SuspensionError", Sk.builtin.SuspensionError);
 
 
@@ -342,8 +328,7 @@ Sk.builtin.SystemExit = function (args) {
     }
     Sk.builtin.BaseException.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.SystemExit, Sk.builtin.BaseException);
-Sk.builtin.SystemExit.prototype.tp$name = "SystemExit";
+Sk.abstr.setUpInheritance("SystemExit", Sk.builtin.SystemExit, Sk.builtin.BaseException);
 goog.exportSymbol("Sk.builtin.SystemExit", Sk.builtin.SystemExit);
 
 
@@ -361,8 +346,7 @@ Sk.builtin.SyntaxError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.SyntaxError, Sk.builtin.StandardError);
-Sk.builtin.SyntaxError.prototype.tp$name = "SyntaxError";
+Sk.abstr.setUpInheritance("SyntaxError", Sk.builtin.SyntaxError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -378,8 +362,7 @@ Sk.builtin.TokenError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.TokenError, Sk.builtin.StandardError);
-Sk.builtin.TokenError.prototype.tp$name = "TokenError";
+Sk.abstr.setUpInheritance("TokenError", Sk.builtin.TokenError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -395,8 +378,7 @@ Sk.builtin.TypeError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.TypeError, Sk.builtin.StandardError);
-Sk.builtin.TypeError.prototype.tp$name = "TypeError";
+Sk.abstr.setUpInheritance("TypeError", Sk.builtin.TypeError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.TypeError", Sk.builtin.TypeError);
 /**
  * @constructor
@@ -412,8 +394,7 @@ Sk.builtin.ValueError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.ValueError, Sk.builtin.StandardError);
-Sk.builtin.ValueError.prototype.tp$name = "ValueError";
+Sk.abstr.setUpInheritance("ValueError", Sk.builtin.ValueError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.ValueError", Sk.builtin.ValueError);
 
 /**
@@ -430,8 +411,7 @@ Sk.builtin.ZeroDivisionError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.ZeroDivisionError, Sk.builtin.StandardError);
-Sk.builtin.ZeroDivisionError.prototype.tp$name = "ZeroDivisionError";
+Sk.abstr.setUpInheritance("ZeroDivisionError", Sk.builtin.ZeroDivisionError, Sk.builtin.StandardError);
 
 /**
  * @constructor
@@ -447,8 +427,7 @@ Sk.builtin.TimeLimitError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.TimeLimitError, Sk.builtin.StandardError);
-Sk.builtin.TimeLimitError.prototype.tp$name = "TimeLimitError";
+Sk.abstr.setUpInheritance("TimeLimitError", Sk.builtin.TimeLimitError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.TimeLimitError", Sk.builtin.TimeLimitError);
 
 /**
@@ -465,8 +444,7 @@ Sk.builtin.IOError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.IOError, Sk.builtin.StandardError);
-Sk.builtin.IOError.prototype.tp$name = "IOError";
+Sk.abstr.setUpInheritance("IOError", Sk.builtin.IOError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.IOError", Sk.builtin.IOError);
 
 
@@ -484,8 +462,7 @@ Sk.builtin.NotImplementedError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.NotImplementedError, Sk.builtin.StandardError);
-Sk.builtin.NotImplementedError.prototype.tp$name = "NotImplementedError";
+Sk.abstr.setUpInheritance("NotImplementedError", Sk.builtin.NotImplementedError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.NotImplementedError", Sk.builtin.NotImplementedError);
 
 /**
@@ -502,8 +479,7 @@ Sk.builtin.NegativePowerError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.NegativePowerError, Sk.builtin.StandardError);
-Sk.builtin.NegativePowerError.prototype.tp$name = "NegativePowerError";
+Sk.abstr.setUpInheritance("NegativePowerError", Sk.builtin.NegativePowerError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.NegativePowerError", Sk.builtin.NegativePowerError);
 
 /**
@@ -528,8 +504,7 @@ Sk.builtin.ExternalError = function (nativeError, args) {
     }
     Sk.builtin.StandardError.apply(this, args);
 };
-goog.inherits(Sk.builtin.ExternalError, Sk.builtin.StandardError);
-Sk.builtin.ExternalError.prototype.tp$name = "ExternalError";
+Sk.abstr.setUpInheritance("ExternalError", Sk.builtin.ExternalError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.ExternalError", Sk.builtin.ExternalError);
 
 /**
@@ -546,8 +521,7 @@ Sk.builtin.OperationError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.OperationError, Sk.builtin.StandardError);
-Sk.builtin.OperationError.prototype.tp$name = "OperationError";
+Sk.abstr.setUpInheritance("OperationError", Sk.builtin.OperationError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.OperationError", Sk.builtin.OperationError);
 
 /**
@@ -564,8 +538,7 @@ Sk.builtin.SystemError = function (args) {
     }
     Sk.builtin.StandardError.apply(this, arguments);
 };
-goog.inherits(Sk.builtin.SystemError, Sk.builtin.StandardError);
-Sk.builtin.SystemError.prototype.tp$name = "SystemError";
+Sk.abstr.setUpInheritance("SystemError", Sk.builtin.SystemError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.SystemError", Sk.builtin.SystemError);
 
 

--- a/src/float.js
+++ b/src/float.js
@@ -228,6 +228,11 @@ Sk.builtin.float_.prototype.nb$add = function (other) {
 };
 
 /** @override */
+Sk.builtin.float_.prototype.nb$reflected_add = function (other) {
+    return Sk.builtin.float_.prototype.nb$add.call(this, other);
+};
+
+/** @override */
 Sk.builtin.float_.prototype.nb$subtract = function (other) {
     if (other instanceof Sk.builtin.int_ || other instanceof Sk.builtin.float_) {
         return new Sk.builtin.float_(this.v - other.v);
@@ -239,6 +244,12 @@ Sk.builtin.float_.prototype.nb$subtract = function (other) {
 };
 
 /** @override */
+Sk.builtin.float_.prototype.nb$reflected_subtract = function (other) {
+    var negative_this = this.nb$negative();
+    return Sk.builtin.float_.prototype.nb$add.call(negative_this, other);
+};
+
+/** @override */
 Sk.builtin.float_.prototype.nb$multiply = function (other) {
     if (other instanceof Sk.builtin.int_ || other instanceof Sk.builtin.float_) {
         return new Sk.builtin.float_(this.v * other.v);
@@ -247,6 +258,11 @@ Sk.builtin.float_.prototype.nb$multiply = function (other) {
     }
 
     return Sk.builtin.NotImplemented.NotImplemented$;
+};
+
+/** @override */
+Sk.builtin.float_.prototype.nb$reflected_multiply = function (other) {
+    return Sk.builtin.float_.prototype.nb$multiply.call(this, other);
 };
 
 /** @override */
@@ -584,7 +600,11 @@ Sk.builtin.float_.prototype.nb$inplace_floor_divide = Sk.builtin.float_.prototyp
 /** @override */
 Sk.builtin.float_.prototype.nb$inplace_power = Sk.builtin.float_.prototype.nb$power;
 
-/** @override */
+/**
+ * @override
+ *
+ * @return {Sk.builtin.float_} A copy of this instance with the value negated.
+ */
 Sk.builtin.float_.prototype.nb$negative = function () {
     return new Sk.builtin.float_(-this.v);
 };

--- a/src/float.js
+++ b/src/float.js
@@ -229,6 +229,8 @@ Sk.builtin.float_.prototype.nb$add = function (other) {
 
 /** @override */
 Sk.builtin.float_.prototype.nb$reflected_add = function (other) {
+    // Should not automatically call this.nb$add, as nb$add may have
+    // been overridden by a subclass
     return Sk.builtin.float_.prototype.nb$add.call(this, other);
 };
 
@@ -245,6 +247,8 @@ Sk.builtin.float_.prototype.nb$subtract = function (other) {
 
 /** @override */
 Sk.builtin.float_.prototype.nb$reflected_subtract = function (other) {
+    // Should not automatically call this.nb$add, as nb$add may have
+    // been overridden by a subclass
     var negative_this = this.nb$negative();
     return Sk.builtin.float_.prototype.nb$add.call(negative_this, other);
 };
@@ -262,6 +266,8 @@ Sk.builtin.float_.prototype.nb$multiply = function (other) {
 
 /** @override */
 Sk.builtin.float_.prototype.nb$reflected_multiply = function (other) {
+    // Should not automatically call this.nb$multiply, as nb$multiply may have
+    // been overridden by a subclass
     return Sk.builtin.float_.prototype.nb$multiply.call(this, other);
 };
 

--- a/src/float.js
+++ b/src/float.js
@@ -42,7 +42,7 @@ Sk.builtin.float_ = function (x) {
     }
 
     // Floats are just numbers
-    if (typeof x === "number" || x instanceof Sk.builtin.int_ || x instanceof Sk.builtin.lng) {
+    if (typeof x === "number" || x instanceof Sk.builtin.int_ || x instanceof Sk.builtin.lng || x instanceof Sk.builtin.float_) {
         this.v = Sk.builtin.asnum$(x);
         return this;
     }

--- a/src/import.js
+++ b/src/import.js
@@ -210,8 +210,8 @@ Sk.doOneTimeInitialization = function () {
     // Sk.builtin.func, as that class was undefined when these functions were declared
     proto = Sk.builtin.object.prototype;
 
-    for (i = 0; i < proto.pythonFunctions.length; i++) {
-        name = proto.pythonFunctions[i];
+    for (i = 0; i < Sk.builtin.object.pythonFunctions.length; i++) {
+        name = Sk.builtin.object.pythonFunctions[i];
 
         if (proto[name] instanceof Sk.builtin.func) {
             // If functions have already been initialized, do not wrap again.

--- a/src/import.js
+++ b/src/import.js
@@ -186,7 +186,7 @@ Sk.doOneTimeInitialization = function () {
 
     var setUpClass = function (child) {
         var parent = child.tp$base;
-        var bases;
+        var bases = [];
         var base;
 
         for (base = parent; base !== undefined; base = base.tp$base) {

--- a/src/import.js
+++ b/src/import.js
@@ -176,15 +176,35 @@ Sk.importSearchPathForName = function (name, ext, failok, canSuspend) {
 };
 
 Sk.doOneTimeInitialization = function () {
-    var proto, name, i;
+    var proto, name, i, x, func;
+    var builtins = [];
 
     // can't fill these out when making the type because tuple/dict aren't
     // defined yet.
     Sk.builtin.type.basesStr_ = new Sk.builtin.str("__bases__");
     Sk.builtin.type.mroStr_ = new Sk.builtin.str("__mro__");
-    Sk.builtin.object["$d"] = new Sk.builtin.dict([]);
-    Sk.builtin.object["$d"].mp$ass_subscript(Sk.builtin.type.basesStr_, new Sk.builtin.tuple([]));
-    Sk.builtin.object["$d"].mp$ass_subscript(Sk.builtin.type.mroStr_, new Sk.builtin.tuple([Sk.builtin.object]));
+
+    var setUpClass = function (child) {
+        var parent = child.tp$base;
+        var bases;
+        var base;
+
+        for (base = parent; base !== undefined; base = base.tp$base) {
+            bases.push(base);
+        }
+
+        child["$d"] = new Sk.builtin.dict([]);
+        child["$d"].mp$ass_subscript(Sk.builtin.type.basesStr_, new Sk.builtin.tuple(bases));
+        child["$d"].mp$ass_subscript(Sk.builtin.type.mroStr_, new Sk.builtin.tuple([child]));
+    };
+
+    for (x in Sk.builtin) {
+        func = Sk.builtin[x];
+        if ((func.prototype instanceof Sk.builtin.object ||
+             func === Sk.builtin.object) && !func.sk$abstract) {
+            setUpClass(func);
+        }
+    }
 
     // Wrap the inner Javascript code of Sk.builtin.object's Python methods inside
     // Sk.builtin.func, as that class was undefined when these functions were declared

--- a/src/import.js
+++ b/src/import.js
@@ -175,6 +175,15 @@ Sk.importSearchPathForName = function (name, ext, failok, canSuspend) {
     })();
 };
 
+/**
+ * Complete any initialization of Python classes which relies on internal
+ * dependencies.
+ *
+ * This includes making Python classes subclassable and ensuring that the
+ * {@link Sk.builtin.object} magic methods are wrapped inside Python functions.
+ *
+ * @return {undefined}
+ */
 Sk.doOneTimeInitialization = function () {
     var proto, name, i, x, func;
     var builtins = [];
@@ -184,6 +193,8 @@ Sk.doOneTimeInitialization = function () {
     Sk.builtin.type.basesStr_ = new Sk.builtin.str("__bases__");
     Sk.builtin.type.mroStr_ = new Sk.builtin.str("__mro__");
 
+    // Register a Python class with an internal dictionary, which allows it to
+    // be subclassed
     var setUpClass = function (child) {
         var parent = child.tp$base;
         var bases = [];

--- a/src/int.js
+++ b/src/int.js
@@ -231,6 +231,11 @@ Sk.builtin.int_.prototype.nb$add = function (other) {
 };
 
 /** @override */
+Sk.builtin.int_.prototype.nb$reflected_add = function (other) {
+    return Sk.builtin.int_.prototype.nb$add.call(this, other);
+};
+
+/** @override */
 Sk.builtin.int_.prototype.nb$subtract = function (other) {
     var thisAsLong, thisAsFloat;
 
@@ -249,6 +254,12 @@ Sk.builtin.int_.prototype.nb$subtract = function (other) {
     }
 
     return Sk.builtin.NotImplemented.NotImplemented$;
+};
+
+/** @override */
+Sk.builtin.int_.prototype.nb$reflected_subtract = function (other) {
+    var negative_this = this.nb$negative();
+    return Sk.builtin.int_.prototype.nb$add.call(negative_this, other);
 };
 
 /** @override */
@@ -278,6 +289,11 @@ Sk.builtin.int_.prototype.nb$multiply = function (other) {
     }
 
     return Sk.builtin.NotImplemented.NotImplemented$;
+};
+
+/** @override */
+Sk.builtin.int_.prototype.nb$reflected_multiply = function (other) {
+    return Sk.builtin.int_.prototype.nb$multiply.call(this, other);
 };
 
 /** @override */
@@ -788,7 +804,11 @@ Sk.builtin.int_.prototype.nb$inplace_lshift = Sk.builtin.int_.prototype.nb$lshif
  */
 Sk.builtin.int_.prototype.nb$inplace_rshift = Sk.builtin.int_.prototype.nb$rshift;
 
-/** @override */
+/**
+ * @override
+ *
+ * @return {Sk.builtin.int_} A copy of this instance with the value negated.
+ */
 Sk.builtin.int_.prototype.nb$negative = function () {
     return new Sk.builtin.int_(-this.v);
 };

--- a/src/int.js
+++ b/src/int.js
@@ -232,6 +232,8 @@ Sk.builtin.int_.prototype.nb$add = function (other) {
 
 /** @override */
 Sk.builtin.int_.prototype.nb$reflected_add = function (other) {
+    // Should not automatically call this.nb$add, as nb$add may have
+    // been overridden by a subclass
     return Sk.builtin.int_.prototype.nb$add.call(this, other);
 };
 
@@ -258,6 +260,8 @@ Sk.builtin.int_.prototype.nb$subtract = function (other) {
 
 /** @override */
 Sk.builtin.int_.prototype.nb$reflected_subtract = function (other) {
+    // Should not automatically call this.nb$add, as nb$add may have
+    // been overridden by a subclass
     var negative_this = this.nb$negative();
     return Sk.builtin.int_.prototype.nb$add.call(negative_this, other);
 };
@@ -293,6 +297,8 @@ Sk.builtin.int_.prototype.nb$multiply = function (other) {
 
 /** @override */
 Sk.builtin.int_.prototype.nb$reflected_multiply = function (other) {
+    // Should not automatically call this.nb$multiply, as nb$multiply may have
+    // been overridden by a subclass
     return Sk.builtin.int_.prototype.nb$multiply.call(this, other);
 };
 

--- a/src/lib/collections.js
+++ b/src/lib/collections.js
@@ -308,6 +308,12 @@ var $builtinmodule = function (name) {
         return Sk.builtin.dict.prototype.mp$del_subscript.call(this, key);
     }
 
+    mod.OrderedDict.prototype.__iter__ = new Sk.builtin.func(function (self) {
+        Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, false, true);
+
+        return mod.OrderedDict.prototype.tp$iter.call(self);
+    });
+
     mod.OrderedDict.prototype.tp$iter = function()
     {
         var ret;

--- a/src/list.js
+++ b/src/list.js
@@ -8,11 +8,13 @@ Sk.builtin.list = function (L, canSuspend) {
     var v, it, thisList;
 
     if (this instanceof Sk.builtin.list) {
-        canSuspend = false;
+        canSuspend = canSuspend || false;
     } else {
         // Default to true in this case, because 'list' gets called directly from Python
-        return new Sk.builtin.list(L, canSuspend || true)
+        return new Sk.builtin.list(L, canSuspend || true);
     }
+
+    this.__class__ = Sk.builtin.list;
 
     if (L === undefined) {
         v = [];
@@ -41,8 +43,6 @@ Sk.builtin.list = function (L, canSuspend) {
     } else {
         throw new Sk.builtin.TypeError("expecting Array or iterable");
     }
-
-    this.__class__ = Sk.builtin.list;
 
     this["v"] = this.v = v;
     return this;

--- a/src/long.js
+++ b/src/long.js
@@ -157,6 +157,8 @@ Sk.builtin.lng.prototype.nb$add = function (other) {
 
 /** @override */
 Sk.builtin.lng.prototype.nb$reflected_add = function (other) {
+    // Should not automatically call this.nb$add, as nb$add may have
+    // been overridden by a subclass
     return Sk.builtin.lng.prototype.nb$add.call(this, other);
 };
 
@@ -188,6 +190,8 @@ Sk.builtin.lng.prototype.nb$subtract = function (other) {
 
 /** @override */
 Sk.builtin.lng.prototype.nb$reflected_subtract = function (other) {
+    // Should not automatically call this.nb$add, as nb$add may have
+    // been overridden by a subclass
     var negative_this = this.nb$negative();
     return Sk.builtin.lng.prototype.nb$add.call(negative_this, other);
 };
@@ -219,6 +223,8 @@ Sk.builtin.lng.prototype.nb$multiply = function (other) {
 
 /** @override */
 Sk.builtin.lng.prototype.nb$reflected_multiply = function (other) {
+    // Should not automatically call this.nb$multiply, as nb$multiply may have
+    // been overridden by a subclass
     return Sk.builtin.lng.prototype.nb$multiply.call(this, other);
 };
 

--- a/src/long.js
+++ b/src/long.js
@@ -155,6 +155,11 @@ Sk.builtin.lng.prototype.nb$add = function (other) {
     return Sk.builtin.NotImplemented.NotImplemented$;
 };
 
+/** @override */
+Sk.builtin.lng.prototype.nb$reflected_add = function (other) {
+    return Sk.builtin.lng.prototype.nb$add.call(this, other);
+};
+
 Sk.builtin.lng.prototype.nb$inplace_add = Sk.builtin.lng.prototype.nb$add;
 
 Sk.builtin.lng.prototype.nb$subtract = function (other) {
@@ -181,6 +186,12 @@ Sk.builtin.lng.prototype.nb$subtract = function (other) {
     return Sk.builtin.NotImplemented.NotImplemented$;
 };
 
+/** @override */
+Sk.builtin.lng.prototype.nb$reflected_subtract = function (other) {
+    var negative_this = this.nb$negative();
+    return Sk.builtin.lng.prototype.nb$add.call(negative_this, other);
+};
+
 Sk.builtin.lng.prototype.nb$inplace_subtract = Sk.builtin.lng.prototype.nb$subtract;
 
 Sk.builtin.lng.prototype.nb$multiply = function (other) {
@@ -204,6 +215,11 @@ Sk.builtin.lng.prototype.nb$multiply = function (other) {
     }
 
     return Sk.builtin.NotImplemented.NotImplemented$;
+};
+
+/** @override */
+Sk.builtin.lng.prototype.nb$reflected_multiply = function (other) {
+    return Sk.builtin.lng.prototype.nb$multiply.call(this, other);
 };
 
 Sk.builtin.lng.prototype.nb$inplace_multiply = Sk.builtin.lng.prototype.nb$multiply;
@@ -622,6 +638,11 @@ Sk.builtin.lng.prototype.nb$reflected_xor = Sk.builtin.lng.prototype.nb$xor;
 
 Sk.builtin.lng.prototype.nb$inplace_xor = Sk.builtin.lng.prototype.nb$xor;
 
+/**
+ * @override
+ *
+ * @return {Sk.builtin.lng} A copy of this instance with the value negated.
+ */
 Sk.builtin.lng.prototype.nb$negative = function () {
     return new Sk.builtin.lng(this.biginteger.negate());
 };

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -592,12 +592,6 @@ Sk.misceval.isTrue = function (x) {
     if (x.constructor === Sk.builtin.float_) {
         return x.v !== 0;
     }
-    if (x.mp$length) {
-        return x.mp$length() !== 0;
-    }
-    if (x.sq$length) {
-        return x.sq$length() !== 0;
-    }
     if (x["__nonzero__"]) {
         ret = Sk.misceval.callsim(x["__nonzero__"], x);
         if (!Sk.builtin.checkInt(ret)) {
@@ -611,6 +605,12 @@ Sk.misceval.isTrue = function (x) {
             throw new Sk.builtin.TypeError("__len__ should return an int");
         }
         return Sk.builtin.asnum$(ret) !== 0;
+    }
+    if (x.mp$length) {
+        return Sk.builtin.asnum$(x.mp$length()) !== 0;
+    }
+    if (x.sq$length) {
+        return Sk.builtin.asnum$(x.sq$length()) !== 0;
     }
     return true;
 };

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -358,10 +358,10 @@ Sk.misceval.richCompareBool = function (v, w, op) {
     }
 
     if (op === "In") {
-        return Sk.abstr.sequenceContains(w, v);
+        return Sk.misceval.isTrue(Sk.abstr.sequenceContains(w, v));
     }
     if (op === "NotIn") {
-        return !Sk.abstr.sequenceContains(w, v);
+        return !Sk.misceval.isTrue(Sk.abstr.sequenceContains(w, v));
     }
 
 

--- a/src/numtype.js
+++ b/src/numtype.js
@@ -443,7 +443,7 @@ Sk.builtin.numtype.prototype.nb$add = function (other) {
 };
 
 Sk.builtin.numtype.prototype.nb$reflected_add = function (other) {
-    return this.nb$add(other);
+    return Sk.builtin.NotImplemented.NotImplemented$;
 };
 
 Sk.builtin.numtype.prototype.nb$inplace_add = function (other) {
@@ -465,8 +465,7 @@ Sk.builtin.numtype.prototype.nb$subtract = function (other) {
 };
 
 Sk.builtin.numtype.prototype.nb$reflected_subtract = function (other) {
-    var negative_this = this.nb$negative();
-    return negative_this.nb$add(other);
+    return Sk.builtin.NotImplemented.NotImplemented$;
 };
 
 Sk.builtin.numtype.prototype.nb$inplace_subtract = function (other) {
@@ -489,7 +488,7 @@ Sk.builtin.numtype.prototype.nb$multiply = function (other) {
 
 
 Sk.builtin.numtype.prototype.nb$reflected_multiply = function (other) {
-    return this.nb$multiply(other);
+    return Sk.builtin.NotImplemented.NotImplemented$;
 };
 
 Sk.builtin.numtype.prototype.nb$inplace_multiply = function (other) {
@@ -507,11 +506,11 @@ Sk.builtin.numtype.prototype.nb$inplace_multiply = function (other) {
  * @return {(Sk.builtin.numtype|Sk.builtin.NotImplemented)} The result of the division
  */
 Sk.builtin.numtype.prototype.nb$divide = function (other) {
-    return this.nb$floor_divide(other);
+    return Sk.builtin.NotImplemented.NotImplemented$;
 };
 
 Sk.builtin.numtype.prototype.nb$reflected_divide = function (other) {
-    return this.nb$reflected_floor_divide(other);
+    return Sk.builtin.NotImplemented.NotImplemented$;
 };
 
 Sk.builtin.numtype.prototype.nb$inplace_divide = function (other) {

--- a/src/numtype.js
+++ b/src/numtype.js
@@ -428,12 +428,6 @@ Sk.builtin.numtype.prototype["__coerce__"] = new Sk.builtin.func(function (self,
 
 });
 
-Sk.abstr.registerPythonFunctions(Sk.builtin.numtype,
-    ["__abs__", "__neg__", "__pos__", "__int__", "__long__", "__float__",
-     "__add__", "__radd__", "__sub__", "__rsub__", "__mul__", "__rmul__",
-     "__div__", "__rdiv__", "__floordiv__", "__rfloordiv__",
-     "__mod__", "__rmod__", "__divmod__", "__rdivmod__", "__coerce__"]);
-
 /**
  * Add a Python object to this instance and return the result (i.e. this + other).
  *

--- a/src/numtype.js
+++ b/src/numtype.js
@@ -17,6 +17,8 @@ Sk.builtin.numtype = function () {
 
 Sk.abstr.setUpInheritance("NumericType", Sk.builtin.numtype, Sk.builtin.object);
 
+Sk.builtin.numtype.sk$abstract = true;
+
 /**
  * Python wrapper of `__abs__` method.
  *

--- a/src/object.js
+++ b/src/object.js
@@ -383,7 +383,7 @@ Sk.builtin.object.prototype.ob$ge = function (other) {
  * Array of all the Python functions which are methods of this class.
  * @type {Array}
  */
-Sk.builtin.object.prototype.pythonFunctions = ["__repr__", "__str__", "__hash__",
+Sk.builtin.object.pythonFunctions = ["__repr__", "__str__", "__hash__",
 "__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__", "__getattr__", "__setattr__"];
 
 /**

--- a/src/seqtype.js
+++ b/src/seqtype.js
@@ -131,7 +131,3 @@ Sk.builtin.seqtype.prototype["__rmul__"] = new Sk.builtin.func(function (self, n
     return self.sq$repeat(n);    
 
 });
-
-Sk.abstr.registerPythonFunctions(Sk.builtin.seqtype, 
-    ["__len__", "__iter__", "__contains__", "__getitem__", "__add__",
-     "__mul__", "__rmul__"]);

--- a/src/seqtype.js
+++ b/src/seqtype.js
@@ -17,6 +17,8 @@ Sk.builtin.seqtype = function () {
 
 Sk.abstr.setUpInheritance("SequenceType", Sk.builtin.seqtype, Sk.builtin.object);
 
+Sk.builtin.seqtype.sk$abstract = true;
+
 /**
  * Python wrapper of `__len__` method.
  *

--- a/src/set.js
+++ b/src/set.js
@@ -65,7 +65,8 @@ Sk.builtin.set.prototype.ob$eq = function (other) {
         return Sk.builtin.bool.false$;
     }
 
-    if (this.sq$length() !== other.sq$length()) {
+    if (Sk.builtin.set.prototype.sq$length.call(this) !==
+        Sk.builtin.set.prototype.sq$length.call(other)) {
         return Sk.builtin.bool.false$;
     }
 
@@ -82,7 +83,8 @@ Sk.builtin.set.prototype.ob$ne = function (other) {
         return Sk.builtin.bool.true$;
     }
 
-    if (this.sq$length() !== other.sq$length()) {
+    if (Sk.builtin.set.prototype.sq$length.call(this) !==
+        Sk.builtin.set.prototype.sq$length.call(other)) {
         return Sk.builtin.bool.true$;
     }
 
@@ -99,7 +101,8 @@ Sk.builtin.set.prototype.ob$lt = function (other) {
         return Sk.builtin.bool.false$;
     }
 
-    if (this.sq$length() >= other.sq$length()) {
+    if (Sk.builtin.set.prototype.sq$length.call(this) >=
+        Sk.builtin.set.prototype.sq$length.call(other)) {
         return Sk.builtin.bool.false$;
     }
 
@@ -112,7 +115,8 @@ Sk.builtin.set.prototype.ob$le = function (other) {
         return Sk.builtin.bool.true$;
     }
 
-    if (this.sq$length() > other.sq$length()) {
+    if (Sk.builtin.set.prototype.sq$length.call(this) >
+        Sk.builtin.set.prototype.sq$length.call(other)) {
         return Sk.builtin.bool.false$;
     }
 
@@ -125,7 +129,8 @@ Sk.builtin.set.prototype.ob$gt = function (other) {
         return Sk.builtin.bool.false$;
     }
 
-    if (this.sq$length() <= other.sq$length()) {
+    if (Sk.builtin.set.prototype.sq$length.call(this) <=
+        Sk.builtin.set.prototype.sq$length.call(other)) {
         return Sk.builtin.bool.false$;
     }
 
@@ -138,7 +143,8 @@ Sk.builtin.set.prototype.ob$ge = function (other) {
         return Sk.builtin.bool.true$;
     }
 
-    if (this.sq$length() < other.sq$length()) {
+    if (Sk.builtin.set.prototype.sq$length.call(this) <
+        Sk.builtin.set.prototype.sq$length.call(other)) {
         return Sk.builtin.bool.false$;
     }
 
@@ -149,7 +155,7 @@ Sk.builtin.set.prototype["__iter__"] = new Sk.builtin.func(function(self) {
 
     Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, false, true);
 
-    return self.tp$iter();
+    return Sk.builtin.set.prototype.tp$iter.call(self);
 
 });
 

--- a/src/str.js
+++ b/src/str.js
@@ -1,4 +1,4 @@
-var interned = {};
+Sk.builtin.interned = {};
 
 /**
  * @constructor
@@ -51,16 +51,14 @@ Sk.builtin.str = function (x) {
     }
 
     // interning required for strings in py
-    if (Object.prototype.hasOwnProperty.call(interned, "1" + ret)) {
-        // note, have to use Object to avoid __proto__, etc.
-        // failing
-        return interned["1" + ret];
+    if (Sk.builtin.interned["1" + ret]) {
+        return Sk.builtin.interned["1" + ret];
     }
 
     this.__class__ = Sk.builtin.str;
     this.v = ret;
     this["v"] = this.v;
-    interned["1" + ret] = this;
+    Sk.builtin.interned["1" + ret] = this;
     return this;
 
 };

--- a/src/type.js
+++ b/src/type.js
@@ -44,8 +44,7 @@ Sk.dunderToSkulpt = {
     "__pow__": "nb$power",
     "__rpow__": "nb$reflected_power",
     "__contains__": "sq$contains",
-    "__len__": "sq$length",
-    "__getitem__": "mp$subscript"
+    "__len__": "sq$length"
 };
 
 /**

--- a/src/type.js
+++ b/src/type.js
@@ -2,6 +2,18 @@ if(Sk.builtin === undefined) {
     Sk.builtin = {};
 }
 
+/**
+ * Maps Python dunder names to the Skulpt Javascript function names that
+ * implement them.
+ *
+ * Note: __add__, __mul__, and __rmul__ can be used for either numeric or
+ * sequence types. Here, they default to the numeric versions (i.e. nb$add,
+ * nb$multiply, and nb$reflected_multiply). This works because Sk.abstr.binary_op_
+ * checks for the numeric shortcuts and not the sequence shortcuts when computing
+ * a binary operation.
+ *
+ * @type {Object}
+ */
 Sk.dunderToSkulpt = {
     "__eq__": "ob$eq",
     "__ne__": "ob$ne",
@@ -31,7 +43,9 @@ Sk.dunderToSkulpt = {
     "__rdivmod__": "nb$reflected_divmod",
     "__pow__": "nb$power",
     "__rpow__": "nb$reflected_power",
-    "__contains__": "sq$contains"
+    "__contains__": "sq$contains",
+    "__len__": "sq$length",
+    "__getitem__": "mp$subscript"
 };
 
 /**

--- a/src/type.js
+++ b/src/type.js
@@ -151,7 +151,7 @@ Sk.builtin.type = function (name, bases, dict) {
             var cname;
             var mod;
             var reprf = this.tp$getattr("__repr__");
-            if (reprf !== undefined) {
+            if (reprf !== undefined && reprf.im_func !== Sk.builtin.object.prototype.__repr__) {
                 return Sk.misceval.apply(reprf, undefined, undefined, undefined, []);
             }
 
@@ -170,8 +170,12 @@ Sk.builtin.type = function (name, bases, dict) {
         };
         klass.prototype.tp$str = function () {
             var strf = this.tp$getattr("__str__");
-            if (strf !== undefined) {
+            if (strf !== undefined && strf.im_func !== Sk.builtin.object.prototype.__str__) {
                 return Sk.misceval.apply(strf, undefined, undefined, undefined, []);
+            }
+            if ((this.tp$base !== undefined) && (this.tp$base !== Sk.builtin.object)) {
+                // If subclass of a builtin which is not object, use that class' repr
+                return goog.base(this, "tp$str");
             }
             return this["$r"]();
         };
@@ -366,6 +370,9 @@ Sk.builtin.type.typeLookup = function (type, name) {
         res = base["$d"].mp$lookup(pyname);
         if (res !== undefined) {
             return res;
+        }
+        if (base.prototype && base.prototype[name] !== undefined) {
+            return base.prototype[name];
         }
     }
 

--- a/src/type.js
+++ b/src/type.js
@@ -54,7 +54,7 @@ Sk.dunderToSkulpt = {
  *
  * @param {*} name name or object to get type of, if only one arg
  *
- * @param {Array.<Object>=} bases
+ * @param {Sk.builtin.tuple=} bases
  *
  * @param {Object=} dict
  *
@@ -231,7 +231,7 @@ Sk.builtin.type = function (name, bases, dict) {
             var cname;
             var mod;
             var reprf = this.tp$getattr("__repr__");
-            if (reprf !== undefined && reprf.im_func !== Sk.builtin.object.prototype.__repr__) {
+            if (reprf !== undefined && reprf.im_func !== Sk.builtin.object.prototype["__repr__"]) {
                 return Sk.misceval.apply(reprf, undefined, undefined, undefined, []);
             }
 
@@ -252,7 +252,7 @@ Sk.builtin.type = function (name, bases, dict) {
         };
         klass.prototype.tp$str = function () {
             var strf = this.tp$getattr("__str__");
-            if (strf !== undefined && strf.im_func !== Sk.builtin.object.prototype.__str__) {
+            if (strf !== undefined && strf.im_func !== Sk.builtin.object.prototype["__str__"]) {
                 return Sk.misceval.apply(strf, undefined, undefined, undefined, []);
             }
             if ((klass.prototype.tp$base !== undefined) &&

--- a/src/type.js
+++ b/src/type.js
@@ -114,10 +114,14 @@ Sk.builtin.type = function (name, bases, dict) {
             self["$d"] = new Sk.builtin.dict([]);
 
             if (klass.prototype.tp$base !== undefined) {
-                // Call super constructor if subclass of a builtin with undefined __init__
-                args_copy = args.slice();
-                args_copy.unshift(klass, this);
-                Sk.abstr.superConstructor.apply(undefined, args_copy);
+                if (klass.prototype.tp$base.sk$klass) {
+                    klass.prototype.tp$base.call(this, kwdict, varargseq, kws, args.slice(), canSuspend);
+                } else {
+                    // Call super constructor if subclass of a builtin
+                    args_copy = args.slice();
+                    args_copy.unshift(klass, this);
+                    Sk.abstr.superConstructor.apply(undefined, args_copy);
+                }
             }
 
             init = Sk.builtin.type.typeLookup(self.ob$type, "__init__");
@@ -204,11 +208,11 @@ Sk.builtin.type = function (name, bases, dict) {
                 return Sk.misceval.apply(reprf, undefined, undefined, undefined, []);
             }
 
-            if ((this.tp$base !== undefined) &&
-                (this.tp$base !== Sk.builtin.object) &&
-                (this.tp$base.prototype["$r"] !== undefined)) {
+            if ((klass.prototype.tp$base !== undefined) &&
+                (klass.prototype.tp$base !== Sk.builtin.object) &&
+                (klass.prototype.tp$base.prototype["$r"] !== undefined)) {
                 // If subclass of a builtin which is not object, use that class' repr
-                return this.tp$base.prototype["$r"].call(this);
+                return klass.prototype.tp$base.prototype["$r"].call(this);
             } else {
                 // Else, use default repr for a user-defined class instance
                 mod = dict.mp$subscript(module_lk); // lookup __module__
@@ -224,11 +228,11 @@ Sk.builtin.type = function (name, bases, dict) {
             if (strf !== undefined && strf.im_func !== Sk.builtin.object.prototype.__str__) {
                 return Sk.misceval.apply(strf, undefined, undefined, undefined, []);
             }
-            if ((this.tp$base !== undefined) &&
-                (this.tp$base !== Sk.builtin.object) &&
-                (this.tp$base.prototype.tp$str !== undefined)) {
+            if ((klass.prototype.tp$base !== undefined) &&
+                (klass.prototype.tp$base !== Sk.builtin.object) &&
+                (klass.prototype.tp$base.prototype.tp$str !== undefined)) {
                 // If subclass of a builtin which is not object, use that class' repr
-                return this.tp$base.prototype.tp$str.call(this);
+                return klass.prototype.tp$base.prototype.tp$str.call(this);
             }
             return this["$r"]();
         };

--- a/src/type.js
+++ b/src/type.js
@@ -159,13 +159,21 @@ Sk.builtin.type = function (name, bases, dict) {
             Sk.abstr.setUpInheritance(_name, klass, Sk.builtin.object);
         }
 
-        var parent, it;
+        var parent, it, firstAncestor;
         // Set up inheritance from any builtins
         for (it = bases.tp$iter(), parent = it.tp$iternext(); parent !== undefined; parent = it.tp$iternext()) {
+            if (firstAncestor === undefined) {
+                firstAncestor = parent;
+            }
             if (parent.prototype instanceof Sk.builtin.object || parent === Sk.builtin.object) {
                 inheritsFromBuiltin = true;
-                Sk.abstr.setUpInheritance(_name, klass, parent);
             }
+        }
+
+        // Javascript does not support multiple inheritance, so only the first
+        // base (if any) will directly inherit in Javascript
+        if (firstAncestor !== undefined) {
+            Sk.abstr.setUpInheritance(_name, klass, firstAncestor);
         }
 
         if (!inheritsFromBuiltin) {

--- a/src/type.js
+++ b/src/type.js
@@ -21,6 +21,7 @@ Sk.dunderToSkulpt = {
     "__le__": "ob$le",
     "__gt__": "ob$gt",
     "__ge__": "ob$ge",
+    "__hash__": "tp$hash",
     "__abs__": "nb$abs",
     "__neg__": "nb$negative",
     "__pos__": "nb$positive",

--- a/test/run/t407.py.real
+++ b/test/run/t407.py.real
@@ -1,3 +1,3 @@
-['__init__', '__module__', 'a', 'b', 'c']
-['__init__', '__module__', 'a', 'b', 'c', 'd']
+['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']

--- a/test/run/t407.py.real.force
+++ b/test/run/t407.py.real.force
@@ -1,3 +1,3 @@
-['__init__', '__module__', 'a', 'b', 'c']
-['__init__', '__module__', 'a', 'b', 'c', 'd']
+['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']

--- a/test/run/t520.py
+++ b/test/run/t520.py
@@ -9,7 +9,7 @@ print z, type(z)
 
 print hash(True), type(hash(True))
 print hash(None), type(hash(None))
-print hash("hello"), type(hash("hello"))
+print hash("hello") > 0, type(hash("hello"))
 
 a = hasattr("hello", "not_a_method")
 print a, type(a)

--- a/test/run/t520.py.real
+++ b/test/run/t520.py.real
@@ -3,5 +3,5 @@ True <type 'bool'>
 True <type 'bool'>
 1 <type 'int'>
 0 <type 'int'>
-127 <type 'int'>
+129 <type 'int'>
 False <type 'bool'>

--- a/test/run/t520.py.real
+++ b/test/run/t520.py.real
@@ -3,5 +3,5 @@ True <type 'bool'>
 True <type 'bool'>
 1 <type 'int'>
 0 <type 'int'>
-129 <type 'int'>
+True <type 'int'>
 False <type 'bool'>

--- a/test/run/t520.py.real.force
+++ b/test/run/t520.py.real.force
@@ -3,5 +3,5 @@ True <type 'bool'>
 True <type 'bool'>
 1 <type 'int'>
 0 <type 'int'>
-127 <type 'int'>
+129 <type 'int'>
 False <type 'bool'>

--- a/test/run/t520.py.real.force
+++ b/test/run/t520.py.real.force
@@ -3,5 +3,5 @@ True <type 'bool'>
 True <type 'bool'>
 1 <type 'int'>
 0 <type 'int'>
-129 <type 'int'>
+True <type 'int'>
 False <type 'bool'>

--- a/test/unit/test_subclass.py
+++ b/test/unit/test_subclass.py
@@ -220,6 +220,40 @@ class SubclassTest(unittest.TestCase):
         class SameBuiltin(MyInt, int): pass
         self.assertEqual(SameBuiltin(5), 5)
 
+    def test_exceptions(self):
+
+        class TestFailed(Exception):
+            """Test failed."""
+
+        def raiseTestFailed():
+            raise TestFailed()
+
+        self.assertRaises(TestFailed, raiseTestFailed)
+
+        try:
+            raise TestFailed("test")
+        except TestFailed as e:
+            self.assertIn("TestFailed: test", str(e))
+
+        class MyTypeError(TypeError): pass
+
+        def raiseMyTypeError():
+            raise MyTypeError()
+
+        self.assertRaises(MyTypeError, raiseMyTypeError)
+        self.assertRaises(TypeError, raiseMyTypeError)
+        self.assertRaises(Exception, raiseMyTypeError)
+
+        class MyStandardError(StandardError):
+            def __str__(self):
+                return "My Standard Error"
+
+        try:
+            raise MyStandardError("test")
+        except MyStandardError as e:
+            self.assertEqual("My Standard Error", str(e))
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_subclass.py
+++ b/test/unit/test_subclass.py
@@ -51,6 +51,25 @@ class AnotherInt(MyInt):
     def __mul__(self, other):
         return 0
 
+foo_radd = "Foo __radd__"
+bar_add = "Bar __add__"
+baz_radd = "Baz __radd__"
+baz_add = "Baz __add__"
+
+class Foo(int):
+    def __radd__(self, other):
+        return foo_radd
+
+class Bar(int):
+    def __add__(self, other):
+        return bar_add
+
+class Baz(Bar):
+    def __add__(self, other):
+        return baz_add
+    def __radd__(self, other):
+        return baz_radd
+
 class SubclassTest(unittest.TestCase):
 
     def test_builtin_functions(self):
@@ -158,6 +177,30 @@ class SubclassTest(unittest.TestCase):
 
         d[1] = "should not change"
         self.assertEqual(d, base_dict)                      # MyDict.__setitem__
+
+    def test_override_ancestor_operations(self):
+
+        foo = Foo(5)
+        bar = Bar(5)
+        baz = Baz(5)
+
+        self.assertEqual(foo + 2, 7)            # int.__add__
+        self.assertEqual(2 + foo, foo_radd)     # Foo.__radd__
+
+        self.assertEqual(bar + 2, bar_add)      # Bar.__add__
+        self.assertEqual(2 + bar, 7)            # int.__radd__ (from Bar)
+
+        self.assertEqual(foo + bar, 10)         # int.__add__ (from Foo)
+        self.assertEqual(bar + foo, bar_add)    # Bar.__add__
+
+        self.assertEqual(baz + 2, baz_add)      # Baz.__add__
+        self.assertEqual(2 + baz, baz_radd)     # Baz.__radd__
+
+        self.assertEqual(foo + baz, 10)         # int.__add__ (from Foo)
+        self.assertEqual(baz + foo, baz_add)    # Baz.__add__
+
+        self.assertEqual(bar + baz, baz_radd)   # Baz.__radd__
+        self.assertEqual(baz + bar, baz_add)    # Baz.add
 
     def test_subclass_of_subclass(self):
 

--- a/test/unit/test_subclass.py
+++ b/test/unit/test_subclass.py
@@ -47,6 +47,10 @@ class MyDict(dict):
     def __setitem__(self, key, value):
         return None
 
+class AnotherInt(MyInt):
+    def __mul__(self, other):
+        return 0
+
 class SubclassTest(unittest.TestCase):
 
     def test_builtin_functions(self):
@@ -154,6 +158,17 @@ class SubclassTest(unittest.TestCase):
 
         d[1] = "should not change"
         self.assertEqual(d, base_dict)                      # MyDict.__setitem__
+
+    def test_subclass_of_subclass(self):
+
+        x = MyInt(5)
+        self.assertEqual(x * 5, 25)
+
+        y = AnotherInt(5)
+        self.assertEqual(y, 5)              # int.__eq__
+        self.assertEqual(y + 2, 3)          # MyInt.__add__
+        self.assertEqual(hash(y), 11)       # MyInt.__hash__
+        self.assertEqual(y * 5, 0)          # AnotherInt.__mul__
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_subclass.py
+++ b/test/unit/test_subclass.py
@@ -199,6 +199,27 @@ class SubclassTest(unittest.TestCase):
         self.assertEqual(hash(z), 11)               # MyInt.__hash__
         self.assertEqual(z.test(), "Hello world")   # Ancestor.test
 
+    def test_bad_multiple_inheritance(self):
+
+        # Note: "with self.assertRaises" syntax is not supported by Skulpt
+        # at this time so must pass a function to "self.assertRaises"
+
+        def two_builtins():
+            class BadClass(int, float): pass
+
+        def builtin_and_subclass():
+            class BadClass(int, MyFloat): pass
+
+        def two_subclasses():
+            class BadClass(MyList, AnotherInt): pass
+
+        self.assertRaises(TypeError, two_builtins)
+        self.assertRaises(TypeError, builtin_and_subclass)
+        self.assertRaises(TypeError, two_subclasses)
+
+        class SameBuiltin(MyInt, int): pass
+        self.assertEqual(SameBuiltin(5), 5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_subclass.py
+++ b/test/unit/test_subclass.py
@@ -1,0 +1,159 @@
+# Python test set -- built-in functions
+
+import unittest
+
+class MySimpleInt(int): pass
+class MySimpleFloat(float): pass
+class MySimpleLong(long): pass
+
+class MyInt(int):
+    def __init__(self, value):
+        self.value = value
+
+    def __add__(self, other):
+        return self.value - other
+
+    def __hash__(self):
+        return 11
+
+class MyFloat(float):
+    def __sub__(self, other):
+        return 0
+
+class MyLong(long):
+    def __lt__(self, other):
+        return True
+
+class MyList(list):
+    def __contains__(self, item):
+        if item == 2:
+            return True
+        else:
+            return False
+    def __add__(self, item):
+        return self
+    def __mul__(self, num):
+        return self[:1]
+    def __rmul__(self, num):
+        return self[1:]
+
+class MySet(set):
+    def __len__(self):
+        return 0
+
+class MyDict(dict):
+    def __getitem__(self, key):
+        return "hello world"
+    def __setitem__(self, key, value):
+        return None
+
+class SubclassTest(unittest.TestCase):
+
+    def test_builtin_functions(self):
+        builtinToSubclass = {5: MySimpleInt(5), 
+                             3L: MySimpleLong(3L), 
+                             1.2: MySimpleFloat(1.2)}
+
+        for builtin in builtinToSubclass:
+            subclass = builtinToSubclass[builtin]
+
+            self.assertEqual(repr(subclass), repr(builtin))
+            self.assertEqual(str(subclass), str(builtin))
+            self.assertEqual(abs(subclass), abs(builtin))
+            self.assertEqual(hash(subclass), hash(builtin))
+
+    def test_comparions(self):
+        less = [MySimpleInt(5), MySimpleLong(5L), MySimpleFloat(5.0), 5, 5L, 5.0]
+        greater = [MySimpleInt(10), MySimpleLong(10L), MySimpleFloat(10.0), 10, 10L, 10.0]
+
+        for x in less:
+            for y in less:
+                self.assertEqual(x, y)
+
+        for l in less:
+            for g in greater:
+                self.assertLess(l, g)
+                self.assertLessEqual(l, g)
+                self.assertGreater(g, l)
+                self.assertGreaterEqual(g, l)
+                self.assertLessEqual(l, l)
+                self.assertGreaterEqual(g, g)
+
+    def test_binop(self):
+        builtinToSubclass = {5: MySimpleInt(5), 
+                             3L: MySimpleLong(3L), 
+                             1.2: MySimpleFloat(1.2)}
+
+        for x_builtin in builtinToSubclass:
+            x_subclass = builtinToSubclass[x_builtin]
+            for y_builtin in builtinToSubclass:
+                y_subclass = builtinToSubclass[y_builtin]
+
+                self.assertEqual(x_subclass + y_subclass, x_builtin + y_builtin)
+                self.assertEqual(y_subclass + x_subclass, y_builtin + x_builtin)
+
+                self.assertEqual(x_subclass - y_subclass, x_builtin - y_builtin)
+                self.assertEqual(y_subclass - x_subclass, y_builtin - x_builtin)
+
+                self.assertEqual(x_subclass * y_subclass, x_builtin * y_builtin)
+                self.assertEqual(y_subclass * x_subclass, y_builtin * x_builtin)
+
+                self.assertEqual(x_subclass / y_subclass, x_builtin / y_builtin)
+                self.assertEqual(y_subclass / x_subclass, y_builtin / x_builtin)
+
+                self.assertEqual(x_subclass % y_subclass, x_builtin % y_builtin)
+                self.assertEqual(y_subclass % x_subclass, y_builtin % x_builtin)
+
+                self.assertEqual(x_subclass // y_subclass, x_builtin // y_builtin)
+                self.assertEqual(y_subclass // x_subclass, y_builtin // x_builtin)
+                
+                self.assertEqual(x_subclass ** y_subclass, x_builtin ** y_builtin)
+                self.assertEqual(y_subclass ** x_subclass, y_builtin ** x_builtin)
+
+    
+    def test_override_dunder_numbers(self):
+        i = MyInt(5)
+        l = MyLong(3L)
+        f = MyFloat(1.2)
+
+        self.assertEqual(i + f, i - f)      # MyInt.__add__
+        self.assertEqual(f - i, 0)          # MyFloat.__sub__
+
+        self.assertLess(l, i)               # MyLong.__lt__
+        self.assertLess(l, f)               # MyLong.__lt__
+
+        self.assertEqual(hash(i), 11)       # MyInt.__hash__
+
+
+    def test_override_dunder_containers(self):
+        base_list = [1, 2, 3]
+        base_dict = {1: 2}
+
+        li = MyList(base_list)
+        self.assertEqual(li, base_list)
+
+        self.assertNotIn(1, li)             # MyList.__contains__
+        self.assertIn(2, li)                # MyList.__contains__
+        self.assertNotIn(3, li)             # MyList.__contains__
+        self.assertNotIn(4, li)             # MyList.__contains__
+
+        self.assertEqual(li + [4], li)      # MyList.__add__
+        self.assertEqual(li * 5, li[:1])    # MyList.__mul__
+        self.assertEqual(5 * li, li[1:])    # MyList.__rmul__
+
+        s = MySet(base_list)
+        self.assertEqual(s, set(base_list))
+
+        self.assertEqual(len(s), 0)         # MySet.__len__
+
+        d = MyDict(base_dict)
+        self.assertEqual(d, base_dict)
+
+        self.assertEqual(d[1], "hello world")               # MyDict.__getitem__
+        self.assertEqual(d["not a key"], "hello world")     # MyDict.__getitem__
+
+        d[1] = "should not change"
+        self.assertEqual(d, base_dict)                      # MyDict.__setitem__
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_subclass.py
+++ b/test/unit/test_subclass.py
@@ -1,4 +1,4 @@
-# Python test set -- built-in functions
+__author__ = 'mchat'
 
 import unittest
 

--- a/test/unit/test_subclass.py
+++ b/test/unit/test_subclass.py
@@ -170,5 +170,35 @@ class SubclassTest(unittest.TestCase):
         self.assertEqual(hash(y), 11)       # MyInt.__hash__
         self.assertEqual(y * 5, 0)          # AnotherInt.__mul__
 
+    def test_multiple_inheritance(self):
+        class Ancestor:
+            def __hash__(self):
+                return 15
+            def __str__(self):
+                return "Ancestor"
+            def test(self):
+                return "Hello world"
+
+        class Foo(Ancestor, int): pass
+        class Bar(Ancestor, MyInt): pass
+        class Baz(MyInt, Ancestor): pass
+
+        x = Foo(5)
+        y = Bar(5)
+        z = Baz(5)
+
+        self.assertEqual(str(x), "Ancestor")        # Ancestor.__str__
+        self.assertEqual(hash(x), 15)               # Ancestor.__hash__
+        self.assertEqual(x.test(), "Hello world")   # Ancestor.test
+
+        self.assertEqual(str(y), "Ancestor")        # Ancestor.__str__
+        self.assertEqual(hash(y), 15)               # Ancestor.__str__
+        self.assertEqual(y.test(), "Hello world")   # Ancestor.test
+
+        self.assertEqual(str(z), "5")               # int.__str__
+        self.assertEqual(hash(z), 11)               # MyInt.__hash__
+        self.assertEqual(z.test(), "Hello world")   # Ancestor.test
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is the last PR related to #481, and makes builtin types subclassable.

Here's a brief overview of what this PR makes possible. See [test_subclass.py](https://github.com/mchat/skulpt/blob/subclass/test/unit/test_subclass.py) for more comprehensive testing.

```python

# Subclass a builtin with no changes
class SimpleInt(int): pass

x = SimpleInt(10)
print x == 10           # True  (int.__eq__)
print x + 10            # 20    (int.__add__)
print x - 10            # 0     (int.__sub__)


# Subclass a builtin and override a magic method
class MyInt(int):
    def __add__(self, other):
        return 5

x = MyInt(10)
print x == 10           # True  (int.__eq__)
print x + 10            # 5     (MyInt.__add__)
print x - 10            # 0     (int.__sub__)


# Subclass a subclassed builtin and override a different magic method
class AnotherInt(MyInt):
    def __sub__(self, other):
        return -5

x = AnotherInt(10)
print x == 10           # True  (int.__eq__)
print x + 10            # 5     (MyInt.__add__)
print x - 10            # -5    (AnotherInt.__sub__)


# Subclass multiple classes which inherit from the same builtin
class MultipleInheritance(MyInt, SimpleInt): pass

x = MultipleInheritance(10)
print x == 10           # True  (int.__eq__)
print x + 10            # 5     (MyInt.__add__)
print x - 10            # 0     (int.__sub__)

# Cannot subclass multiple classes which inherit from different builtins
try:
    class BadMultipleInheritance(int, float): pass
    print "should not see this"
except TypeError:
    print "Caught TypeError"
```