### PR TITLE
Invokes setTimeout call in time.sleep with window as this.

### DIFF
--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -65,7 +65,7 @@ var $builtinmodule = function (name) {
         var susp = new Sk.misceval.Suspension();
         susp.resume = function() { return Sk.builtin.none.none$; }
         susp.data = {type: "Sk.promise", promise: new Promise(function(resolve) {
-            Sk.setTimeout(resolve, Sk.ffi.remapToJs(delay)*1000);
+            Sk.setTimeout.call(window, resolve, Sk.ffi.remapToJs(delay)*1000);
         })};
         return susp;
     });


### PR DESCRIPTION
As far as I can tell this solves the `Illegal Invocation` error I was seeing in Chrome. May also resolve #584 but I'm not sure if `setTimeout` is overridden on skulpt.org.

I tested this in Chrome both with and without `setTimeout` passed into `Sk.configure`. I think other `Sk.setTimeout` calls may also need to be invoked this way.