### PR TITLE
Fix issue #536

### DIFF
--- a/src/str.js
+++ b/src/str.js
@@ -428,6 +428,7 @@ Sk.builtin.str.prototype["rpartition"] = new Sk.builtin.func(function (self, sep
 });
 
 Sk.builtin.str.prototype["count"] = new Sk.builtin.func(function (self, pat, start, end) {
+    var normaltext;
     var ctl;
     var slice;
     var m;
@@ -456,7 +457,8 @@ Sk.builtin.str.prototype["count"] = new Sk.builtin.func(function (self, pat, sta
         end = end >= 0 ? end : self.v.length + end;
     }
 
-    m = new RegExp(pat.v, "g");
+    normaltext = pat.v.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+    m = new RegExp(normaltext, "g");
     slice = self.v.slice(start, end);
     ctl = slice.match(m);
     if (!ctl) {

--- a/test/unit/test_strcount.py
+++ b/test/unit/test_strcount.py
@@ -1,0 +1,37 @@
+import unittest
+
+class string_count(unittest.TestCase):
+    def test_singles(self):
+        self.assertEqual(1, 'abc'.count('a'))
+        self.assertEqual(2, 'abcab'.count('b'))
+        self.assertEqual(2, 'abc..abc'.count('.'))
+
+    def test_multiples(self):
+        self.assertEqual(2, 'abab'.count('ab'))
+        self.assertEqual(2, 'abcab'.count('ab'))
+
+        self.assertEqual(1, 'aaa'.count('aa'))
+
+    def test_specials(self):
+        self.assertEqual(2, '-abc-'.count('-'))
+        self.assertEqual(2, '[[abc]'.count('['))
+        self.assertEqual(2, '\\abc\\'.count('\\'))
+        self.assertEqual(4, ']]]abc]'.count(']'))
+        self.assertEqual(2, '{{}}'.count('{'))
+        self.assertEqual(3, '{}}}'.count('}'))
+        self.assertEqual(1, '(abc]'.count('('))
+        self.assertEqual(2, 'abc))'.count(')'))
+        self.assertEqual(3, 'a*b*c*d'.count('*'))
+        self.assertEqual(2, 'a+b+c'.count('+'))
+        self.assertEqual(2, '?abc?'.count('?'))
+        self.assertEqual(2, 'abc..abc'.count('.'))
+        self.assertEqual(4, 'a, b, c, d, '.count(','))
+        self.assertEqual(1, 'a^b*c'.count('^'))
+        self.assertEqual(3, '$$$'.count('$'))
+        self.assertEqual(2, 'a|b|c'.count('|'))
+        self.assertEqual(1, '#abc'.count('#'))
+        self.assertEqual(1, ' '.count(' '))
+        self.assertEqual(3, '   '.count(' '))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
str.count('.') now first escapes all the special regex characters.