### PR TITLE
Minor v8 speedups

### DIFF
--- a/src/misceval.js
+++ b/src/misceval.js
@@ -211,6 +211,15 @@ Sk.misceval.swappedOp_ = {
     "NotIn": "In_"
 };
 
+Sk.misceval._tryCatch = function (func, catchHandler) {
+    try {
+        return func();
+    } catch (err) {
+        return catchHandler(err);
+    }
+};
+goog.exportSymbol("Sk.misceval._tryCatch", Sk.misceval._tryCatch);
+
 /**
 * @param{*} v
 * @param{*} w
@@ -447,7 +456,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
 
     vcmp = Sk.abstr.lookupSpecial(v, "__cmp__");
     if (vcmp) {
-        try {
+        return Sk.misceval._tryCatch(function() {
             ret = Sk.misceval.callsim(vcmp, v, w);
             if (Sk.builtin.checkNumber(ret)) {
                 ret = Sk.builtin.asnum$(ret);
@@ -469,15 +478,15 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
             if (ret !== Sk.builtin.NotImplemented.NotImplemented$) {
                 throw new Sk.builtin.TypeError("comparison did not return an int");
             }
-        } catch (e) {
+        }, function (e) {
             throw new Sk.builtin.TypeError("comparison did not return an int");
-        }
+        });
     }
 
     wcmp = Sk.abstr.lookupSpecial(w, "__cmp__");
     if (wcmp) {
         // note, flipped on return value and call
-        try {
+        return Sk.misceval._tryCatch(function() {
             ret = Sk.misceval.callsim(wcmp, w, v);
             if (Sk.builtin.checkNumber(ret)) {
                 ret = Sk.builtin.asnum$(ret);
@@ -499,9 +508,9 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
             if (ret !== Sk.builtin.NotImplemented.NotImplemented$) {
                 throw new Sk.builtin.TypeError("comparison did not return an int");
             }
-        } catch (e) {
+        }, function (e) {
             throw new Sk.builtin.TypeError("comparison did not return an int");
-        }
+        });
     }
 
     // handle special cases for comparing None with None or Bool with Bool

--- a/src/object.js
+++ b/src/object.js
@@ -19,6 +19,13 @@ Sk.builtin.object = function () {
 
 
 
+var _tryGetSubscript = function(dict, pyName) {
+    try {
+        return dict.mp$subscript(pyName);
+    } catch (x) {
+        return undefined;
+    }
+};
 
 /**
  * @return {undefined}
@@ -42,11 +49,7 @@ Sk.builtin.object.prototype.GenericGetAttr = function (name) {
         if (dict.mp$lookup) {
             res = dict.mp$lookup(pyName);
         } else if (dict.mp$subscript) {
-            try {
-                res = dict.mp$subscript(pyName);
-            } catch (x) {
-                res = undefined;
-            }
+            res = _tryGetSubscript(dict, pyName);
         } else if (typeof dict === "object") {
             // todo; definitely the wrong place for this. other custom tp$getattr won't work on object -- bnm -- implemented custom __getattr__ in abstract.js
             res = dict[name];

--- a/src/set.js
+++ b/src/set.js
@@ -317,16 +317,17 @@ goog.exportSymbol("Sk.builtin.set", Sk.builtin.set);
  * @param {Object} obj
  */
 Sk.builtin.set_iter_ = function (obj) {
-    var allkeys, k, i, bucket;
+    var allkeys, k, i, bucket, buckets;
     if (!(this instanceof Sk.builtin.set_iter_)) {
         return new Sk.builtin.set_iter_(obj);
     }
     this.$obj = obj;
     this.tp$iter = this;
     allkeys = [];
-    for (k in obj.v) {
-        if (obj.v.hasOwnProperty(k)) {
-            bucket = obj.v[k];
+    buckets = obj.v.buckets;
+    for (k in buckets) {
+        if (buckets.hasOwnProperty(k)) {
+            bucket = buckets[k];
             if (bucket && bucket.$hash !== undefined && bucket.items !== undefined) {
                 // skip internal stuff. todo; merge pyobj and this
                 for (i = 0; i < bucket.items.length; i++) {


### PR DESCRIPTION
Trying to be a bit more compiler/v8 friendly. Timed in a browser with @rixner's [script](https://gist.github.com/rixner/f79dfa52a0385e5c82d147ae3d06c50c), modified to time each `update()` call separately instead of all of them together, and to aggregate these timings.

Timings before:
```
min time: 0.0622251033783
average time: 0.0676951956749
stddev: 0.00581978406985
```

Timings after:
```
min time: 0.0563948154449
average time: 0.0603578090668
stddev: 0.00456230040262
```