### PR TITLE
Turtle clone works, still has some issues

### DIFF
--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -1072,6 +1072,70 @@ function generateTurtleModule(_target) {
         };
         proto.$getscreen.isSk = true;
 
+        proto.$clone = function() {
+            console.log(this.skInstance);
+            var turtleMod = Sk.misceval.loadname('turtle',Sk.globals);
+            console.log(turtleMod);
+            var turtleKlass = Sk.abstr.gattr(turtleMod,'Turtle', true);
+            console.log(turtleKlass);
+            var newTurtleInstance = Sk.misceval.callsimOrSuspend(turtleKlass);
+            console.log(newTurtleInstance);
+
+            newTurtleInstance._x = this._x;
+            newTurtleInstance._y = this._y;
+            newTurtleInstance._angle = this._angle;
+            newTurtleInstance._radians = this._radians;
+            newTurtleInstance._shape = this._shape;
+            newTurtleInstance._color = this._color;
+            newTurtleInstance._fill = this._fill;
+            newTurtleInstance._filling = this._filling;
+            newTurtleInstance._size = this._size;
+            newTurtleInstance._computed_speed = this._computed_speed;
+            newTurtleInstance._down = this._down;
+            newTurtleInstance._shown = this._shown;
+
+            newTurtleInstance._clonedFrom = this;
+
+            return newTurtleInstance;
+
+        };
+        proto.$clone.returnType = function(value) {
+            console.log('return type value');
+            console.log(value);
+            console.log('return type this');
+            console.log(this);
+
+            value._x = value._clonedFrom._x;
+            value._y = value._clonedFrom._y;
+            value._angle = value._clonedFrom._angle;
+            value._radians = value._clonedFrom._radians;
+            value._shape = value._clonedFrom._shape;
+            value._color = value._clonedFrom._color;
+            value._fill = value._clonedFrom._fill;
+            value._filling = value._clonedFrom._filling;
+            value._size = value._clonedFrom._size;
+            value._computed_speed = value._clonedFrom._computed_speed;
+            value._down = value._clonedFrom._down;
+            value._shown = value._clonedFrom._shown;
+
+            //value.addUpdate(undefined, false, {
+            //    _x : value._clonedFrom._x,
+            //    _y : value._clonedFrom._y,
+            //    _angle : value._clonedFrom._angle,
+            //    _radians : value._clonedFrom._radians,
+            //    _shape : value._clonedFrom._shape,
+            //    _color : value._clonedFrom._color,
+            //    _fill : value._clonedFrom._fill,
+            //    _filling : value._clonedFrom._filling,
+            //    _size : value._clonedFrom._size,
+            //    _computed_speed : value._clonedFrom._computed_speed,
+            //    _down : value._clonedFrom._down,
+            //    _shown : value._clonedFrom._shown
+            //});
+
+            return value
+        };
+
         proto.$getturtle = proto.$getpen = function() {
             return this.skInstance;
         };

