### PR TITLE
Add keyword arg names for some turtle methods

### DIFF
--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -585,7 +585,9 @@ function generateTurtleModule(_target) {
                 {angle:this._angle, radians: this._radians}
             );
         };
-        proto.$degrees.returnType = Types.FLOAT;
+        proto.$degrees.minArgs     = 0;
+        proto.$degrees.keywordArgs = ["fullcircle"];
+        proto.$degrees.returnType  = Types.FLOAT;
 
         proto.$radians = function() {
             if (!this._isRadians) {
@@ -819,6 +821,7 @@ function generateTurtleModule(_target) {
             return this._speed;
         };
         proto.$speed.minArgs = 0;
+        proto.$speed.keywordArgs = ["speed"];
 
         proto.$pencolor = function(r,g,b,a) {
             var color;
@@ -986,6 +989,7 @@ function generateTurtleModule(_target) {
             return this._size;
         };
         proto.$pensize.minArgs = proto.$width.minArgs = 0;
+        proto.$pensize.keywordArgs = proto.$width.keywordArgs = ["width"];
 
         proto.$showturtle = proto.$st = function() {
             this._shown = true;
@@ -1009,7 +1013,8 @@ function generateTurtleModule(_target) {
 
             return this._shape;
         };
-        proto.$shape.minArgs = 0;
+        proto.$shape.minArgs     = 0;
+        proto.$shape.keywordArgs = ["name"];
 
         proto.$window_width = function() {
             return this._screen.$window_width();
@@ -1022,7 +1027,8 @@ function generateTurtleModule(_target) {
         proto.$tracer = function(n, delay) {
             return this._screen.$tracer(n, delay);
         };
-        proto.$tracer.minArgs = 0;
+        proto.$tracer.minArgs     = 0;
+        proto.$tracer.keywordArgs = ["n", "delay"];
         
         proto.$update = function() {
             return this._screen.$update();
@@ -1031,7 +1037,8 @@ function generateTurtleModule(_target) {
         proto.$delay = function(delay) {
             return this._screen.$delay(delay);
         };
-        proto.$delay.minArgs = 0;
+        proto.$delay.minArgs     = 0;
+        proto.$delay.keywordArgs = ["delay"];
 
         proto.$reset = function() {
             this.reset();
@@ -1233,8 +1240,8 @@ function generateTurtleModule(_target) {
 
             return this._setworldcoordinates(-width/2, -height/2, width/2, height/2);
         };
-        proto.$setup.minArgs = 2;
-
+        proto.$setup.minArgs     = 0;
+        proto.$setup.keywordArgs = ["width", "height", "startx", "starty"];
 
         proto.$register_shape = proto.$addshape = function(name, points) {
             SHAPES[name] = points;


### PR DESCRIPTION
Without this patch some turtle methods accept only unnamed keywords arguments. For example, this works:

`turtle.Screen().setup(400, 400)`

but this fails with the error `got an unexpected keyword argument`:

`turtle.Screen().setup(width=400, height=400)`

Fixes #483