### PR TITLE
Fix bug in input

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -803,7 +803,7 @@ Sk.builtin.setattr = function setattr (obj, name, value) {
 Sk.builtin.raw_input = function (prompt) {
     var sys = Sk.importModule("sys");
     if (prompt) {
-        Sk.misceval.callsimOrSuspend(sys["$d"]["stdout"]["write"], sys["$d"]["stdout"], prompt);
+        Sk.misceval.callsimOrSuspend(sys["$d"]["stdout"]["write"], sys["$d"]["stdout"], new Sk.builtin.str(prompt));
     }
     return Sk.misceval.callsimOrSuspend(sys["$d"]["stdin"]["readline"], sys["$d"]["stdin"]);
 };

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -802,7 +802,9 @@ Sk.builtin.setattr = function setattr (obj, name, value) {
 
 Sk.builtin.raw_input = function (prompt) {
     var sys = Sk.importModule("sys");
-    Sk.misceval.callsimOrSuspend(sys["$d"]["stdout"]["write"], sys["$d"]["stdout"], prompt);
+    if (prompt) {
+        Sk.misceval.callsimOrSuspend(sys["$d"]["stdout"]["write"], sys["$d"]["stdout"], prompt);
+    }
     return Sk.misceval.callsimOrSuspend(sys["$d"]["stdin"]["readline"], sys["$d"]["stdin"]);
 };
 

--- a/test/unit/test_StringIO.py
+++ b/test/unit/test_StringIO.py
@@ -18,6 +18,25 @@ class TestGenericStringIO(unittest.TestCase):
     def setup(self):
         self._fp = StringIO.StringIO(self._lines)
 
+    def test_input(self):
+        #with prompt
+        teststdout = StringIO.StringIO();
+        sys.stdin = StringIO.StringIO("test input")
+        sys.stdout = teststdout
+        res = raw_input("test prompt")
+        sys.stdout = sys.__stdout__
+        self.assertEqual(res, "test input")
+        self.assertEqual(teststdout.getvalue(), "test prompt")
+
+        #without prompt
+        sys.stdin = StringIO.StringIO("test input")
+        teststdout = StringIO.StringIO();
+        sys.stdout = teststdout
+        res = raw_input()
+        sys.stdout = sys.__stdout__
+        sys.stdin = sys.__stdin__
+        self.assertEqual(res, "test input")
+
     def test_reads(self):
         eq = self.assertEqual
         self.assertRaises(TypeError, self._fp.seek)


### PR DESCRIPTION
This fixes a bug in the new implementation of `raw_input` that would break if no prompt was given.