### PR TITLE
Prevent dict.__getattr__() from exploding

### DIFF
--- a/src/dict.js
+++ b/src/dict.js
@@ -481,7 +481,7 @@ Sk.builtin.dict.prototype.__len__ = new Sk.builtin.func(function (self) {
 
 Sk.builtin.dict.prototype.__getattr__ = new Sk.builtin.func(function (self, attr) {
     Sk.builtin.pyCheckArgs("__getattr__", arguments, 1, 1, false, true);
-    return Sk.builtin.dict.prototype.tp$getattr.call(self, attr);
+    return Sk.builtin.dict.prototype.tp$getattr.call(self, Sk.ffi.remapToJs(attr));
 });
 
 Sk.builtin.dict.prototype.__iter__ = new Sk.builtin.func(function (self) {

--- a/src/dict.js
+++ b/src/dict.js
@@ -481,6 +481,7 @@ Sk.builtin.dict.prototype.__len__ = new Sk.builtin.func(function (self) {
 
 Sk.builtin.dict.prototype.__getattr__ = new Sk.builtin.func(function (self, attr) {
     Sk.builtin.pyCheckArgs("__getattr__", arguments, 1, 1, false, true);
+    if (!Sk.builtin.checkString(attr)) { throw new Sk.builtin.TypeError("__getattr__ requires a string"); }
     return Sk.builtin.dict.prototype.tp$getattr.call(self, Sk.ffi.remapToJs(attr));
 });
 

--- a/test/unit/test_dict.py
+++ b/test/unit/test_dict.py
@@ -193,5 +193,12 @@ class DictTest(unittest.TestCase):
         self.assertRaises(TypeError, d.get)
         self.assertRaises(TypeError, d.get, None, None, None)
 
+    def test_attrib(self):
+        d = {}
+        def do_set():
+            d.x = 42
+        self.assertRaises(AttributeError, do_set)
+        self.assertRaises(AttributeError, lambda: d.x)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It was getting an unpleasant `AssertionError`, rather than the correct `AttributeError`. Fix it by remapping arguments correctly.

Also added my first new-style unit test for it (they're nice! Yes, I'm behind the times :-P)
