### PR TITLE
Fixes imports that are own files but show up in the from list

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -364,6 +364,8 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, canS
         external = Sk.loadExternalLibrary(name);
         if (external) {
             co = external;
+            filename = Sk.externalLibraries[name].path; // get path from config
+            // ToDo: check if this is a dotted name or import from ...
         } else {
             // Try loading as a builtin (i.e. already in JS) module, then try .py files
             codeAndPath = Sk.importSearchPathForName(name, ".js", true, canSuspend);
@@ -376,6 +378,7 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, canS
                     isPy = true;
                     return compileReadCode(Sk.importSearchPathForName(name, ".py", false, canSuspend));
                 } else {
+                    filename = codeAndPath.filename;
                     return isPy ? Sk.compile(codeAndPath.code, codeAndPath.filename, "exec", canSuspend)
                         : { funcname: "$builtinmodule", code: codeAndPath.code };
                 }
@@ -391,6 +394,11 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, canS
 
         module.$js = co.code; // todo; only in DEBUG?
         finalcode = co.code;
+
+        if (filename == null) {
+            filename = co.filename;
+        }
+
         if (Sk.dateSet == null || !Sk.dateSet) {
             finalcode = "Sk.execStart = Sk.lastYield = new Date();\n" + co.code;
             Sk.dateSet = true;
@@ -443,6 +451,8 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, canS
             if (!modlocs["__name__"]) {
                 modlocs["__name__"] = new Sk.builtin.str(modname);
             }
+
+            modlocs["__path__"] = new Sk.builtin.str(filename);
 
             module["$d"] = modlocs;
             

--- a/src/import.js
+++ b/src/import.js
@@ -364,7 +364,11 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, canS
         external = Sk.loadExternalLibrary(name);
         if (external) {
             co = external;
-            filename = Sk.externalLibraries[name].path; // get path from config
+            if (Sk.externalLibraries) {
+                filename = Sk.externalLibraries[name].path; // get path from config
+            } else {
+                filename = 'unknown';
+            }
             // ToDo: check if this is a dotted name or import from ...
         } else {
             // Try loading as a builtin (i.e. already in JS) module, then try .py files
@@ -566,9 +570,6 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
             }
         }
 
-        // check if modules in name list are in the module
-
-
         // if there's a fromlist we want to return the actual module, not the
         // toplevel namespace
         ret = Sk.sysmodules.mp$subscript(name);
@@ -580,18 +581,6 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
 Sk.importStar = function (module, loc, global) {
     // from the global scope, globals and locals can be the same.  So the loop below
     // could accidentally overwrite __name__, erasing __main__.
-    var i;
-    var nn = global["__name__"];
-    var props = Object["getOwnPropertyNames"](module["$d"]);
-    for (i in props) {
-        loc[props[i]] = module["$d"][props[i]];
-    }
-    if (global["__name__"] !== nn) {
-        global["__name__"] = nn;
-    }
-};
-
-Sk.importFromList = function(module, loc, global) {
     var i;
     var nn = global["__name__"];
     var props = Object["getOwnPropertyNames"](module["$d"]);

--- a/src/import.js
+++ b/src/import.js
@@ -367,7 +367,7 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, canS
             if (Sk.externalLibraries) {
                 filename = Sk.externalLibraries[name].path; // get path from config
             } else {
-                filename = 'unknown';
+                filename = "unknown";
             }
             // ToDo: check if this is a dotted name or import from ...
         } else {


### PR DESCRIPTION
Should fix #299 .

Example:

```python
from unittest import gui as mystuff

print("nothing to see here")
print(dir(mystuff))
```