### PR TITLE
Support catching multiple types of exceptions in an 'except' block

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -1232,9 +1232,7 @@ Compiler.prototype.ctryexcept = function (s) {
             // var isinstance = this.nameop(new Sk.builtin.str("isinstance"), Load));
             // var check = this._gr('call', "Sk.misceval.callsim(", isinstance, ", $err, ", handlertype, ")");
 
-            // this check is not right, should use isinstance, but exception objects
-            // are not yet proper Python objects
-            check = this._gr("instance", "$err instanceof ", handlertype);
+            check = this._gr("instance", "Sk.misceval.isTrue(Sk.builtin.isinstance($err, ", handlertype, "))");
             this._jumpfalse(check, next);
         }
 

--- a/test/unit/test_subclass.py
+++ b/test/unit/test_subclass.py
@@ -275,8 +275,8 @@ class SubclassTest(unittest.TestCase):
 
         try:
             raise TestFailed("test")
+            self.fail("Should never get here")
         except TestFailed as e:
-            print e
             self.assertIn("TestFailed: test", str(e))
 
         class MyTypeError(TypeError): pass
@@ -294,8 +294,16 @@ class SubclassTest(unittest.TestCase):
 
         try:
             raise MyStandardError("test")
+            self.fail("Should never get here")
         except MyStandardError as e:
             self.assertEqual("My Standard Error", str(e))
+
+        # Test multiple-class catch
+        try:
+            raiseTestFailed()
+            self.fail("Shouldn't get here")
+        except (StandardError, TestFailed):
+            pass
 
 
 


### PR DESCRIPTION
We were using JS `instanceof` in exception-type testing. The real Python `isinstance` now works fine, and supports syntax like catching tuples of exception types. This PR makes us use it.