### PR TITLE
Unpack reverse before comparison for sorted()

### DIFF
--- a/src/sorted.js
+++ b/src/sorted.js
@@ -4,6 +4,16 @@ Sk.builtin.sorted = function sorted (iterable, cmp, key, reverse) {
     var iter;
     var compare_func;
     var list;
+    var rev;
+
+    if (reverse === undefined) {
+        rev = false;
+    } else if (reverse === Sk.builtin.none.none$) {
+        throw new Sk.builtin.TypeError("an integer is required");
+    } else {
+        rev = Sk.misceval.isTrue(reverse);
+    }
+
     if (key !== undefined && !(key instanceof Sk.builtin.none)) {
         if (cmp instanceof Sk.builtin.none || cmp === undefined) {
             compare_func = function (a, b) {
@@ -35,7 +45,7 @@ Sk.builtin.sorted = function sorted (iterable, cmp, key, reverse) {
         list.list_sort_(list);
     }
 
-    if (reverse) {
+    if (rev) {
         list.list_reverse_(list);
     }
 

--- a/test/unit/test_list.py
+++ b/test/unit/test_list.py
@@ -63,6 +63,13 @@ class IterInheritsTestCase(unittest.TestCase):
         r = sorted(a,reverse=True)
         self.assertEqual(list(r), list(range(19, -1, -1)))
 
+    def test_explicit_not_reversed(self):
+        a = list(range(20))
+        # r = sorted(a,reverse=False)
+        # self.assertEqual(list(r), list(a)))
+        r = sorted(a,reverse=False)
+        self.assertEqual(r, a)
+
     def test_delitem(self):
         self.type2test = list
         a = self.type2test([0, 1])

--- a/test/unit/test_list.py
+++ b/test/unit/test_list.py
@@ -65,8 +65,6 @@ class IterInheritsTestCase(unittest.TestCase):
 
     def test_explicit_not_reversed(self):
         a = list(range(20))
-        # r = sorted(a,reverse=False)
-        # self.assertEqual(list(r), list(a)))
         r = sorted(a,reverse=False)
         self.assertEqual(r, a)
 


### PR DESCRIPTION
Fixes #459.

The issue is that currently, calling sorted([2, 3, 1], reverse=False) returns [3, 2, 1] (same as sorted([2, 3, 1], reverse=True). This is my first time contributing, please let me know anything I can do to make this more correct. Thanks!