### PR TITLE
Fixes #583 Broken Import for dotted names in from list

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -559,6 +559,8 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
         if (saveSk !== Sk.globals) {
             Sk.globals = saveSk;
         }
+
+        // There is no fromlist, so we have reached the end of the lookup, return
         if (!fromlist || fromlist.length === 0) {
             return ret;
         } else {
@@ -568,10 +570,23 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
             var fromName; // name of current module for fromlist
             var fromImportName; // dotted name
             var dottedName = name.split("."); // get last module in dotted path
-            dottedName = dottedName[dottedName.length-1];
+            var lastDottedName = dottedName[dottedName.length-1];
+            
+            var found; // Contains sysmodules the "name"
+            var foundFromName; // Contains the sysmodules[name] the current item from the fromList
+
             for (i = 0; i < fromlist.length; i++) {
                 fromName = fromlist[i];
-                if (fromName != "*" && ret.$d[fromName] == null && (ret.$d[dottedName] != null || ret.$d.__name__.v == dottedName)) {
+
+                var foundFromName = false;
+                var found = Sk.sysmodules.sq$contains(name); // Check if "name" is inside sysmodules
+                if (found) {
+                    // Check if the current fromName is already in the "name" module
+                    foundFromName = Sk.sysmodules.mp$subscript(name)["$d"][fromName] != null;
+                }
+
+                // Only import from file system if we have not found the fromName in the current module
+                if (!foundFromName && fromName != "*" && ret.$d[fromName] == null && (ret.$d[lastDottedName] != null || ret.$d.__name__.v == lastDottedName)) {
                     // add the module name to our requiredImport list
                     fromImportName = "" + name + "." + fromName;
                     fromNameRet = Sk.importModuleInternal_(fromImportName, undefined, undefined, undefined, true, currentDir);

--- a/src/import.js
+++ b/src/import.js
@@ -578,8 +578,8 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
             for (i = 0; i < fromlist.length; i++) {
                 fromName = fromlist[i];
 
-                var foundFromName = false;
-                var found = Sk.sysmodules.sq$contains(name); // Check if "name" is inside sysmodules
+                foundFromName = false;
+                found = Sk.sysmodules.sq$contains(name); // Check if "name" is inside sysmodules
                 if (found) {
                     // Check if the current fromName is already in the "name" module
                     foundFromName = Sk.sysmodules.mp$subscript(name)["$d"][fromName] != null;

--- a/test/unit/test_import.py
+++ b/test/unit/test_import.py
@@ -1,0 +1,30 @@
+import unittest
+import sys
+
+class ImportDottedNamesTest(unittest.TestCase):
+
+    def test_dotted_fromname(self):
+        from unittest.gui import TestCaseGui
+        self.assertTrue(TestCaseGui is not None)
+
+class ImportFromModulesTest(unittest.TestCase):
+
+    def test_from_submodule(self):
+        # Try to delete the module from the internal module list
+        # sys.modules is a reference on Sk.sysmodules 
+        # Should allow a fresh import -> testing the intended feature
+        try:
+            del sys.modules["unittest"]
+        except:
+            pass
+
+        try:
+            del sys.modules["unittest.gui"]
+        except:
+            pass
+
+        from unittest import gui as mystuff
+        self.assertTrue(mystuff is not None)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
See issue #583 

With the fix both ways are working:

```python
from unittest.gui import TestCaseGui
```

and
```python
from unittest import gui as mystuff
```

I've added two unit tests, so that we do not break those again in future.