### PR TITLE
Fixes abs builtin for User Defined Classes

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -440,7 +440,7 @@ Sk.builtin.abs = function abs (x) {
 
     // call custom __abs__ methods
     if (x.tp$getattr) {
-        var f = x.tp$getattr('__abs__');
+        var f = x.tp$getattr("__abs__");
         return Sk.misceval.callsim(f);
     }
 

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -438,6 +438,12 @@ Sk.builtin.abs = function abs (x) {
         return Sk.misceval.callsim(x.__abs__, x);
     }
 
+    // call custom __abs__ methods
+    if (x.tp$getattr) {
+        var f = x.tp$getattr('__abs__');
+        return Sk.misceval.callsim(f);
+    }
+
     throw new TypeError("bad operand type for abs(): '" + Sk.abstr.typeName(x) + "'");
 };
 

--- a/test/unit/test_builtin.py
+++ b/test/unit/test_builtin.py
@@ -235,6 +235,19 @@ class BuiltinTest(unittest.TestCase):
             raise RuntimeError
         self.assertRaises(RuntimeError, map, badfunc, range(5))
 
+    def test_abs(self):
+        class TestAbs:
+
+            def __init__(self):
+                self.foo = -3
+
+            def __abs__(self):
+                return -self.foo
+
+        bar = TestAbs()
+        self.assertEqual(abs(bar), 3)
+        self.assertEqual(abs(-3), 3)
+
     def test_reduce(self):
         add = lambda x, y: x+y
         self.assertEqual(reduce(add, ['a', 'b', 'c'], ''), 'abc')


### PR DESCRIPTION
Fixes `abs` for calling `__abs__` on user defined classes.

```python
class TestAbs:

    def __init__(self):
        self.foo = -3

    def __abs__(self):
        return -self.foo

bar = TestAbs()
print abs(bar)
```