### PR TITLE
Update NPM dependencies

### DIFF
--- a/m
+++ b/m
@@ -1,1 +1,2 @@
-skulpt.py
+#!/bin/bash
+PATH=$(npm bin):$PATH ./skulpt.py "$@"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "jshint": "~2.5.2",
-    "jscs": "~1.11"
+    "jscs": "~1.12",
+    "jsdoc": "~3.3.2"
   }
 }


### PR DESCRIPTION
`package.json` was demanding a version of `jscs` that barfed on the codebase, and didn't demand `jsdoc` at all. Presumably everyone else so far has been using globally-installed versions!

These commits update those dependencies, and make `m` (which used to be a symlink) a bash script that runs `skulpt.py` with a `$PATH` that makes sure we invoke `jshint` from our own dependencies rather than whatever's installed globally.