### PR TITLE
Make $ret, currLineNo, and currColNo local variables.

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2235,7 +2235,7 @@ Compiler.prototype.cmod = function (mod) {
 
     var entryBlock = this.newBlock("module entry");
     this.u.prefixCode = "var " + modf + "=(function($modname){";
-    this.u.varDeclsCode = "var $gbl = {}, $blk=" + entryBlock + ",$exc=[],$loc=$gbl,$err=undefined;$gbl.__name__=$modname,$ret=undefined,currLineNo=undefined,currColNo=undefined;";
+    this.u.varDeclsCode = "var $gbl = {}, $blk=" + entryBlock + ",$exc=[],$loc=$gbl,$err=undefined;$gbl.__name__=$modname;var $ret=undefined,currLineNo=undefined,currColNo=undefined;";
     if (Sk.execLimit !== null) {
         this.u.varDeclsCode += "if (typeof Sk.execStart === 'undefined') {Sk.execStart = Date.now()}";
     }


### PR DESCRIPTION
These were global variables.  At a minimum, this causes problems when there is an exception thrown by an imported module. The traceback will be corrupted, as the line and column numbers will all be the same, since all modules were sharing the same variables.