### PR TITLE
Remap bools correctly in Sk.ffi.remapToPy()

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -34,7 +34,7 @@ Sk.ffi.remapToPy = function (obj) {
     } else if (typeof obj === "number") {
         return Sk.builtin.assk$(obj);
     } else if (typeof obj === "boolean") {
-        return obj;
+        return new Sk.builtin.bool(obj);
     }
     goog.asserts.fail("unhandled remap type " + typeof(obj));
 };


### PR DESCRIPTION
JS bools were not being turned into `Sk.builtin.bool`s. This patch fixes that.