### PR TITLE
return None from sys.debug

### DIFF
--- a/src/builtin/sys.js
+++ b/src/builtin/sys.js
@@ -62,6 +62,7 @@ var $builtinmodule = function (name) {
 
     sys.debug = new Sk.builtin.func(function () {
         debugger;
+        return Sk.builtin.none.none$;
     });
 
     return sys;


### PR DESCRIPTION
when you call sys.debug from the repl it fails because it returns `undefined` @spaceone reported this. In #283.