--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -1074,12 +1074,7 @@ function generateTurtleModule(_target) {
 
         proto.$clone = function() {
 
-            // I'm loading the module from the global scope.
-            // This means if turtle was imported within a function
-            // then this line will think it's undefined
-            var turtleMod = Sk.misceval.loadname('turtle',Sk.globals);
-            var turtleKlass = Sk.abstr.gattr(turtleMod,'Turtle', true);
-            var newTurtleInstance = Sk.misceval.callsimOrSuspend(turtleKlass);
+            var newTurtleInstance = Sk.misceval.callsimOrSuspend(_module.Turtle);
 
             newTurtleInstance.instance._x = this._x;
             newTurtleInstance.instance._y = this._y;

--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -1073,66 +1073,33 @@ function generateTurtleModule(_target) {
         proto.$getscreen.isSk = true;
 
         proto.$clone = function() {
-            console.log(this.skInstance);
-            var turtleMod = Sk.misceval.loadname('turtle',Sk.globals);
-            console.log(turtleMod);
-            var turtleKlass = Sk.abstr.gattr(turtleMod,'Turtle', true);
-            console.log(turtleKlass);
-            var newTurtleInstance = Sk.misceval.callsimOrSuspend(turtleKlass);
-            console.log(newTurtleInstance);
 
-            newTurtleInstance._x = this._x;
-            newTurtleInstance._y = this._y;
-            newTurtleInstance._angle = this._angle;
-            newTurtleInstance._radians = this._radians;
-            newTurtleInstance._shape = this._shape;
-            newTurtleInstance._color = this._color;
-            newTurtleInstance._fill = this._fill;
-            newTurtleInstance._filling = this._filling;
-            newTurtleInstance._size = this._size;
-            newTurtleInstance._computed_speed = this._computed_speed;
-            newTurtleInstance._down = this._down;
-            newTurtleInstance._shown = this._shown;
+            // I'm loading the module from the global scope.
+            // This means if turtle was imported within a function
+            // then this line will think it's undefined
+            var turtleMod = Sk.misceval.loadname('turtle',Sk.globals);
+            var turtleKlass = Sk.abstr.gattr(turtleMod,'Turtle', true);
+            var newTurtleInstance = Sk.misceval.callsimOrSuspend(turtleKlass);
+
+            newTurtleInstance.instance._x = this._x;
+            newTurtleInstance.instance._y = this._y;
+            newTurtleInstance.instance._angle = this._angle;
+            newTurtleInstance.instance._radians = this._radians;
+            newTurtleInstance.instance._shape = this._shape;
+            newTurtleInstance.instance._color = this._color;
+            newTurtleInstance.instance._fill = this._fill;
+            newTurtleInstance.instance._filling = this._filling;
+            newTurtleInstance.instance._size = this._size;
+            newTurtleInstance.instance._computed_speed = this._computed_speed;
+            newTurtleInstance.instance._down = this._down;
+            newTurtleInstance.instance._shown = this._shown;
 
             newTurtleInstance._clonedFrom = this;
 
             return newTurtleInstance;
-
         };
         proto.$clone.returnType = function(value) {
-            console.log('return type value');
-            console.log(value);
-            console.log('return type this');
-            console.log(this);
-
-            value._x = value._clonedFrom._x;
-            value._y = value._clonedFrom._y;
-            value._angle = value._clonedFrom._angle;
-            value._radians = value._clonedFrom._radians;
-            value._shape = value._clonedFrom._shape;
-            value._color = value._clonedFrom._color;
-            value._fill = value._clonedFrom._fill;
-            value._filling = value._clonedFrom._filling;
-            value._size = value._clonedFrom._size;
-            value._computed_speed = value._clonedFrom._computed_speed;
-            value._down = value._clonedFrom._down;
-            value._shown = value._clonedFrom._shown;
-
-            //value.addUpdate(undefined, false, {
-            //    _x : value._clonedFrom._x,
-            //    _y : value._clonedFrom._y,
-            //    _angle : value._clonedFrom._angle,
-            //    _radians : value._clonedFrom._radians,
-            //    _shape : value._clonedFrom._shape,
-            //    _color : value._clonedFrom._color,
-            //    _fill : value._clonedFrom._fill,
-            //    _filling : value._clonedFrom._filling,
-            //    _size : value._clonedFrom._size,
-            //    _computed_speed : value._clonedFrom._computed_speed,
-            //    _down : value._clonedFrom._down,
-            //    _shown : value._clonedFrom._shown
-            //});
-
+            // When I return the instance here, I'm not sure if it ends up with the right "Turtle" python type.
             return value
         };
 

--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -1076,6 +1076,7 @@ function generateTurtleModule(_target) {
 
             var newTurtleInstance = Sk.misceval.callsimOrSuspend(_module.Turtle);
 
+            // All the properties that are in getState()
             newTurtleInstance.instance._x = this._x;
             newTurtleInstance.instance._y = this._y;
             newTurtleInstance.instance._angle = this._angle;
@@ -1088,6 +1089,15 @@ function generateTurtleModule(_target) {
             newTurtleInstance.instance._computed_speed = this._computed_speed;
             newTurtleInstance.instance._down = this._down;
             newTurtleInstance.instance._shown = this._shown;
+
+            // Other properties to copy
+            newTurtleInstance.instance._isRadians = this._isRadians;
+            newTurtleInstance.instance._fullCircle = this._fullCircle;
+            newTurtleInstance.instance._bufferSize = this._bufferSize;
+            console.log(this._undoBuffer);
+            newTurtleInstance.instance._undoBuffer = this._undoBuffer;
+            console.log(newTurtleInstance.instance._undoBuffer);
+
 
             newTurtleInstance._clonedFrom = this;
 


### PR DESCRIPTION
Looking to resolve #409 I have a working turtle.clone() method, but with one problem that I can see. It loads the turtle module using Sk.misceval.loadname using the Sk.globals object, so if the user writes 'import turtle' in a function then this method will not be able to find it.

Also, I'm not totally sure if the new clone turtle instance has the write Turtle type according to skulpt.

But this is a start