### PR TITLE
Use test.test_support to be compatible with CPython.

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -574,8 +574,8 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
                 if (fromName != "*" && ret.$d[fromName] == null && (ret.$d[dottedName] != null || ret.$d.__name__.v == dottedName)) {
                     // add the module name to our requiredImport list
                     fromImportName = "" + name + "." + fromName;
-                    fromNameRet = Sk.importModuleInternal_(fromImportName, undefined, undefined, undefined, true, currentDir);
-                    ret["$d"][fromName] = Sk.abstr.gattr(fromNameRet, fromName, true);
+                    fromNameRet = Sk.importModuleInternal_(fromImportName, undefined, undefined, undefined, false, currentDir);
+                    ret["$d"][fromName] = Sk.abstr.gattr(fromNameRet, fromName, false);
                 }
             }
         }

--- a/src/import.js
+++ b/src/import.js
@@ -574,8 +574,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
                 if (fromName != "*" && ret.$d[fromName] == null && (ret.$d[dottedName] != null || ret.$d.__name__.v == dottedName)) {
                     // add the module name to our requiredImport list
                     fromImportName = "" + name + "." + fromName;
-                    fromNameRet = Sk.importModuleInternal_(fromImportName, undefined, undefined, undefined, false, currentDir);
-                    ret["$d"][fromName] = Sk.abstr.gattr(fromNameRet, fromName, false);
+                    Sk.importModuleInternal_(fromImportName, undefined, undefined, undefined, false, currentDir);
                 }
             }
         }

--- a/src/import.js
+++ b/src/import.js
@@ -575,7 +575,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
                     // add the module name to our requiredImport list
                     fromImportName = "" + name + "." + fromName;
                     fromNameRet = Sk.importModuleInternal_(fromImportName, undefined, undefined, undefined, true, currentDir);
-                    ret["$d"][fromName] = fromNameRet;
+                    ret["$d"][fromName] = Sk.abstr.gattr(fromNameRet, fromName, true);
                 }
             }
         }

