### PR TITLE
Update packeage.json to be compatible with npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,24 @@
 {
+  "name": "skulpt",
+  "version": "1.0.0",
+  "description": "Skulpt is a Javascript implementation of Python 2.x. Python that runs in your browser!",
+  "keywords": ["skulpt"],
+  "scripts": {
+    "lint": "jshint ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/skulpt/skulpt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/skulpt/skulpt/issues"
+  },
+  "homepage": "http://www.skulpt.org/",
+  "author": {
+    "name": "Brad Miller"
+  },
+  "license": "MIT",
+  "private": true,
   "dependencies": {
     "jshint": "~2.5.2",
     "jscs": "~1.12",


### PR DESCRIPTION
This package.json modification are to used to load the current source code over npm directly from github.
Because of the "private": "true" flag it will not be uploaded the to the npm repository.