### PR TITLE
changing input method in case integer value is entered in prompt.

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -809,16 +809,16 @@ Sk.builtin.raw_input = function (prompt) {
 };
 
 Sk.builtin.input = function (prompt) {
-  var raw_input = Sk.builtin.raw_input(prompt);
+    var raw_input = Sk.builtin.raw_input(prompt);
 
-  if (raw_input instanceof Sk.builtin.str) {
-    try {
-      return new Sk.builtin.int_(raw_input);
-    } catch (err) {
-      //do nothing, this is not a number
+    if (raw_input instanceof Sk.builtin.str) {
+        try {
+            return new Sk.builtin.int_(raw_input);
+        } catch (err) {
+            //do nothing, this is not a number
+        }
     }
-  }
-  return raw_input;
+    return raw_input;
 };
 
 Sk.builtin.jseval = function jseval (evalcode) {

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -808,7 +808,18 @@ Sk.builtin.raw_input = function (prompt) {
     return Sk.misceval.callsimOrSuspend(sys["$d"]["stdin"]["readline"], sys["$d"]["stdin"]);
 };
 
-Sk.builtin.input = Sk.builtin.raw_input;
+Sk.builtin.input = function (prompt) {
+  var raw_input = Sk.builtin.raw_input(prompt);
+
+  if (raw_input instanceof Sk.builtin.str) {
+    try {
+      return new Sk.builtin.int_(raw_input);
+    } catch (err) {
+      //do nothing, this is not a number
+    }
+  }
+  return raw_input;
+};
 
 Sk.builtin.jseval = function jseval (evalcode) {
     goog.global["eval"](evalcode);


### PR DESCRIPTION
In its current implementation, the input method returns the same value as returned by the raw_input function. However, the input function is expected to return an integer value in case an integer is entered, else a string.

Please review this pull request. If changes are required in other places as part of best practices, let me know and I can work on it.