### PR TITLE
Fixes call to the PVector::normalize method in processing.

### DIFF
--- a/src/lib/processing.js
+++ b/src/lib/processing.js
@@ -1871,7 +1871,7 @@ var $builtinmodule = function (name) {
 
 	$loc.normalize = new Sk.builtin.func(function (self) {
 	    // normalize()	Normalizes the vector
-	    self.v.normalize(vec.v);
+	    self.v.normalize();
 	});
 
 	$loc.limit = new Sk.builtin.func(function (self, value) {


### PR DESCRIPTION
The `PVector::normalize` method was referencing an undefined variable and throwing an error any time it was called.