### PR TITLE
Add infrastructure to allow Skulpt to be reset.

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -58,6 +58,16 @@ Sk.configure = function (options) {
     Sk.breakpoints = options["breakpoints"] || function() { return true; };
     goog.asserts.assert(typeof Sk.breakpoints === "function");
 
+    Sk.setTimeout = options["setTimeout"];
+    if (Sk.setTimeout === undefined) {
+        if (typeof setTimeout === "function") {
+            Sk.setTimeout = setTimeout;
+        } else {
+            Sk.setTimeout = function(func, delay) { func(); };
+        }
+    }
+    goog.asserts.assert(typeof Sk.setTimeout === "function");
+
     if ("execLimit" in options) {
         Sk.execLimit = options["execLimit"];
     }

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -65,12 +65,7 @@ var $builtinmodule = function (name) {
         var susp = new Sk.misceval.Suspension();
         susp.resume = function() { return Sk.builtin.none.none$; }
         susp.data = {type: "Sk.promise", promise: new Promise(function(resolve) {
-            if (typeof setTimeout === "undefined") {
-                // We can't sleep (eg test environment), so resume immediately
-                resolve();
-            } else {
-                setTimeout(resolve, Sk.ffi.remapToJs(delay)*1000);
-            }
+            Sk.setTimeout(resolve, Sk.ffi.remapToJs(delay)*1000);
         })};
         return susp;
     });

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -930,8 +930,10 @@ Sk.misceval.asyncToPromise = function(suspendablefn, suspHandlers) {
                             r.data["promise"].then(resumeWithData, resumeWithError);
                             return;
 
-                        } else if (r.data["type"] == "Sk.yield" && typeof setTimeout === "function") {
-                            setTimeout(resume, 0);
+                        } else if (r.data["type"] == "Sk.yield") {
+                            // Assumes all yields are optional, as Sk.setTimeout might
+                            // not be able to yield.
+                            Sk.setTimeout(resume, 0);
                             return;
 
                         } else if (r.optional) {


### PR DESCRIPTION
This adds some infrastructure to allow the problem in #560 to be addressed.  Currently, if you want to reset Skulpt, you have to do so externally in the code that is driving Skulpt.  This PR allows that external code visibility to see any pending timers.  If you don't change anything, it defaults to behaving as it does now.  But, if you set ```setTimeout``` in the call to ```Sk.configure```, you can manage the timers.

The demo infrastructure doesn't have any sort of "reset" button, so here's a simple example of how one might use this:

```
var timers = [];

var timeout = function (func, delay) {
    var id;
    var wrapper = function () {
        var idx = timers.indexOf(id);
        if (idx > -1) {
            timers.splice(idx, 1);
        }
        func();
    };
    id = setTimeout(wrapper, delay);
    timers.push(id);
};

var clear_timeouts = function () {
    var idx;
    for (idx = 0; idx < timers.length; idx++) {
        clearTimeout(timers[idx]);
    }
    timers = [];
};
```

You would then set ```setTimeout``` in the call to ```Sk.configure``` to be ```timeout``` and you would call ```clear_timeouts``` when you want to reset Skulpt.  I am pretty sure there can only be one pending timer at any given time, but figured I'd give a more general example in case that changes in the future.  Obviously, one could choose to do this differently, as well.

I used the infrastructure in this PR to solve the problem described in #560 in CodeSkulptor (although the symptoms were different in CodeSkulptor, as the behavior you see depends on how you handle suspensions in the Skulpt driver), so I think these changes are sufficient, it is just up to the user to decide how to put the reset machinery into their driver.

This requires that anyone wanting to add a call to ```setTimeout``` in Skulpt in the future instead use ```Sk.setTimeout```.  I don't use turtle and image and they directly call ```window.setTimeout```, so I wasn't sure what behavior people want in those modules.  So, I left them alone, but they could be easily modified to use ```Sk.setTimeout```, as well so that they could be reset.