### PR TITLE
Fixes integer modulo for zero divisions

### DIFF
--- a/src/int.js
+++ b/src/int.js
@@ -356,21 +356,14 @@ Sk.builtin.int_.prototype.nb$reflected_floor_divide = function (other) {
 Sk.builtin.int_.prototype.nb$remainder = function (other) {
     var thisAsLong, thisAsFloat;
     var tmp;
+    var divResult;
 
     if (other instanceof Sk.builtin.int_) {
-
         //  Javacript logic on negatives doesn't work for Python... do this instead
-        tmp = this.v % other.v;
-
-        if (this.v < 0) {
-            if (other.v > 0 && tmp < 0) {
-                tmp = tmp + other.v;
-            }
-        } else {
-            if (other.v < 0 && tmp !== 0) {
-                tmp = tmp + other.v;
-            }
-        }
+        divResult = Sk.abstr.numberBinOp(this, other, "FloorDiv");
+        tmp = Sk.abstr.numberBinOp(divResult, other, "Mult");
+        tmp = Sk.abstr.numberBinOp(this, tmp, "Sub");
+        tmp = tmp.v;
 
         if (other.v < 0 && tmp === 0) {
             tmp = -0.0; // otherwise the sign gets lost by javascript modulo

--- a/test/unit/test_int.py
+++ b/test/unit/test_int.py
@@ -399,6 +399,21 @@ class IntTestCases(unittest.TestCase):
         self.assertEqual(bool(True).conjugate(), 1)
         self.assertEqual(bool(False).conjugate(), 0)
 
+    def test_modulo(self):
+        # helper
+        def mod(a, b):
+            return a % b
+
+        self.assertRaises(ZeroDivisionError, mod, 5, 0)
+        self.assertEqual(mod(5, 1), 0)
+        self.assertEqual(mod(5, 2), 1)
+        self.assertEqual(mod(5, 4), 1)
+        self.assertEqual(mod(5, 5), 0)
+        self.assertEqual(mod(5, 6), 5)
+        self.assertEqual(mod(0, 1), 0)
+        self.assertEqual(mod(-5, 6), 1)
+        self.assertEqual(mod(-5, -2), -1)
+
 class IntTest(unittest.TestCase):
     def test_int_inherited(self):
         class c:


### PR DESCRIPTION
This PR fixes the #513. Instead of using the javascript calculation I've used "python" methods for calculating. Those ensure the correct handling of the types and throw appropriate errors.