--- a/src/import.js
+++ b/src/import.js
@@ -564,7 +564,6 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
         } else {
             // try to load the module from the file system if it is not present on the module itself
             var i;
-            var fromNameRet; // module returned
             var fromName; // name of current module for fromlist
             var fromImportName; // dotted name
             var dottedName = name.split("."); // get last module in dotted path

--- a/src/lib/test/test_support.py
+++ b/src/lib/test/test_support.py
@@ -1,0 +1,32 @@
+"""Supporting definitions for the Python regression tests."""
+
+if __name__ != 'test.test_support':
+    raise ImportError('test_support must be imported from the test package')
+
+import unittest
+
+
+# def run_unittest(*classes):
+#     """Run tests from unittest.TestCase-derived classes."""
+#     valid_types = (unittest.TestSuite, unittest.TestCase)
+#     suite = unittest.TestSuite()
+#     for cls in classes:
+#         if isinstance(cls, str):
+#             if cls in sys.modules:
+#                 suite.addTest(unittest.findTestCases(sys.modules[cls]))
+#             else:
+#                 raise ValueError("str arguments must be keys in sys.modules")
+#         elif isinstance(cls, valid_types):
+#             suite.addTest(cls)
+#         else:
+#             suite.addTest(unittest.makeSuite(cls))
+#     _run_suite(suite)
+
+def run_unittest(*classes):
+    """Run tests from unittest.TestCase-derived classes."""
+    for cls in classes:
+        print cls
+        if issubclass(cls, unittest.TestCase):
+            cls().main()
+        else:
+            print "Don't know what to do with ", cls

--- a/src/lib/unittest/__init__.py
+++ b/src/lib/unittest/__init__.py
@@ -184,11 +184,9 @@ class TestCase:
 
 
 
-def main(verbosity=1, names=None):
+def main(verbosity=1):
     glob = globals() # globals() still needs work
-    if names == None:
-        names = glob
-    for name in names:
+    for name in glob:
         if issubclass(glob[name],TestCase):
             try:
                 tc = glob[name]()

--- a/test/unit/test_index.py
+++ b/test/unit/test_index.py
@@ -1,5 +1,5 @@
 import unittest
-#from test import test_support
+from test import test_support
 import operator
 #from sys import maxint
 #maxsize = test_support.MAX_Py_ssize_t
@@ -13,13 +13,13 @@ class oldstyle:
 #     def __index__(self):
 #         return self.ind
 
-# class TrapInt(int):
-#     def __index__(self):
-#         return self
+class TrapInt(int):
+    def __index__(self):
+        return self
 
-# class TrapLong(long):
-#     def __index__(self):
-#         return self
+class TrapLong(long):
+    def __index__(self):
+        return self
 
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
@@ -52,12 +52,12 @@ class BaseTestCase(unittest.TestCase):
         #self.assertEqual(True.__index__(), 1)
         #self.assertEqual(False.__index__(), 0)
 
-    # def test_subclasses(self):
-    #     r = range(10)
-    #     self.assertEqual(r[TrapInt(5):TrapInt(10)], r[5:10])
-    #     self.assertEqual(r[TrapLong(5):TrapLong(10)], r[5:10])
-    #     self.assertEqual(slice(TrapInt()).indices(0), (0,0,1))
-    #     self.assertEqual(slice(TrapLong(0)).indices(0), (0,0,1))
+    def test_subclasses(self):
+        r = range(10)
+        self.assertEqual(r[TrapInt(5):TrapInt(10)], r[5:10])
+        self.assertEqual(r[TrapLong(5):TrapLong(10)], r[5:10])
+        self.assertEqual(slice(TrapInt()).indices(0), (0,0,1))
+        self.assertEqual(slice(TrapLong(0)).indices(0), (0,0,1))
 
     def test_error(self):
         self.o.ind = 'dumb'
@@ -120,19 +120,19 @@ class SeqTestCase(unittest.TestCase):
         self.assertEqual(self.o * self.seq, self.seq * 3)
         #self.assertEqual(self.n * self.seq, self.seq * 2)
 
-    # def test_wrappers(self):
-    #     self.o.ind = 4
-    #     self.n.ind = 5
-    #     self.assertEqual(self.seq.__getitem__(self.o), self.seq[4])
-    #     self.assertEqual(self.seq.__mul__(self.o), self.seq * 4)
-    #     self.assertEqual(self.seq.__rmul__(self.o), self.seq * 4)
-    #     self.assertEqual(self.seq.__getitem__(self.n), self.seq[5])
-    #     self.assertEqual(self.seq.__mul__(self.n), self.seq * 5)
-    #     self.assertEqual(self.seq.__rmul__(self.n), self.seq * 5)
+    def test_wrappers(self):
+        self.o.ind = 4
+        #self.n.ind = 5
+        self.assertEqual(self.seq.__getitem__(self.o), self.seq[4])
+        self.assertEqual(self.seq.__mul__(self.o), self.seq * 4)
+        self.assertEqual(self.seq.__rmul__(self.o), self.seq * 4)
+        #self.assertEqual(self.seq.__getitem__(self.n), self.seq[5])
+        #self.assertEqual(self.seq.__mul__(self.n), self.seq * 5)
+        #self.assertEqual(self.seq.__rmul__(self.n), self.seq * 5)
 
-    # def test_subclasses(self):
-    #     self.assertEqual(self.seq[TrapInt()], self.seq[0])
-    #     self.assertEqual(self.seq[TrapLong()], self.seq[0])
+    def test_subclasses(self):
+        self.assertEqual(self.seq[TrapInt()], self.seq[0])
+        self.assertEqual(self.seq[TrapLong()], self.seq[0])
 
     def test_error(self):
         self.o.ind = 'dumb'
@@ -304,25 +304,18 @@ class StringTestCase(SeqTestCase):
 
 
 def test_main():
-    tests = ["BaseTestCase",
-             "ListTestCase",
-             "TupleTestCase",
-             "StringTestCase"]
-
-    unittest.main(False, tests)
-
-    # test_support.run_unittest(
-    #     BaseTestCase,
-    #     ListTestCase,
-    #     TupleTestCase,
-    #     ByteArrayTestCase,
-    #     StringTestCase,
-    #     UnicodeTestCase,
-    #     ClassicSeqTestCase,
-    #     NewSeqTestCase,
-    #     XRangeTestCase,
-    #     OverflowTestCase,
-    # )
+    test_support.run_unittest(
+        BaseTestCase,
+        ListTestCase,
+        TupleTestCase,
+        # ByteArrayTestCase,
+        StringTestCase,
+        # UnicodeTestCase,
+        # ClassicSeqTestCase,
+        # NewSeqTestCase,
+        # XRangeTestCase,
+        # OverflowTestCase,
+    )
     # with test_support.check_py3k_warnings():
     #     test_support.run_unittest(
     #         ClassicSeqDeprecatedTestCase,


### PR DESCRIPTION
Updates to allow more unittest files to pass in CPython.

This one requires some thought.  I am not sure that the change to import.js is correct.  It doesn't break any of the other tests, but I'm not sure if the change should be here or if ```Sk.importModuleInternal_``` should be returning something different.  So, I'd like to have multiple people look this over and think about it.

There were attempts to get importing test_support working in #310 and #450, but they are out of date at this point, so I could not just use that solution, but it may be instructive for others to look at those ideas.

(Incidentally, I also uncommented some tests in test_index.py that now pass because we have implemented more features!)