### PR TITLE
remapToJS() wasnt working for Dicts 

### DIFF
--- a/src/dict.js
+++ b/src/dict.js
@@ -187,7 +187,7 @@ Sk.builtin.dict.prototype.tp$iter = function () {
     for (k in this) {
         if (this.hasOwnProperty(k)) {
             bucket = this[k];
-            if (bucket && bucket.$hash !== undefined) {
+            if (bucket && bucket.$hash !== undefined && bucket.items !== undefined) {
                 // skip internal stuff. todo; merge pyobj and this
                 for (i = 0; i < bucket.items.length; i++) {
                     allkeys.push(bucket.items[i].lhs);


### PR DESCRIPTION
Sk.remapToJs(Sk.remapToPy({hello:"world"})) was failing on properties with a $hash but not items.  I added an explicit check and now it works.  Happy to add a test to go with it if you show me where the javascript only tests go.