### PR TITLE
Descriptors

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -1632,6 +1632,9 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         out(scopename, ".$defaults=[", defaults.join(","), "];");
     }
 
+    if (decos.length > 0) {
+        out(scopename, ".$decorators=[", decos.join(","), "];");
+    }
 
     //
     // attach co_varnames (only the argument names) for keyword argument
@@ -1687,7 +1690,14 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         }
     }
     else {
-        return this._gr("funcobj", "new Sk.builtins['function'](", scopename, ",$gbl", frees, ")");
+        var res;
+        if (decos.length > 0)
+        {
+            res = this._gr("funcobj", "Sk.misceval.callsim(", scopename, ".$decorators[0], new Sk.builtins['function'](", scopename, ",$gbl", frees, "))"); // scopename, ".$decorators[0](new Sk.builtins['function'](", scopename, ",$gbl", frees, "))";
+        } else {
+            res = this._gr("funcobj", "new Sk.builtins['function'](", scopename, ",$gbl", frees, ")");
+        }
+        return res;
     }
 };
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -1693,7 +1693,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         var res;
         if (decos.length > 0)
         {
-            res = this._gr("funcobj", "Sk.misceval.callsim(", scopename, ".$decorators[0], new Sk.builtins['function'](", scopename, ",$gbl", frees, "))"); // scopename, ".$decorators[0](new Sk.builtins['function'](", scopename, ",$gbl", frees, "))";
+            res = this._gr("funcobj", "Sk.misceval.callsimOrSuspend(", scopename, ".$decorators[0], new Sk.builtins['function'](", scopename, ",$gbl", frees, "))"); // scopename, ".$decorators[0](new Sk.builtins['function'](", scopename, ",$gbl", frees, "))";
         } else {
             res = this._gr("funcobj", "new Sk.builtins['function'](", scopename, ",$gbl", frees, ")");
         }

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1187,6 +1187,14 @@ Sk.misceval.applyOrSuspend = function (func, kwdict, varargseq, kws, args) {
         //append kw args to args, filling in the default value where none is provided.
         return func.apply(null, args);
     } else {
+        fcall = func.__get__;
+        if (fcall !== undefined) {
+            fcall = Sk.misceval.callsim(func.__get__, func, func);
+            //args.unshift(func);
+            if (fcall.tp$call) {
+                return fcall.tp$call.call(fcall, args);                
+            }
+        }
         fcall = func.tp$call;
         if (fcall !== undefined) {
             if (varargseq) {

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1189,7 +1189,7 @@ Sk.misceval.applyOrSuspend = function (func, kwdict, varargseq, kws, args) {
     } else {
         fcall = func.__get__;
         if (fcall !== undefined) {
-            fcall = Sk.misceval.callsim(func.__get__, func, func);
+            fcall = Sk.misceval.callsimOrSuspend(func.__get__, func, func);
             //args.unshift(func);
             if (fcall.tp$call) {
                 return fcall.tp$call.call(fcall, args);                

--- a/src/object.js
+++ b/src/object.js
@@ -37,6 +37,20 @@ Sk.builtin.object.prototype.GenericGetAttr = function (name) {
 
     dict = this["$d"] || this.constructor["$d"];
 
+    descr = Sk.builtin.type.typeLookup(tp, name);
+
+    // otherwise, look in the type for a descr
+    if (descr !== undefined && descr !== null && descr.ob$type !== undefined) {
+        f = descr.ob$type.tp$descr_get;
+        if (!(f) && descr["__get__"]) {
+            f = descr["__get__"];
+            return Sk.misceval.callsim(f, descr, this);
+        }
+        // todo;
+        //if (f && descr.tp$descr_set) // is a data descriptor if it has a set
+        //return f.call(descr, this, this.ob$type);
+    }
+
     // todo; assert? force?
     if (dict) {
         if (dict.mp$lookup) {
@@ -88,8 +102,28 @@ Sk.builtin.object.prototype.GenericSetAttr = function (name, value) {
     var objname = Sk.abstr.typeName(this);
     var pyname;
     var dict;
+    var descr;
+    var tp;
+    var f;
     goog.asserts.assert(typeof name === "string");
-    // todo; lots o' stuff
+
+    tp = this.ob$type;
+    goog.asserts.assert(tp !== undefined, "object has no ob$type!");
+
+    descr = Sk.builtin.type.typeLookup(tp, name);
+
+    // otherwise, look in the type for a descr
+    if (descr !== undefined && descr !== null && descr.ob$type !== undefined) {
+        // f = descr.ob$type.tp$descr_set;
+        if (!(f) && descr["__set__"]) {
+            f = descr["__set__"];
+            Sk.misceval.callsim(f, descr, this, value);
+            return;
+        }
+        // todo;
+        //if (f && descr.tp$descr_set) // is a data descriptor if it has a set
+        //return f.call(descr, this, this.ob$type);
+    }
 
     dict = this["$d"] || this.constructor["$d"];
 

--- a/src/object.js
+++ b/src/object.js
@@ -44,7 +44,7 @@ Sk.builtin.object.prototype.GenericGetAttr = function (name) {
         f = descr.ob$type.tp$descr_get;
         if (!(f) && descr["__get__"]) {
             f = descr["__get__"];
-            return Sk.misceval.callsim(f, descr, this);
+            return Sk.misceval.callsimOrSuspend(f, descr, this);
         }
         // todo;
         //if (f && descr.tp$descr_set) // is a data descriptor if it has a set

--- a/test/unit/test_decorators.py
+++ b/test/unit/test_decorators.py
@@ -1,0 +1,176 @@
+import unittest
+
+log1 = []
+log2 = []
+
+def decofunc(fn):
+    log1.append(str(fn))
+    return fn
+
+@decofunc
+def func(x):
+    log1.append(x)
+
+class TestFunctionDecoratorOnFunction(unittest.TestCase):
+    def setup(self):
+        log1 = []
+
+    def test_function_on_function(self):
+        func('help')
+        self.assertEqual(log1, ['<function func>', 'help'])
+
+class cdeco:
+    cnt = 0
+    def __init__(self, fget=None, fset=None, fdel=None,doc=None):
+        self.id = cdeco.cnt
+        cdeco.cnt = cdeco.cnt + 1
+        log2.append("cdeco.__init__" + str(self.id))
+        log2.append("  " + str(fget))
+        log2.append("  " + str(fset))
+        log2.append("  " + str(fdel))
+        self.fget = fget
+        self.fset = fset
+        self.fdel = fdel
+
+    def __get__(self, obj):
+        log2.append("cdeco.__get__" + str(self.id))
+        return self.fget(obj)
+
+    def __set__(self, obj, value):
+        log2.append("cdeco.__set__" + str(self.id))
+        if self.fset is None:
+            raise AttributeError("can't set attribute")
+        self.fset(obj, value)
+        
+    def __delete__(self, obj):
+        log2.append("cdeco.__delete__" + str(self.id))
+        if self.fdel is None:
+            raise AttributeError("can't delete attribute")
+        self.fdel(obj)
+        
+    def getter(self, fset):
+        log2.append("cdeco.getter" + str(self.id))
+        return type(self)(fget, self.fset, self.fdel)
+    
+    def setter(self, fset):
+        log2.append("cdeco.setter" + str(self.id))
+        return type(self)(self.fget, fset, self.fdel)
+    
+    def deleter(self, fdel):
+        log2.append("cdeco.deleter" + str(self.id))
+        return type(self)(self.fget, self.fset, fdel)    
+        
+class testclass:
+    def __init__(self, val):
+        self._val = val;
+
+    @cdeco
+    def val(self):
+        log2.append("testclass.val - getter")
+        return self._val
+    
+    @val.setter
+    def val(self, val):
+        log2.append("testclass.val - setter")
+        self._val = val;
+    
+    @val.deleter
+    def val(self):
+        log2.append("testclass.val - deleter")
+
+
+
+class Property(object):
+    "Emulate PyProperty_Type() in Objects/descrobject.c"
+
+    def __init__(self, fget=None, fset=None, fdel=None, doc=None):
+        self.fget = fget
+        self.fset = fset
+        self.fdel = fdel
+        if doc is None and fget is not None:
+            doc = fget.__doc__
+        self.__doc__ = doc
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        if self.fget is None:
+            raise AttributeError("unreadable attribute")
+        return self.fget(obj)
+
+    def __set__(self, obj, value):
+        if self.fset is None:
+            raise AttributeError("can't set attribute")
+        self.fset(obj, value)
+
+    def __delete__(self, obj):
+        if self.fdel is None:
+            raise AttributeError("can't delete attribute")
+        self.fdel(obj)
+
+    def getter(self, fget):
+        return type(self)(fget, self.fset, self.fdel, self.__doc__)
+
+    def setter(self, fset):
+        return type(self)(self.fget, fset, self.fdel, self.__doc__)
+
+    def deleter(self, fdel):
+        return type(self)(self.fget, self.fset, fdel, self.__doc__)
+
+class test():
+    def __init__(self):
+        self._foo = 4
+    def h(self):
+        return self._foo
+    def hset(self,newval):
+        self._foo = newval * 10
+
+    h = Property(h, hset, doc='''returns 4''')
+
+
+class TestDescriptorGetSetOnMethod(unittest.TestCase):
+    def setup(self):
+        log2 = []
+
+    def test_handmade_descriptor(self):
+        y = testclass(123)
+        log2.append(y.val)
+        y.val = 456
+        log2.append(y.val)
+        self.assertEqual(log2, [
+            'cdeco.__init__0', 
+            '  <function val>', 
+            '  None', 
+            '  None', 
+            'cdeco.setter0', 
+            'cdeco.__init__1', 
+            '  <function val>', 
+            '  <function val>', 
+            '  None', 
+            'cdeco.deleter1', 
+            'cdeco.__init__2', 
+            '  <function val>', 
+            '  <function val>', 
+            '  <function val>', 
+            'cdeco.__get__2', 
+            'testclass.val - getter',
+            123, 
+            'cdeco.__set__2', 
+            'testclass.val - setter', 
+            'cdeco.__get__2', 
+            'testclass.val - getter', 
+            456])
+        #del y.val del is not yet implemented
+
+
+    def test_property(self):
+        t1 = test()
+        self.assertEqual(t1.h, 4)
+        t1.h = 9
+        self.assertEqual(t1.h, 90)
+
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This takes the work from the decorators branch, and gets it cleanly up to date with master.  I propose that we focus on getting the descriptor part to work in this PR, which I think is pretty close.  Then make a second PR when we are ready to get decorators fully working.

The great thing about this branch is that @waywaaard 's python only implementation of property works!  I would really like to get that into a builtin because I'm looking at some changes to the book where I would use properties.