### PR TITLE
remapToPy() maps null to 'None' rather than '{}'

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -22,6 +22,8 @@ Sk.ffi.remapToPy = function (obj) {
             arr.push(Sk.ffi.remapToPy(obj[i]));
         }
         return new Sk.builtin.list(arr);
+    } else if (obj === null) {
+        return Sk.builtin.none.none$;
     } else if (typeof obj === "object") {
         kvs = [];
         for (k in obj) {


### PR DESCRIPTION
Currently, `remapToPy()` turns `null` into an empty dictionary (because `typeof (null) == "object"`). Make it map to `None` instead.