### PR TITLE
Run setTimeout within the global context.

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -61,7 +61,7 @@ Sk.configure = function (options) {
     Sk.setTimeout = options["setTimeout"];
     if (Sk.setTimeout === undefined) {
         if (typeof setTimeout === "function") {
-            Sk.setTimeout = setTimeout;
+            Sk.setTimeout = function(func, delay) { setTimeout(func, delay); };
         } else {
             Sk.setTimeout = function(func, delay) { func(); };
         }


### PR DESCRIPTION
Fix ```Illegal Invocation``` error introduced by #579.  Most (all?) browsers need ```setTimeout``` to run within the global context.