### PR TITLE
check for python3 flag to get python3 division

### DIFF
--- a/src/int.js
+++ b/src/int.js
@@ -304,6 +304,11 @@ Sk.builtin.int_.prototype.nb$reflected_multiply = function (other) {
 
 /** @override */
 Sk.builtin.int_.prototype.nb$divide = function (other) {
+    var thisAsFloat;
+    if (Sk.python3) {
+        thisAsFloat = new Sk.builtin.float_(this.v);
+        return thisAsFloat.nb$divide(other);
+    }
     return this.nb$floor_divide(other);
 };
 


### PR DESCRIPTION
In all of @mchat 's great work we lost the check for the python3 flag for the regular / operator.  I realize some may think that was a good thing, but it breaks a bunch of examples in my books.