### PR TITLE
Make the `in` operation suspendable

### DIFF
--- a/skulpt.py
+++ b/skulpt.py
@@ -1036,7 +1036,9 @@ def rununits(opt=False, p3=False):
 var input = read('%s');
 print('%s');
 Sk.configure({syspath:["%s"], read:read, python3:%s});
-Sk.importMain("%s", false);
+Sk.misceval.asyncToPromise(function() {
+    Sk.importMain("%s", false, true);
+}).then(quit, function(e) { throw e; });
         """ % (fn, fn, os.path.split(fn)[0], p3on, modname))
         f.close()
         if opt:

--- a/src/compile.js
+++ b/src/compile.js
@@ -475,9 +475,10 @@ Compiler.prototype.ccompare = function (e) {
 
     for (i = 0; i < n; ++i) {
         rhs = this.vexpr(e.comparators[i]);
-        res = this._gr("compare", "Sk.builtin.bool(Sk.misceval.richCompareBool(", cur, ",", rhs, ",'", e.ops[i].prototype._astname, "'))");
-        out(fres, "=", res, ";");
-        this._jumpfalse(res, done);
+        out("$ret = Sk.builtin.bool(Sk.misceval.richCompareBool(", cur, ",", rhs, ",'", e.ops[i].prototype._astname, "', true));");
+        this._checkSuspension(e);
+        out(fres, "=$ret;");
+        this._jumpfalse("$ret", done);
         cur = rhs;
     }
     this._jump(done);

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -211,8 +211,13 @@ Sk.misceval.swappedOp_ = {
     "NotIn": "In_"
 };
 
-
-Sk.misceval.richCompareBool = function (v, w, op) {
+/**
+* @param{*} v
+* @param{*} w
+* @param{string} op
+* @param{boolean=} canSuspend
+ */
+Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     // v and w must be Python objects. will return Javascript true or false for internal use only
     // if you want to return a value from richCompareBool to Python you must wrap as Sk.builtin.bool first
     var wname,
@@ -363,10 +368,11 @@ Sk.misceval.richCompareBool = function (v, w, op) {
     }
 
     if (op === "In") {
-        return Sk.misceval.isTrue(Sk.abstr.sequenceContains(w, v));
+        return Sk.misceval.chain(Sk.abstr.sequenceContains(w, v, canSuspend), Sk.misceval.isTrue);
     }
     if (op === "NotIn") {
-        return !Sk.misceval.isTrue(Sk.abstr.sequenceContains(w, v));
+        return Sk.misceval.chain(Sk.abstr.sequenceContains(w, v, canSuspend),
+                                 function(x) { return !Sk.misceval.isTrue(x); });
     }
 
     // Call Javascript shortcut method if exists for either object
@@ -1028,6 +1034,73 @@ Sk.misceval.tryCatch = function (tryFn, catchFn) {
     }
 };
 goog.exportSymbol("Sk.misceval.tryCatch", Sk.misceval.tryCatch);
+
+/**
+ * Perform a suspension-aware for-each on an iterator, without
+ * blowing up the stack.
+ * forFn() is called for each element in the iterator, with two
+ * arguments: the current element and the previous return value
+ * of forFn() (or initialValue on the first call). In this way,
+ * iterFor() can be used as a simple for loop, or alternatively
+ * as a 'reduce' operation. The return value of the final call to
+ * forFn() will be the return value of iterFor() (after all
+ * suspensions are resumed, that is; if the iterator is empty then
+ * initialValue will be returned.)
+ *
+ * The iteration can be terminated early, by returning
+ * an instance of Sk.misceval.Break. If an argument is given to
+ * the Sk.misceval.Break() constructor, that value will be
+ * returned from iterFor(). It is therefore possible to use
+ * iterFor() on infinite iterators.
+ *
+ * @param {*} iter
+ * @param {function(*,*=)} forFn
+ * @param {*=} initialValue
+ */
+Sk.misceval.iterFor = function (iter, forFn, initialValue) {
+    var prevValue = initialValue;
+
+    var breakOrIterNext = function(r) {
+        prevValue = r;
+        return (r instanceof Sk.misceval.Break) ? r : iter.tp$iternext(true);
+    };
+
+    return (function nextStep(i) {
+        while (i !== undefined) {
+            if (i instanceof Sk.misceval.Suspension) {
+                return new Sk.misceval.Suspension(nextStep, i);
+            }
+
+            if (i === Sk.misceval.Break || i instanceof Sk.misceval.Break) {
+                return i.brValue;
+            }
+
+            i = Sk.misceval.chain(
+                forFn(i, prevValue),
+                breakOrIterNext
+            );
+        }
+        return prevValue;
+    })(iter.tp$iternext(true));
+};
+goog.exportSymbol("Sk.misceval.iterFor", Sk.misceval.iterFor);
+
+/**
+ * A special value to return from an iterFor() function,
+ * to abort the iteration. Optionally supply a value for iterFor() to return
+ * (defaults to 'undefined')
+ *
+ * @constructor
+ * @param {*=}  brValue
+ */
+Sk.misceval.Break = function(brValue) {
+    if (!(this instanceof Sk.misceval.Break)) {
+        return new Sk.misceval.Break(brValue);
+    }
+
+    this.brValue = brValue;
+};
+goog.exportSymbol("Sk.misceval.Break", Sk.misceval.Break);
 
 /**
  * same as Sk.misceval.call except args is an actual array, rather than

--- a/test/unit/test_contains.py
+++ b/test/unit/test_contains.py
@@ -1,4 +1,5 @@
 import unittest
+from time import sleep
 
 class base_set:
     def __init__(self, el):
@@ -99,6 +100,14 @@ class TestContains(unittest.TestCase):
         except TypeError:
             pass
 
+
+    def test_suspending_generator(self):
+        def gen():
+            sleep(0.0001)
+            yield 42
+
+        self.assertIn(42, gen())
+        self.assertNotIn(43, gen())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR makes it possible to use the `in` operator over suspendable generators.

It also introduces the `iterFor` function, which makes loops over suspending iterators a much more pleasant experience.

Testing it also required allowing unit tests to suspend.