### PR TITLE
Make custom iterators suspendable, and fix StopIteration

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -918,7 +918,7 @@ Sk.abstr.iter = function(obj) {
             try {
                 ret = Sk.misceval.callsim(this.getitem, this.myobj, Sk.ffi.remapToPy(this.idx));
             } catch (e) {
-                if (e instanceof Sk.builtin.IndexError) {
+                if (e instanceof Sk.builtin.IndexError || e instanceof Sk.builtin.StopIteration) {
                     return undefined;
                 } else {
                     throw e;

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -932,7 +932,10 @@ Sk.abstr.iter = function(obj) {
     if (obj.tp$getattr) {
         iter =  Sk.abstr.lookupSpecial(obj,"__iter__");
         if (iter) {
-            return Sk.misceval.callsim(iter,obj);
+            ret = Sk.misceval.callsim(iter, obj);
+            if (ret.tp$iternext) {
+                return ret;
+            }
         }
     }
     if (obj.tp$iter) {

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -54,6 +54,7 @@ Sk.builtins = {
     "OverflowError"      : Sk.builtin.OverflowError,
     "OperationError"     : Sk.builtin.OperationError,
     "RuntimeError"       : Sk.builtin.RuntimeError,
+    "StopIteration"      : Sk.builtin.StopIteration,
 
     "dict"      : Sk.builtin.dict,
     "file"      : Sk.builtin.file,

--- a/src/compile.js
+++ b/src/compile.js
@@ -1162,42 +1162,32 @@ Compiler.prototype.cfor = function (s) {
 };
 
 Compiler.prototype.craise = function (s) {
-    var inst, exc;
-    if (s && s.type && s.type.id && (s.type.id.v === "StopIteration")) {
-        // currently, we only handle StopIteration, and all it does it return
-        // undefined which is what our iterator protocol requires.
-        //
-        // totally hacky, but good enough for now.
-        out("return undefined;");
+    var inst = "", exc;
+    if (s.inst) {
+        // handles: raise Error, arguments
+        inst = this.vexpr(s.inst);
+        out("throw ", this.vexpr(s.type), "(", inst, ");");
     }
-    else {
-        inst = "";
-        if (s.inst) {
-            // handles: raise Error, arguments
-            inst = this.vexpr(s.inst);
-            out("throw ", this.vexpr(s.type), "(", inst, ");");
-        }
-        else if (s.type) {
-            if (s.type.func) {
-                // handles: raise Error(arguments)
-                out("throw ", this.vexpr(s.type), ";");
-            }
-            else {
-                // handles: raise Error OR raise someinstance
-                exc = this._gr("err", this.vexpr(s.type));
-                out("if(",exc," instanceof Sk.builtin.type) {",
-                    "throw Sk.misceval.callsim(", exc, ");",
-                    "} else if(typeof(",exc,") === 'function') {",
-                    "throw ",exc,"();",
-                    "} else {",
-                    "throw ", exc, ";",
-                    "}");
-            }
+    else if (s.type) {
+        if (s.type.func) {
+            // handles: raise Error(arguments)
+            out("throw ", this.vexpr(s.type), ";");
         }
         else {
-            // re-raise
-            out("throw $err;");
+            // handles: raise Error OR raise someinstance
+            exc = this._gr("err", this.vexpr(s.type));
+            out("if(",exc," instanceof Sk.builtin.type) {",
+                "throw Sk.misceval.callsim(", exc, ");",
+                "} else if(typeof(",exc,") === 'function') {",
+                "throw ",exc,"();",
+                "} else {",
+                "throw ", exc, ";",
+                "}");
         }
+    }
+    else {
+        // re-raise
+        out("throw $err;");
     }
 };
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -541,5 +541,22 @@ Sk.builtin.SystemError = function (args) {
 Sk.abstr.setUpInheritance("SystemError", Sk.builtin.SystemError, Sk.builtin.StandardError);
 goog.exportSymbol("Sk.builtin.SystemError", Sk.builtin.SystemError);
 
+/**
+ * @constructor
+ * @extends Sk.builtin.Exception
+ * @param {...*} args
+ */
+Sk.builtin.StopIteration = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.StopIteration)) {
+        o = Object.create(Sk.builtin.StopIteration.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.Exception.apply(this, arguments);
+};
+Sk.abstr.setUpInheritance("StopIteration", Sk.builtin.StopIteration, Sk.builtin.Exception);
+goog.exportSymbol("Sk.builtin.StopIteration", Sk.builtin.StopIteration);
+
 
 goog.exportSymbol("Sk", Sk);

--- a/src/type.js
+++ b/src/type.js
@@ -290,20 +290,20 @@ Sk.builtin.type = function (name, bases, dict) {
             }
             throw new Sk.builtin.TypeError("'" + tname + "' object is not iterable");
         };
-        klass.prototype.tp$iternext = function () {
+        klass.prototype.tp$iternext = function (canSuspend) {
+            var r;
             var iternextf = this.tp$getattr("next");
-            var ret;
             if (iternextf) {
-                try {
-                    ret = Sk.misceval.callsim(iternextf);
-                } catch (e) {
+                r = Sk.misceval.tryCatch(function() {
+                    return Sk.misceval.callsimOrSuspend(iternextf);
+                }, function(e) {
                     if (e instanceof Sk.builtin.StopIteration) {
-                        ret = undefined;
+                        return undefined;
                     } else {
                         throw e;
                     }
-                }
-                return ret;
+                });
+                return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
             }
         };
 

--- a/test/unit/test_iter.py
+++ b/test/unit/test_iter.py
@@ -1,4 +1,5 @@
 import unittest
+from time import sleep
 # from test.test_support import run_unittest, TESTFN, unlink, have_unicode, \
 #                               check_py3k_warnings, cpython_only
 
@@ -33,6 +34,19 @@ class IteratingSequenceClass:
         self.n = n
     def __iter__(self):
         return BasicIterClass(self.n)
+
+class SleepingIterClass(BasicIterClass):
+    def __init__(self, n):
+        BasicIterClass.__init__(self, n)
+    def next(self):
+        sleep(0.01)
+        return BasicIterClass.next(self)
+
+class SleepingSequenceClass:
+    def __init__(self, n):
+        self.n = n
+    def __iter__(self):
+        return SleepingIterClass(self.n)
 
 class SequenceClass:
     def __init__(self, n):
@@ -106,6 +120,10 @@ class TestCase(unittest.TestCase):
     # Test a class with __iter__ in a for loop
     def test_iter_class_for(self):
         self.check_for_loop(IteratingSequenceClass(10), range(10))
+
+    # Test a class with a suspending iterator in a for loop
+    def test_iter_sleeping_class_for(self):
+        self.check_for_loop(SleepingSequenceClass(10), range(10))
 
     # Test a class with __iter__ with explicit iter()
     # def test_iter_class_iter(self):
@@ -189,6 +207,32 @@ class TestCase(unittest.TestCase):
             self.assertEqual(res, range(10))
         else:
             self.fail("should have raised RuntimeError")
+
+    # Test exception propagation through explicit iterator
+    #def test_exception_iter(self):
+    #    class MyIterClass(object):
+    #        def __init__(self):
+    #            self.i = -1
+    #            SequenceClass.__init__(self)
+
+    #        def next(self):
+    #            self.i += 1
+    #            if self.i == 10:
+    #                raise RuntimeError
+    #            return self.i
+
+    #    class MySequenceClass(SequenceClass):
+    #        def __iter__(self):
+    #            return MyIterClass()
+
+    #    res = []
+    #    try:
+    #        for x in MySequenceClass(20):
+    #            res.append(x)
+    #    except RuntimeError:
+    #        self.assertEqual(res, range(10))
+    #    else:
+    #        self.fail("should have raised RuntimeError")
 
     # Test for StopIteration from __getitem__
     def test_stop_sequence(self):


### PR DESCRIPTION
`raise StopIteration` used to be a horrible hack; it is now an exception (as in Python) that is caught in the shim code between `tp$iternext` and user code.

Also makes `next()` suspendable (but not `__iter__`, yet)