### PR TITLE
Wrap compiler output in a function to avoid scope gensyms colliding

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2316,9 +2316,9 @@ Sk.compile = function (source, filename, mode, canSuspend) {
     var c = new Compiler(filename, st, flags.cf_flags, canSuspend, source); // todo; CO_xxx
     var funcname = c.cmod(ast);
 
-    var ret = c.result.join("");
+    var ret = "$compiledmod = function() {" + c.result.join("") + "\nreturn " + funcname + ";}();";
     return {
-        funcname: funcname,
+        funcname: "$compiledmod",
         code    : ret
     };
 };


### PR DESCRIPTION
This should provide a more universal fix to the problem identified in #606 

@rixner, @DIJamner for review please