### PR TITLE
Improve optimisability of Sk.misceval.chain()

### DIFF
--- a/src/misceval.js
+++ b/src/misceval.js
@@ -981,7 +981,13 @@ goog.exportSymbol("Sk.misceval.applyAsync", Sk.misceval.applyAsync);
  */
 
 Sk.misceval.chain = function (initialValue, chainedFns) {
-    var fs = arguments, i = 1;
+    var fs = new Array(arguments.length), i = 1;
+
+    for (i = 1; i < arguments.length; i++) {
+        fs[i] = arguments[i];
+    }
+
+    i = 1;
 
     return (function nextStep(r) {
         while (i < fs.length) {


### PR DESCRIPTION
Realising the `arguments` makes the V8 optimiser bail out. While this isn't the most glaring performance bottleneck in Skulpt, it was contributing to some performance issues in Anvil.