### PR TITLE
Fix tuple comparison to other types and fix failing tests.

### DIFF
--- a/src/tuple.js
+++ b/src/tuple.js
@@ -154,7 +154,8 @@ Sk.builtin.tuple.prototype.tp$richcompare = function (w, op) {
     var wl;
     var vl;
     var v;
-    if (!w.__class__ || !Sk.builtin.isinstance(w, Sk.builtin.tuple)) {
+    if (!w.__class__ ||
+        !Sk.misceval.isTrue(Sk.builtin.isinstance(w, Sk.builtin.tuple))) {
         // shortcuts for eq/not
         if (op === "Eq") {
             return false;

--- a/test/unit/test_calling.py
+++ b/test/unit/test_calling.py
@@ -20,39 +20,39 @@ class C:
 class BuiltinTest(unittest.TestCase):
 
     def test_simple_call(self):
-        self.assertEqual(f1(1, 2), (1, 2, [], {}))
+        self.assertEqual(f1(1, 2), (1, 2, (), {}))
         self.assertRaises(TypeError, lambda: f1(1))
-        self.assertEqual(f2(1), (1, None, [], {}))
+        self.assertEqual(f2(1), (1, None, (), {}))
 
-        self.assertEqual(f1(1, 2, 3, 4), (1, 2, [3, 4], {}))
-        self.assertEqual(f1(1, y=2), (1, 2, [], {}))
-        self.assertEqual(f1(1, z=3, y=2), (1, 2, [], {'z': 3}))
+        self.assertEqual(f1(1, 2, 3, 4), (1, 2, (3, 4), {}))
+        self.assertEqual(f1(1, y=2), (1, 2, (), {}))
+        self.assertEqual(f1(1, z=3, y=2), (1, 2, (), {'z': 3}))
         self.assertRaises(TypeError, lambda: f1(1, 2, y=3))
 
-        self.assertEqual(f1(1, *[2, 3]), (1, 2, [3], {}))
-        self.assertEqual(f1(**{'x': 1, 'y': 2}), (1, 2, [], {}))
-        self.assertEqual(f1(**{'x': 1, 'y': 2, 'z': 3}), (1, 2, [], {'z': 3}))
-        self.assertEqual(f1(*[1, 2, 3], **{'z': 4}), (1, 2, [3], {'z': 4}))
+        self.assertEqual(f1(1, *[2, 3]), (1, 2, (3,), {}))
+        self.assertEqual(f1(**{'x': 1, 'y': 2}), (1, 2, (), {}))
+        self.assertEqual(f1(**{'x': 1, 'y': 2, 'z': 3}), (1, 2, (), {'z': 3}))
+        self.assertEqual(f1(*[1, 2, 3], **{'z': 4}), (1, 2, (3,), {'z': 4}))
         self.assertRaises(TypeError, lambda: f1(*[1, 2, 3], **{'y', 4}))
 
 
     def test_method_call(self):
         o = C()
 
-        self.assertEqual(o.f1(1, 2), (o, 1, 2, [], {}))
+        self.assertEqual(o.f1(1, 2), (o, 1, 2, (), {}))
         self.assertRaises(TypeError, lambda: o.f1(1))
-        self.assertEqual(o.f2(1), (o, 1, None, [], {}))
+        self.assertEqual(o.f2(1), (o, 1, None, (), {}))
 
-        self.assertEqual(o.f1(1, 2, 3, 4), (o, 1, 2, [3, 4], {}))
-        self.assertEqual(o.f1(1, y=2), (o, 1, 2, [], {}))
-        self.assertEqual(o.f1(1, z=3, y=2), (o, 1, 2, [], {'z': 3}))
+        self.assertEqual(o.f1(1, 2, 3, 4), (o, 1, 2, (3, 4), {}))
+        self.assertEqual(o.f1(1, y=2), (o, 1, 2, (), {}))
+        self.assertEqual(o.f1(1, z=3, y=2), (o, 1, 2, (), {'z': 3}))
         self.assertRaises(TypeError, lambda: o.f1(1, 2, y=3))
         self.assertRaises(TypeError, lambda: o.f1(1, 2, self=3))
 
-        self.assertEqual(o.f1(1, *[2, 3]), (o, 1, 2, [3], {}))
-        self.assertEqual(o.f1(**{'x': 1, 'y': 2}), (o, 1, 2, [], {}))
-        self.assertEqual(o.f1(**{'x': 1, 'y': 2, 'z': 3}), (o, 1, 2, [], {'z': 3}))
-        self.assertEqual(o.f1(*[1, 2, 3], **{'z': 4}), (o, 1, 2, [3], {'z': 4}))
+        self.assertEqual(o.f1(1, *[2, 3]), (o, 1, 2, (3,), {}))
+        self.assertEqual(o.f1(**{'x': 1, 'y': 2}), (o, 1, 2, (), {}))
+        self.assertEqual(o.f1(**{'x': 1, 'y': 2, 'z': 3}), (o, 1, 2, (), {'z': 3}))
+        self.assertEqual(o.f1(*[1, 2, 3], **{'z': 4}), (o, 1, 2, (3,), {'z': 4}))
         self.assertRaises(TypeError, lambda: o.f1(*[1, 2, 3], **{'y', 4}))
 
 


### PR DESCRIPTION
The recently added test_calling.py fails when called from CPython.  The problem is that ```*args``` is a tuple, but the assertions were expecting a list.  I think this highlights that we should run the unittests through CPython in travis so that we can test the tests, so to speak, before we merge them.

Fixing the tests exposed a bug.  The bugfix is simple, as we were not properly checking if we were comparing to a different type in the tuple ```tp$richcompare``` function.