### PR TITLE
Adds POST request to urllib.request.urlopen(..)

### DIFF
--- a/src/lib/urllib/request/__init__.js
+++ b/src/lib/urllib/request/__init__.js
@@ -107,8 +107,16 @@ var $builtinmodule = function (name) {
      */
     request.urlopen = new Sk.builtin.func(function (url, data, timeout) {
         var xmlhttp = new XMLHttpRequest();
-        xmlhttp.open("GET", url.v, false);
-        xmlhttp.send(null);
+
+        if (!data) {
+          xmlhttp.open("GET", url.v, false);
+          xmlhttp.send(null);
+        } else {
+          xmlhttp.open("POST", url.v, false);
+          xmlhttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+          xmlhttp.setRequestHeader("Content-length", data.v.length);
+          xmlhttp.send(data.v);
+        }
 
         return Sk.misceval.callsim(request.Response, xmlhttp)
     });


### PR DESCRIPTION
The Python spec says urlopen issues a POST request in case the data parameter is set. (https://docs.python.org/3.0/library/urllib.request.html)

This PR adds a simple check for that and changes the request type to POST and sends the data as the request body.