### PR TITLE
Bugfix: Explicitly (re)declare all suspendable temporary variables

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -932,7 +932,8 @@ Compiler.prototype.outputSuspensionHelpers = function (unit) {
     var localsToSave = unit.localnames.concat(unit.tempsToSave);
     var seenTemps = {};
     var hasCell = unit.ste.blockType === FunctionBlock && unit.ste.childHasFree;
-    var output = "var $wakeFromSuspension = function() {" +
+    var output = (localsToSave.length > 0 ? ("var " + localsToSave.join(",") + ";") : "") +
+                 "var $wakeFromSuspension = function() {" +
                     "var susp = "+unit.scopename+".$wakingSuspension; delete "+unit.scopename+".$wakingSuspension;" +
                     "$blk=susp.$blk; $loc=susp.$loc; $gbl=susp.$gbl; $exc=susp.$exc; $err=susp.$err;" +
                     "$currLineNo=susp.$lineno; $currColNo=susp.$colno; Sk.lastYield=Date.now();" +


### PR DESCRIPTION
Otherwise we can attempt to save temporaries from now-eliminated dead code,
and we get "no such variable X" errors.

Repro case:
```python
import time

time.sleep(0.01)

for p in []:
  break
  for n in []:
    pass
```

The inner loop (`for n in []`...) is dead code, so it is not included in the compiled output, but the suspension code still tries to save its temporaries (which are now undeclared). This is the straightforward fix that forces the declaration of all saved temporaries.

Long-term, we need to improve our temporary/variable lifetimes, probably by reifying them into heap objects that can survive an exception (#295 and friends), but that shouldn't stop us fixing a bug like this.