### PR TITLE
Normalise implicit calls

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -243,11 +243,11 @@ Sk.builtin.len = function len (item) {
     Sk.builtin.pyCheckArgs("len", arguments, 1, 1);
 
     if (item.sq$length) {
-        return Sk.misceval.chain(item.sq$length(true), Sk.builtin.int_);
+        return Sk.misceval.chain(item.sq$length(), Sk.builtin.int_);
     }
 
     if (item.mp$length) {
-        return Sk.misceval.chain(item.mp$length(true), Sk.builtin.int_);
+        return Sk.misceval.chain(item.mp$length(), Sk.builtin.int_);
     }
 
     if (item.tp$length) {

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -242,16 +242,18 @@ Sk.builtin.round = function round (number, ndigits) {
 Sk.builtin.len = function len (item) {
     Sk.builtin.pyCheckArgs("len", arguments, 1, 1);
 
+    var int_ = function(i) { return new Sk.builtin.int_(i); };
+
     if (item.sq$length) {
-        return Sk.misceval.chain(item.sq$length(), Sk.builtin.int_);
+        return Sk.misceval.chain(item.sq$length(), int_);
     }
 
     if (item.mp$length) {
-        return Sk.misceval.chain(item.mp$length(), Sk.builtin.int_);
+        return Sk.misceval.chain(item.mp$length(), int_);
     }
 
     if (item.tp$length) {
-        return Sk.misceval.chain(item.tp$length(true), Sk.builtin.int_);
+        return Sk.misceval.chain(item.tp$length(true), int_);
     }
 
     throw new Sk.builtin.TypeError("object of type '" + Sk.abstr.typeName(item) + "' has no len()");

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -243,15 +243,15 @@ Sk.builtin.len = function len (item) {
     Sk.builtin.pyCheckArgs("len", arguments, 1, 1);
 
     if (item.sq$length) {
-        return new Sk.builtin.int_(item.sq$length());
+        return Sk.misceval.chain(item.sq$length(true), Sk.builtin.int_);
     }
 
     if (item.mp$length) {
-        return new Sk.builtin.int_(item.mp$length());
+        return Sk.misceval.chain(item.mp$length(true), Sk.builtin.int_);
     }
 
     if (item.tp$length) {
-        return new Sk.builtin.int_(item.tp$length());
+        return Sk.misceval.chain(item.tp$length(true), Sk.builtin.int_);
     }
 
     throw new Sk.builtin.TypeError("object of type '" + Sk.abstr.typeName(item) + "' has no len()");

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -996,7 +996,7 @@ Sk.misceval.chain = function (initialValue, chainedFns) {
         if (i == arguments.length) {
             return value;
         }
-        if (value && value.isSuspension) { break; } // oops, slow case
+        if (value && value.$isSuspension) { break; } // oops, slow case
         value = arguments[i](value);
         i++;
     }

--- a/src/type.js
+++ b/src/type.js
@@ -341,7 +341,7 @@ Sk.builtin.type = function (name, bases, dict) {
                 args.unshift(magic_func, this);
 
                 if (canSuspendIdx) {
-                    var canSuspend = args[canSuspendIdx+1];
+                    canSuspend = args[canSuspendIdx+1];
                     args.splice(canSuspendIdx+1, 1);
                     if (canSuspend) {
                         return Sk.misceval.callsimOrSuspend.apply(undefined, args);

--- a/src/type.js
+++ b/src/type.js
@@ -288,7 +288,18 @@ Sk.builtin.type = function (name, bases, dict) {
             return Sk.misceval.callsim(iterf);
         };
         klass.prototype.tp$iternext = function (canSuspend) {
-            var r = Sk.misceval.chain(Sk.abstr.gattr(this, "next", canSuspend), function(/** {Object} */ iternextf) {
+            var self = this;
+            var r = Sk.misceval.chain(
+                Sk.misceval.tryCatch(function() {
+                    return Sk.abstr.gattr(self, "next", canSuspend);
+                }, function(e) {
+                    if (e instanceof Sk.builtin.AttributeError) {
+                        throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(self) + "' object is not iterable");
+                    } else {
+                        throw e;
+                    }
+                }),
+            function(/** {Object} */ iternextf) {
                 return Sk.misceval.tryCatch(function() {
                     return Sk.misceval.callsimOrSuspend(iternextf);
                 }, function(e) {

--- a/src/type.js
+++ b/src/type.js
@@ -263,14 +263,11 @@ Sk.builtin.type = function (name, bases, dict) {
             }
             return this["$r"]();
         };
-        klass.prototype.tp$length = function () {
-            var tname;
-            var lenf = this.tp$getattr("__len__");
-            if (lenf !== undefined) {
-                return Sk.misceval.apply(lenf, undefined, undefined, undefined, []);
-            }
-            tname = Sk.abstr.typeName(this);
-            throw new Sk.builtin.AttributeError(tname + " instance has no attribute '__len__'");
+        klass.prototype.tp$length = function (canSuspend) {
+            var r = Sk.misceval.chain(Sk.abstr.gattr(this, "__len__", canSuspend), function(lenf) {
+                return Sk.misceval.applyOrSuspend(lenf, undefined, undefined, undefined, []);
+            });
+            return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
         };
         klass.prototype.tp$call = function (args, kw) {
             var callf = this.tp$getattr("__call__");

--- a/src/type.js
+++ b/src/type.js
@@ -284,11 +284,11 @@ Sk.builtin.type = function (name, bases, dict) {
             });
         };
         klass.prototype.tp$iter = function () {
-            var iterf = Sk.abstr.gattr(this, "__iter__");
+            var iterf = Sk.abstr.gattr(this, "__iter__", false);
             return Sk.misceval.callsim(iterf);
         };
         klass.prototype.tp$iternext = function (canSuspend) {
-            var r = Sk.misceval.chain(Sk.abstr.gattr(this, "next"), function(iternextf) {
+            var r = Sk.misceval.chain(Sk.abstr.gattr(this, "next", canSuspend), function(/** {Object} */ iternextf) {
                 return Sk.misceval.tryCatch(function() {
                     return Sk.misceval.callsimOrSuspend(iternextf);
                 }, function(e) {
@@ -304,7 +304,7 @@ Sk.builtin.type = function (name, bases, dict) {
         };
 
         klass.prototype.tp$getitem = function (key, canSuspend) {
-            var getf = Sk.abstr.gattr(this, "__getitem__"), r;
+            var getf = Sk.abstr.gattr(this, "__getitem__", canSuspend), r;
             if (getf !== undefined) {
                 r = Sk.misceval.applyOrSuspend(getf, undefined, undefined, undefined, [key]);
                 return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
@@ -312,7 +312,7 @@ Sk.builtin.type = function (name, bases, dict) {
             throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(this) + "' object does not support indexing");
         };
         klass.prototype.tp$setitem = function (key, value, canSuspend) {
-            var setf = Sk.abstr.gattr(this, "__setitem__"), r;
+            var setf = Sk.abstr.gattr(this, "__setitem__", canSuspend), r;
             if (setf !== undefined) {
                 r = Sk.misceval.applyOrSuspend(setf, undefined, undefined, undefined, [key, value]);
                 return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);

--- a/src/type.js
+++ b/src/type.js
@@ -12,6 +12,13 @@ if(Sk.builtin === undefined) {
  * checks for the numeric shortcuts and not the sequence shortcuts when computing
  * a binary operation.
  *
+ * Because many of these functions are used in contexts in which Skulpt does not
+ * [yet] handle suspensions, the assumption is that they must not suspend. However,
+ * some of these built-in functions are acquiring 'canSuspend' arguments to signal
+ * where this is not the case. These need to be spliced out of the argument list before
+ * it is passed to python. Array values in this map contain [dunderName, argumentIdx],
+ * where argumentIdx specifies the index of the 'canSuspend' boolean argument.
+ *
  * @type {Object}
  */
 Sk.dunderToSkulpt = {
@@ -45,7 +52,7 @@ Sk.dunderToSkulpt = {
     "__pow__": "nb$power",
     "__rpow__": "nb$reflected_power",
     "__contains__": "sq$contains",
-    "__len__": "sq$length"
+    "__len__": ["sq$length", 0]
 };
 
 /**
@@ -328,22 +335,39 @@ Sk.builtin.type = function (name, bases, dict) {
         // fix for class attributes
         klass.tp$setattr = Sk.builtin.type.prototype.tp$setattr;
 
-        var shortcutDunder = function (skulpt_name, magic_name, magic_func) {
+        var shortcutDunder = function (skulpt_name, magic_name, magic_func, canSuspendIdx) {
             klass.prototype[skulpt_name] = function () {
-                var args = Array.prototype.slice.call(arguments);
+                var args = Array.prototype.slice.call(arguments), canSuspend;
                 args.unshift(magic_func, this);
+
+                if (canSuspendIdx) {
+                    var canSuspend = args[canSuspendIdx+1];
+                    args.splice(canSuspendIdx+1, 1);
+                    if (canSuspend) {
+                        return Sk.misceval.callsimOrSuspend.apply(undefined, args);
+                    }
+                }
                 return Sk.misceval.callsim.apply(undefined, args);
             };
         };
 
-        // Register skulpt shortcuts to magic methods defined by this class
-        var dunder, skulpt_name;
+        // Register skulpt shortcuts to magic methods defined by this class.
+        // TODO: This is somewhat problematic, as it means that dynamically defined
+        // methods (eg those returned by __getattr__()) cannot be used by these magic
+        // functions.
+        var dunder, skulpt_name, canSuspendIdx;
         for (dunder in Sk.dunderToSkulpt) {
             skulpt_name = Sk.dunderToSkulpt[dunder];
+            if (typeof(skulpt_name) === "string") {
+                canSuspendIdx = null;
+            } else {
+                canSuspendIdx = skulpt_name[1];
+                skulpt_name = skulpt_name[0];
+            }
 
             if (klass[dunder]) {
                 // scope workaround
-                shortcutDunder(skulpt_name, dunder, klass[dunder]);
+                shortcutDunder(skulpt_name, dunder, klass[dunder], canSuspendIdx);
             }
         }
 

--- a/test/run/t376.py.real
+++ b/test/run/t376.py.real
@@ -1,1 +1,1 @@
-EXCEPTION: AttributeError: NoLen instance has no attribute '__len__' on line 21
+EXCEPTION: AttributeError: 'NoLen' object has no attribute '__len__' on line 21

--- a/test/run/t376.py.real.force
+++ b/test/run/t376.py.real.force
@@ -1,1 +1,1 @@
-EXCEPTION: AttributeError: NoLen instance has no attribute '__len__' on line 21
+EXCEPTION: AttributeError: 'NoLen' object has no attribute '__len__' on line 21


### PR DESCRIPTION
There are many implicit calls (to functions like `__len__`) triggered from internal 'dunder-named' function calls (like `tp$length`). This PR starts the work of normalising those calls - it uses `Sk.abstr.gattr()` to get the attributes (so they can be dynamically returned by `__getattr__` and friends), and makes some (such as `__call__` and `__len__`) suspendable.