### PR TITLE
Fix suspension resumption after importing Python modules

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2237,7 +2237,9 @@ Compiler.prototype.cmod = function (mod) {
     var modf = this.enterScope(new Sk.builtin.str("<module>"), mod, 0, this.canSuspend);
 
     var entryBlock = this.newBlock("module entry");
-    this.u.prefixCode = "var " + modf + "=(function($modname){";
+    // we name the function to guarantee that internal references to modf reference this function
+    // even if the global var is redefined
+    this.u.prefixCode = "var " + modf + "=(function " + modf + "($modname){";
     this.u.varDeclsCode =
         "var $gbl = {}, $blk=" + entryBlock +
         ",$exc=[],$loc=$gbl,$err=undefined;$gbl.__name__=$modname;$loc.__file__=new Sk.builtins.str('" + this.filename +


### PR DESCRIPTION
Fixes suspension resumption via $saveSuspension after importing an external Python module. Both the main script and the external module could be compiled to code assigning to "$scope0". As a result, when the main script imported the external script, it would overwrite $scope0. Then, when the main script suspended, it would resume in the external library.

To fix this, we simply name the generated function the same as the var. Thus, references within the function body are guaranteed to refer to it whether or not the global variable is overwritten.