### PR TITLE
Stop Processing instance (if it exists) on subsequent runs.

### DIFF
--- a/src/lib/processing.js
+++ b/src/lib/processing.js
@@ -25,6 +25,7 @@ var $builtinmodule = function (name) {
     var mod = {};
     var imList = [];
     var looping = true;
+    var instance = null;
 
     // We need this to store a reference to the actual processing object which is not created
     // until the run function is called.  Even then the processing object is passed by the
@@ -1548,6 +1549,11 @@ var $builtinmodule = function (name) {
         window.Processing.logger = { log : function(message) {
             Sk.misceval.print_(message);
         }};
+        // if a Processing instance already exists it's likely still running, stop it by exiting
+        instance = window.Processing.getInstanceById(Sk.canvas);
+        if (instance) {
+            instance.exit();
+        }
         mod.p = new window.Processing(canvas, sketchProc);
 
 


### PR DESCRIPTION
When using the processing module, processing instances keep running across subsequent Skulpt runs if it's not explicitly stopped. This is best seen with an example.

Try pasting the code below into the editor over at: http://www.skulpt.org/static/proctest.html

Click Run several times and you'll notice that the ball starts moving quicker and quicker with each run. At first I thought it was a frameRate issue but determined that the Processing instance was still running. From [Processing](http://processingjs.org/learning/): "The draw function loops continuously unless you tell it otherwise by using the exit() command." I think another draw function is started each time Run.  

```python
from processing import *
import math

def setup():
  size(203, 500)
  frameRate(60)
  global position
  position = PVector(environment.width / 2, environment.height / 4)
  global direction
  direction = PVector(1, 1)
  global r
  r = 20

def draw():
  background(color(255, 255, 255))
  position.x += direction.x
  position.y += direction.y

  if position.x + r > environment.width:
    position.x = environment.width - r
    direction.x = -1
  elif position.x - r < 0:
    position.x = r
    direction.x = 1
  if position.y + r > environment.height:
    position.y = environment.height - r
    direction.y = -1
  elif position.y < r:
    position.y = r
    direction.y = 1
  fill(color(255, 0, 0))
  ellipse(position.x, position.y, 2 * r, 2 * r)
  
run()
```