### PR TITLE
Add default behavior for __iadd__ to call regular __add__

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -249,6 +249,18 @@ Sk.builtin.object.prototype["__ge__"] = function (self, other) {
     return self.ob$ge(other);
 };
 
+/**
+ * Python wrapper for `__iadd__` method.
+ * @name  __iadd__
+ * @memberOf Sk.builtin.object.prototype
+ * @instance
+ */Sk.builtin.object.prototype["__iadd__"] = function (self, other) {
+    Sk.builtin.pyCheckArgs("__iadd__", arguments, 1, 2, false, true);
+
+    return self.nb$add(other);
+};
+
+
 /** Default implementations of Javascript functions used in dunder methods */
 
 /**
@@ -379,7 +391,7 @@ Sk.builtin.object.prototype.ob$ge = function (other) {
  * @type {Array}
  */
 Sk.builtin.object.pythonFunctions = ["__repr__", "__str__", "__hash__",
-"__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__", "__getattr__", "__setattr__"];
+"__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__", "__getattr__", "__setattr__","__iadd__"];
 
 /**
  * @constructor


### PR DESCRIPTION
This demonstrates an easy approach to fixing #465  -- causes t407.py (which tests `dir` of a classes and subclasses) to fail, but that test is pretty bogus if you ask me as it really does not match real python in any case.

So if we think this is good I can add defaults for other inplace operators.
