### PR TITLE
Copy module

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -559,7 +559,8 @@ Sk.builtin.dir = function dir (x) {
         var internal = [
             "__bases__", "__mro__", "__class__", "__name__", "GenericGetAttr",
             "GenericSetAttr", "GenericPythonGetAttr", "GenericPythonSetAttr",
-            "pythonFunctions", "HashNotImplemented", "constructor"];
+            "pythonFunctions", "HashNotImplemented", "constructor", "__dict__"
+        ];
         if (internal.indexOf(k) !== -1) {
             return null;
         }
@@ -754,11 +755,11 @@ Sk.builtin.hash = function hash (value) {
             value.$savedHash_ = value.tp$hash();
             return value.$savedHash_;
         } else {
-            if (value.__id === undefined) {
+            if (value.__hash === undefined) {
                 Sk.builtin.hashCount += 1;
-                value.__id = Sk.builtin.hashCount;
+                value.__hash = Sk.builtin.hashCount;
             }
-            return new Sk.builtin.int_(value.__id);
+            return new Sk.builtin.int_(value.__hash);
         }
     } else if (typeof value === "number" || value === null ||
         value === true || value === false) {
@@ -1205,6 +1206,17 @@ Sk.builtin.reversed = function reversed (seq) {
 
         return new reverseIter(seq);
     }
+};
+
+Sk.builtin.id = function (obj) {
+    Sk.builtin.pyCheckArgs("id", arguments, 1, 1);
+
+    if (obj.__id === undefined) {
+        Sk.builtin.idCount += 1;
+        obj.__id = Sk.builtin.idCount;
+    }
+
+    return new Sk.builtin.int_(obj.__id);
 };
 
 Sk.builtin.bytearray = function bytearray () {

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -25,6 +25,7 @@ Sk.builtins = {
     "float_$rw$": Sk.builtin.float_,
     "int_$rw$"  : Sk.builtin.int_,
     "hasattr"   : Sk.builtin.hasattr,
+    "id"        : Sk.builtin.id,
 
     "map"   : Sk.builtin.map,
     "filter": Sk.builtin.filter,

--- a/src/function.js
+++ b/src/function.js
@@ -216,7 +216,7 @@ Sk.builtin.func.prototype.tp$descr_get = function (obj, objtype) {
     if (obj == null) {
         return this;
     }
-    return new Sk.builtin.method(this, obj);
+    return new Sk.builtin.method(this, obj, objtype);
 };
 Sk.builtin.func.prototype.tp$call = function (args, kw) {
     var j;

--- a/src/lib/copy.py
+++ b/src/lib/copy.py
@@ -1,1 +1,286 @@
-raise NotImplementedError("copy is not yet implemented in Skulpt")
+"""
+This file was modified from cpython.
+Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015 Python Software Foundation; All Rights Reserved
+"""
+import types
+class Error(Exception):
+    pass
+error = Error 
+class _EmptyClass:
+    pass
+
+def copy(x):
+    cls = type(x)
+    if callable(x):
+        return x
+    copier = getattr(cls, "__copy__", None)
+    if copier:
+        return copier(x)
+    if cls in (type(None), int, float, bool, long, str, tuple, type):
+        return x
+    if (cls == list) or (cls == dict) or (cls == set) or (cls == slice):
+        return cls(x)
+    try:
+        getstate = getattr(x, "__getstate__", None)
+        setstate = getattr(x, "__setstate__", None)
+        initargs = getattr(x, "__getinitargs__", None)
+    except:
+        reductor = False
+    if getstate or setstate or initargs:
+        raise NotImplementedError("Skulpt does not yet support copying with user-defined __getstate__, __setstate__ or __getinitargs__()")
+    reductor = getattr(x, "__reduce_ex__", None)
+    if reductor:
+        rv = reductor(4)
+    else:
+        reductor = getattr(x, "__reduce__", None)
+        if reductor:
+            rv = reductor()
+        elif str(cls)[1:6] == "class":
+            copier = _copy_inst
+            return copier(x)
+        else:
+            raise Error("un(shallow)copyable object of type %s" % cls)
+    if isinstance(rv, str):
+        return x
+    return _reconstruct(x, rv, 0)
+
+def _copy_inst(x):
+    if hasattr(x, '__copy__'):
+        return x.__copy__()
+    if hasattr(x, '__getinitargs__'):
+        args = x.__getinitargs__()
+        y = x.__class__(*args)
+    else:
+        y = _EmptyClass()
+        y.__class__ = x.__class__
+    if hasattr(x, '__getstate__'):
+        state = x.__getstate__()
+    else:
+        state = x.__dict__
+    if hasattr(y, '__setstate__'):
+        y.__setstate__(state)
+    else:
+        y.__dict__.update(state)
+    return y
+
+d = _deepcopy_dispatch = {}
+
+def deepcopy(x, memo=None, _nil=[]):
+    """Deep copy operation on arbitrary Python objects.
+    See the module's __doc__ string for more info.
+    """
+    if memo is None:
+        memo = {}
+    idx = id(x)
+    y = memo.get(idx, _nil)
+    if y is not _nil:
+        return y
+    cls = type(x)
+    try:
+        getstate = getattr(x, "__getstate__", None)
+        setstate = getattr(x, "__setstate__", None)
+        initargs = getattr(x, "__getinitargs__", None)
+    except:
+        reductor = False
+    if getstate or setstate or initargs:
+        raise NotImplementedError("Skulpt does not yet support copying with user-defined __getstate__, __setstate__ or __getinitargs__()")
+    copier = _deepcopy_dispatch.get(cls)
+    if copier:
+        y = copier(x, memo)
+    elif str(cls)[1:6] == "class":
+        copier = _deepcopy_dispatch["InstanceType"]
+        y = copier(x, memo)
+    else:
+        try:
+            issc = issubclass(cls, type)
+        except TypeError: # cls is not a class (old Boost; see SF #502085)
+            issc = 0
+        if issc:
+            y = _deepcopy_atomic(x, memo)
+        else:
+            copier = getattr(x, "__deepcopy__", None)
+            if copier:
+                y = copier(memo)
+            else:
+                reductor = getattr(x, "__reduce_ex__", None)
+                if reductor:
+                    rv = reductor(2)
+                else:
+                    reductor = getattr(x, "__reduce__", None)
+                    if reductor:
+                        rv = reductor()
+                    else:
+                        raise Error(
+                            "un(deep)copyable object of type %s" % cls)
+                y = _reconstruct(x, rv, 1, memo)
+    memo[idx] = y
+    _keep_alive(x, memo) # Make sure x lives at least as long as d
+    return y
+
+def _deepcopy_atomic(x, memo):
+    return x
+d[type(None)] = _deepcopy_atomic
+# d[type(Ellipsis)] = _deepcopy_atomic
+d[type(NotImplemented)] = _deepcopy_atomic
+d[int] = _deepcopy_atomic
+d[float] = _deepcopy_atomic
+d[bool] = _deepcopy_atomic
+d[complex] = _deepcopy_atomic
+# d[bytes] = _deepcopy_atomic
+d[str] = _deepcopy_atomic
+# try:
+# d[types.CodeType] = _deepcopy_atomic
+# except AttributeError:
+#   pass
+d[type] = _deepcopy_atomic
+# d[types.BuiltinFunctionType] = _deepcopy_atomic
+d[types.FunctionType] = _deepcopy_atomic
+# d[weakref.ref] = _deepcopy_atomic
+
+def _deepcopy_list(x, memo):
+    y = []
+    memo[id(x)] = y
+    for a in x:
+        y.append(deepcopy(a, memo))
+    return y
+d[list] = _deepcopy_list
+
+def _deepcopy_set(x, memo):
+    result = set([])  # make empty set
+    memo[id(x)] = result  # register this set in the memo for loop checking
+    for a in x:   # go through elements of set
+        result.add(deepcopy(a, memo))  # add the copied elements into the new set
+    return result # return the new set
+d[set] = _deepcopy_set
+
+def _deepcopy_tuple(x, memo):
+    y = [deepcopy(a, memo) for a in x]
+    # We're not going to put the tuple in the memo, but it's still important we
+    # check for it, in case the tuple contains recursive mutable structures.
+    try:
+        return memo[id(x)]
+    except KeyError:
+        pass
+    for k, j in zip(x, y):
+        if k is not j:
+            y = tuple(y)
+            break
+    else:
+        y = x
+    return y
+d[tuple] = _deepcopy_tuple
+
+def _deepcopy_dict(x, memo):
+    y = {}
+    memo[id(x)] = y
+    for key, value in x.items():
+        y[deepcopy(key, memo)] = deepcopy(value, memo)
+    return y
+d[dict] = _deepcopy_dict
+
+def _deepcopy_method(x, memo): # Copy instance methods
+    y = type(x)(x.im_func, deepcopy(x.im_self, memo), x.im_class);
+    return y
+d[types.MethodType] = _deepcopy_method
+
+def _deepcopy_inst(x, memo):
+    if hasattr(x, '__deepcopy__'):
+         return x.__deepcopy__(memo)
+    if hasattr(x, '__getinitargs__'):
+        args = x.__getinitargs__()
+        args = deepcopy(args, memo)
+        y = x.__class__(*args)
+    else:
+        y = _EmptyClass()
+        y.__class__ = x.__class__
+    memo[id(x)] = y
+    if hasattr(x, '__getstate__'):
+        state = x.__getstate__()
+    else:
+        state = x.__dict__
+    state = deepcopy(state, memo)
+    if hasattr(y, '__setstate__'):
+        y.__setstate__(state)
+    else:
+        y.__dict__.update(state)
+        return y
+d["InstanceType"] = _deepcopy_inst
+
+def _keep_alive(x, memo):
+    """Keeps a reference to the object x in the memo.
+    Because we remember objects by their id, we have
+    to assure that possibly temporary objects are kept
+    alive by referencing them.
+    We store a reference at the id of the memo, which should
+    normally not be used unless someone tries to deepcopy
+    the memo itself...
+    """
+    try:
+        memo[id(memo)].append(x)
+    except KeyError:
+        # aha, this is the first one :-)
+        memo[id(memo)]=[x]
+
+def _reconstruct(x, info, deep, memo=None):
+    if isinstance(info, str):
+        return x
+    assert isinstance(info, tuple)
+    if memo is None:
+        memo = {}
+    n = len(info)
+    assert n in (2, 3, 4, 5)
+    callable, args = info[:2]
+    if n > 2:
+        state = info[2]
+    else:
+        state = None
+    if n > 3:
+        listiter = info[3]
+    else:
+        listiter = None
+    if n > 4:
+        dictiter = info[4]
+    else:
+        dictiter = None
+    if deep:
+        args = deepcopy(args, memo)
+    y = callable(*args)
+    memo[id(x)] = y
+
+    if state is not None:
+        if deep:
+            state = deepcopy(state, memo)
+        if hasattr(y, '__setstate__'):
+            y.__setstate__(state)
+        else:
+            if isinstance(state, tuple) and len(state) == 2:
+                state, slotstate = state
+            else:
+                slotstate = None
+            if state is not None:
+                y.__dict__.update(state)
+            if slotstate is not None:
+                for key, value in slotstate.items():
+                    setattr(y, key, value)
+
+    if listiter is not None:
+        for item in listiter:
+            if deep:
+                item = deepcopy(item, memo)
+            y.append(item)
+    if dictiter is not None:
+        for key, value in dictiter:
+            if deep:
+                key = deepcopy(key, memo)
+                value = deepcopy(value, memo)
+            y[key] = value
+    return y
+
+del d
+
+del types
+
+# Helper for instance creation without calling __init__
+class _EmptyClass:
+    pass

--- a/src/lib/copy.py
+++ b/src/lib/copy.py
@@ -1,5 +1,5 @@
 """
-This file was modified from cpython.
+This file was modified from CPython.
 Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
 2011, 2012, 2013, 2014, 2015 Python Software Foundation; All Rights Reserved
 """

--- a/src/lib/types.py
+++ b/src/lib/types.py
@@ -1,1 +1,86 @@
-raise NotImplementedError("types is not yet implemented in Skulpt")
+"""
+This file was modified from cpython.
+Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015 Python Software Foundation; All Rights Reserved
+"""
+"""Define names for all type symbols known in the standard interpreter.
+Types that are part of optional modules (e.g. array) are not listed.
+"""
+import sys
+
+# Iterators in Python aren't a matter of type but of protocol.  A large
+# and changing number of builtin types implement *some* flavor of
+# iterator.  Don't check the type!  Use hasattr to check for both
+# "__iter__" and "next" attributes instead.
+
+NoneType = type(None)
+TypeType = type
+ObjectType = object
+IntType = int
+LongType = long
+FloatType = float
+BooleanType = bool
+try:
+    ComplexType = complex
+except NameError:
+    pass
+StringType = str
+
+# StringTypes is already outdated.  Instead of writing "type(x) in
+# types.StringTypes", you should use "isinstance(x, basestring)".  But
+# we keep around for compatibility with Python 2.2.
+try:
+    UnicodeType = unicode
+    StringTypes = (StringType, UnicodeType)
+except NameError:
+    StringTypes = (StringType,)
+
+BufferType = buffer
+
+TupleType = tuple
+ListType = list
+DictType = DictionaryType = dict
+
+def _f(): pass
+FunctionType = type(_f)
+LambdaType = type(lambda: None)         # Same as FunctionType
+CodeType = type(_f.func_code)
+
+def _g():
+    yield 1
+GeneratorType = type(_g())
+
+class _C:
+    def _m(self): pass
+ClassType = type(_C)
+UnboundMethodType = type(_C._m)         # Same as MethodType
+_x = _C()
+InstanceType = type(_x)
+MethodType = type(_x._m)
+BuiltinFunctionType = type(len)
+BuiltinMethodType = type([].append)     # Same as BuiltinFunctionType
+
+ModuleType = type(sys)
+FileType = file
+XRangeType = xrange
+
+# try:
+#     raise TypeError
+# except TypeError:
+#     tb = sys.exc_info()[2]
+#     TracebackType = type(tb)
+#     FrameType = type(tb.tb_frame)
+#     del tb
+
+SliceType = slice
+# EllipsisType = type(Ellipsis)
+
+# DictProxyType = type(TypeType.__dict__)
+NotImplementedType = type(NotImplemented)
+
+# For Jython, the following two types are identical
+# GetSetDescriptorType = type(FunctionType.func_code)
+# MemberDescriptorType = type(FunctionType.func_globals)
+
+del sys, _f, _g, _C, _x                           # Not for export
+__all__ = list(n for n in globals() if n[:1] != '_')

--- a/src/lib/types.py
+++ b/src/lib/types.py
@@ -1,5 +1,5 @@
 """
-This file was modified from cpython.
+This file was modified from CPython.
 Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
 2011, 2012, 2013, 2014, 2015 Python Software Foundation; All Rights Reserved
 """

--- a/src/method.js
+++ b/src/method.js
@@ -3,12 +3,26 @@
  *
  * co_varnames and co_name come from generated code, must access as dict.
  */
-Sk.builtin.method = function (func, self) {
+Sk.builtin.method = function (func, self, klass) {
+    if (!(this instanceof Sk.builtin.method)) {
+        Sk.builtin.pyCheckArgs("method", arguments, 3, 3);
+        if (!Sk.builtin.checkCallable(func)) {
+            throw new Sk.builtin.TypeError("First argument must be callable");
+        }
+        if (self.ob$type === undefined) {
+            throw new Sk.builtin.TypeError("Second argument must be object of known type");
+        }
+        return new Sk.builtin.method(func, self, klass);
+    }
     this.im_func = func;
     this.im_self = self;
-    //print("constructing method", this.im_func.tp$name, this.im_self.tp$name);
+    this.im_class = klass;
+    this["$d"] = new Sk.builtin.dict([new Sk.builtin.str("im_self"), self,
+        new Sk.builtin.str("im_class"), klass,
+        new Sk.builtin.str("im_func"), func]);
 };
 goog.exportSymbol("Sk.builtin.method", Sk.builtin.method);
+Sk.abstr.setUpInheritance("instancemethod", Sk.builtin.method, Sk.builtin.object);
 
 Sk.builtin.method.prototype.tp$call = function (args, kw) {
     goog.asserts.assert(this.im_self, "should just be a function, not a method since there's no self?");
@@ -23,8 +37,6 @@ Sk.builtin.method.prototype.tp$call = function (args, kw) {
 
     return this.im_func.tp$call(args, kw);
 };
-
-Sk.builtin.method.prototype.tp$name = "instancemethod";
 
 Sk.builtin.method.prototype["$r"] = function () {
     var name = (this.im_func.func_code && this.im_func.func_code["co_name"] && this.im_func.func_code["co_name"].v) || "<native JS>";

--- a/src/method.js
+++ b/src/method.js
@@ -17,9 +17,11 @@ Sk.builtin.method = function (func, self, klass) {
     this.im_func = func;
     this.im_self = self;
     this.im_class = klass;
-    this["$d"] = new Sk.builtin.dict([new Sk.builtin.str("im_self"), self,
-        new Sk.builtin.str("im_class"), klass,
-        new Sk.builtin.str("im_func"), func]);
+    this["$d"] = {
+        im_func: func,
+        im_self: self,
+        im_class: klass
+    };
 };
 goog.exportSymbol("Sk.builtin.method", Sk.builtin.method);
 Sk.abstr.setUpInheritance("instancemethod", Sk.builtin.method, Sk.builtin.object);

--- a/src/object.js
+++ b/src/object.js
@@ -289,6 +289,7 @@ Sk.builtin.object.prototype["$r"] = function () {
 };
 
 Sk.builtin.hashCount = 1;
+Sk.builtin.idCount = 1;
 
 /**
  * Return the hash value of this instance.

--- a/src/type.js
+++ b/src/type.js
@@ -119,6 +119,7 @@ Sk.builtin.type = function (name, bases, dict) {
 
             args = args || [];
             self["$d"] = new Sk.builtin.dict([]);
+            self["$d"].mp$ass_subscript(new Sk.builtin.str("__dict__"), self["$d"]);
 
             if (klass.prototype.tp$base !== undefined) {
                 if (klass.prototype.tp$base.sk$klass) {
@@ -627,13 +628,14 @@ Sk.builtin.type.prototype.tp$richcompare = function (other, op) {
     if (other.ob$type != Sk.builtin.type) {
         return undefined;
     }
-
     if (!this["$r"] || !other["$r"]) {
         return undefined;
     }
-
-    r1 = this["$r"]();
-    r2 = other["$r"]();
-
+    r1 = new Sk.builtin.str(this["$r"]().v.slice(1,6));
+    r2 = new Sk.builtin.str(other["$r"]().v.slice(1,6));
+    if (this["$r"]().v.slice(1,6) !== "class") {
+        r1 = this["$r"]();
+        r2 = other["$r"]();
+    }
     return r1.tp$richcompare(r2, op);
 };

--- a/test/unit/test_copy.py
+++ b/test/unit/test_copy.py
@@ -1,0 +1,332 @@
+"""
+This file was modified from cpython.
+Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016 Python Software Foundation; All Rights Reserved
+"""
+import copy, unittest
+from operator import le, lt, ge, gt, eq, ne
+
+class C:
+    def __init__(self, foo):
+        self.foo = foo
+    def __copy__(self):
+        return C(self.foo)
+
+class ReduceEx(object):
+    def __reduce_ex__(self, proto):
+        c.append(1)
+        return ""
+    def __reduce__(self):
+        self.fail("shouldn't call this")
+c = []
+
+class Reduce(object):
+    def __reduce__(self):
+        d.append(1)
+        return ""
+d = []
+
+class InstVan:
+    def __init__(self, foo):
+        self.foo = foo
+    # def __eq__(self, other):
+    #   return self.foo == other.foo
+
+class Copy_eq:
+    def __init__(self, foo):
+        self.foo = foo
+    def __copy__(self):
+        return C(self.foo)
+    def __eq__(self, other):
+        return self.foo == other.foo
+
+class User_def:
+    def __init__(self, name):
+        self.name = name
+    def rename(self,newname):
+        self.name = newname
+
+class NewArgs(int):
+    def __new__(cls, foo):
+        self = int.__new__(cls)
+        self.foo = foo
+        return self
+    def __getnewargs__(self):
+        return self.foo,
+    def __eq__(self, other):
+        return self.foo == other.foo
+
+class TestCopy(unittest.TestCase):
+    def test_exceptions(self):
+        self.assertIs(copy.Error, copy.error)
+        self.assertTrue(issubclass(copy.Error, Exception))
+
+    # The copy() method
+
+    def test_copy_basic(self):
+        x = 42
+        y = copy.copy(x)
+        self.assertEqual(x, y)
+
+    def test_copy_copy(self):
+        x = C(42)
+        y = copy.copy(x)
+        self.assertEqual(y.__class__, x.__class__)
+        self.assertEqual(y.foo, x.foo)
+
+    def test_copy_inst(self):
+        x = User_def("One")
+        y = copy.copy(x)
+        self.assertEqual(x.name, "One")
+        self.assertFalse(x==y)
+        self.assertFalse(x is y)
+        self.assertTrue(x.name is y.name)
+        x.rename("Two")
+        self.assertFalse(x==y)
+        self.assertFalse(x is y)
+        self.assertEqual(x.name, "Two")
+        self.assertEqual(y.name, "One")
+
+    def test_copy_cant(self):
+        class Cant:
+            def __getattribute__(self, name):
+                pass
+                # if name.startswith("__reduce"):
+                #   raise AttributeError(name)
+                # return object.__getattribute__(self, name)
+        x = Cant()
+        self.assertRaises(TypeError, copy.copy, x)
+
+    def test_copy_atomic(self):
+        class Classic:
+            pass
+        def f():
+            pass
+        # class WithMetaclass(metaclass=abc.ABCMeta):
+        #   pass
+        tests = [None, 42, 3.14, True, False,
+                 "hello", "hello\u1234", Classic]
+        #None, .../, NotImplemented,
+                 # 42, 2**100, 3.14, True, False, 1j,
+                 # "hello", "hello\u1234", f.__code__,
+                 # b"world", bytes(range(256)), slice(1, 10, 2),
+                 # NewStyle, Classic, max, WithMetaclass]
+        for x in tests:
+            self.assertIs(copy.copy(x), x)
+
+    def test_copy_list(self):
+        x = [1, 2, 3]
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        x = []
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+    def test_copy_mixed_set(self):
+        class FooSet:
+            def bar(self):
+                pass
+        a = set([1,2,3])
+        b = copy.deepcopy(a)
+        a = set([1,2,3])
+        b = copy.deepcopy(a)
+        self.assertTrue(a == b)
+        self.assertFalse(a is b)
+        mixed = set([(1,2), FooSet.bar])
+        mixedcopy = copy.deepcopy(mixed)
+        self.assertTrue(mixed == mixedcopy)
+        self.assertFalse(mixed is mixedcopy)
+        mixed.add(9)
+        mixedcopy2 = copy.deepcopy(mixed)
+        self.assertTrue(mixed == mixedcopy2)
+        self.assertFalse(mixed is mixedcopy2)
+        mixed.add(9)
+        self.assertFalse(mixed == mixedcopy)
+        mixedcopy2 = copy.copy(mixed)
+        self.assertTrue(mixed == mixedcopy2)
+
+    def test_copy_tuple(self):
+        x = (1, 2, 3)
+        self.assertIs(copy.copy(x), x)
+        x = ()
+        self.assertIs(copy.copy(x), x)
+        x = (1, 2, 3, [])
+        self.assertIs(copy.copy(x), x)
+
+    # def test_copy_registry(self):
+    #   class C:
+    #       def __new__(cls, foo):
+    #           obj = object.__new__(cls)
+    #           obj.foo = foo
+    #           return obj
+    #   def pickle_C(obj):
+    #       return (C, (obj.foo,))
+    #   x = C(42)
+    #   self.assertRaises(TypeError, copy.copy, x)
+        # copyreg.pickle(C, pickle_C, C)
+        # y = copy.copy(x)
+
+    def test_copy_reduce_ex(self):
+        x = ReduceEx()
+        y = copy.copy(x)
+        self.assertIs(y, x)
+        self.assertEqual(c, [1])
+
+    def test_copy_reduce(self):
+        x = Reduce()
+        y = copy.copy(x)
+        self.assertIs(y, x)
+        self.assertEqual(d, [1])
+
+    def test_copy_list(self):
+        x = [1, 2, 3]
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        x = []
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+    def test_copy_tuple(self):
+        x = (1, 2, 3)
+        self.assertIs(copy.copy(x), x)
+        x = ()
+        self.assertIs(copy.copy(x), x)
+        x = (1, 2, 3, [])
+        self.assertIs(copy.copy(x), x)
+
+    def test_copy_dict(self):
+        x = {"foo": 1, "bar": 2}
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        x = {}
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+
+    def test_copy_set(self):
+        x = {1, 2, 3}
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        x = set()
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+    # # def test_copy_frozenset(self):
+    # #     x = frozenset({1, 2, 3})
+    # #     self.assertIs(copy.copy(x), x)
+    # #     x = frozenset()
+    # #     self.assertIs(copy.copy(x), x)
+    
+    # # def test_copy_bytearray(self):
+    # #     x = bytearray(b'abc')
+    # #     y = copy.copy(x)
+    # #     self.assertEqual(y, x)
+    # #     self.assertIsNot(y, x)
+    # #     x = bytearray()
+    # #     y = copy.copy(x)
+    # #     self.assertEqual(y, x)
+    # #     self.assertIsNot(y, x)
+
+    def test_copy_inst_vanilla(self):
+        x = InstVan(42)
+        # print x == copy.copy(x)
+        self.assertFalse(copy.copy(x) == x)
+
+    def test_copy_inst_copy(self):
+        x = Copy_eq(42)
+        self.assertEqual(copy.copy(x), x)
+        
+    def test_copy_inst_getinitargs(self):
+        class C:
+            def __init__(self, foo):
+                self.foo = foo
+            def __getinitargs__(self):
+                return (self.foo,)
+            def __eq__(self, other):
+                return self.foo == other.foo
+        x = C(42)
+        self.assertRaises(NotImplementedError, copy.copy, x)
+        # self.assertEqual(copy.copy(x), x)
+
+    # def test_copy_inst_getnewargs(self):
+    #   # class NewArgs(int):
+    #   #   def __new__(cls, foo):
+    #   #       self = int.__new__(cls)
+    #   #       self.foo = foo
+    #   #       return self
+    #   #   def __getnewargs__(self):
+    #   #       return self.foo,
+    #   #   def __eq__(self, other):
+    #   #       return self.foo == other.foo
+    #   x = NewArgs(42)
+    #   y = copy.copy(x)
+    #   print y.__dict__()
+    #   self.assertIsInstance(y, NewArgs)
+    #   self.assertEqual(y, x)
+    #   self.assertIsNot(y, x)
+    #   self.assertEqual(y.foo, x.foo)
+    # def test_copy_inst_getnewargs_ex(self):
+    #   class C(int):
+    #       def __new__(cls, *, foo):
+    #           self = int.__new__(cls)
+    #           self.foo = foo
+    #           return self
+    #       def __getnewargs_ex__(self):
+    #           return (), {'foo': self.foo}
+    #       def __eq__(self, other):
+    #           return self.foo == other.foo
+    #   x = C(foo=42)
+    #   y = copy.copy(x)
+    #   self.assertIsInstance(y, C)
+    #   self.assertEqual(y, x)
+    #   self.assertIsNot(y, x)
+    #   self.assertEqual(y.foo, x.foo)
+
+    def test_copy_inst_getstate(self):
+        class C:
+            def __init__(self, foo):
+                self.foo = foo
+            def __getstate__(self):
+                return {"foo": self.foo}
+            def __eq__(self, other):
+                return self.foo == other.foo
+        x = C(42)
+        self.assertRaises(NotImplementedError, copy.copy, x)
+        # self.assertEqual(copy.copy(x), x)
+
+    def test_copy_inst_setstate(self):
+        class C:
+            def __init__(self, foo):
+                self.foo = foo
+            def __setstate__(self, state):
+                self.foo = state["foo"]
+            def __eq__(self, other):
+                return self.foo == other.foo
+        x = C(42)
+        self.assertRaises(NotImplementedError, copy.copy, x)
+    #   self.assertEqual(copy.copy(x), x)
+
+    def test_copy_inst_getstate_setstate(self):
+        class C:
+            def __init__(self, foo):
+                self.foo = foo
+            def __getstate__(self):
+                return self.foo
+            def __setstate__(self, state):
+                self.foo = state
+            def __eq__(self, other):
+                return self.foo == other.foo
+        x = C(42)
+        self.assertRaises(NotImplementedError, copy.copy, x)
+
+        # self.assertEqual(copy.copy(x), x)
+        # # State with boolean value is false (issue #25718)
+        # x = C(0.0)
+        # self.assertEqual(copy.copy(x), x)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_copy.py
+++ b/test/unit/test_copy.py
@@ -1,5 +1,5 @@
 """
-This file was modified from cpython.
+This file was modified from CPython.
 Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
 2011, 2012, 2013, 2014, 2015, 2016 Python Software Foundation; All Rights Reserved
 """
@@ -264,7 +264,6 @@ class TestCopy(unittest.TestCase):
     #   #       return self.foo == other.foo
     #   x = NewArgs(42)
     #   y = copy.copy(x)
-    #   print y.__dict__()
     #   self.assertIsInstance(y, NewArgs)
     #   self.assertEqual(y, x)
     #   self.assertIsNot(y, x)

--- a/test/unit/test_deepcopy.py
+++ b/test/unit/test_deepcopy.py
@@ -1,5 +1,5 @@
 """
-This file was modified from cpython.
+This file was modified from CPython.
 Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
 2011, 2012, 2013, 2014, 2015, 2016 Python Software Foundation; All Rights Reserved
 """
@@ -52,26 +52,26 @@ class reconstruct_state():
     def __reduce__(self):
         return (reconstruct_state, (), self.__dict__)
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__()
+        return self.__dict__ == other.__dict__
 
 class reconstruct_state_setstate(object):
     def __reduce__(self):
-        return (reconstruct_state_setstate, (), self.__dict__())
+        return (reconstruct_state_setstate, (), self.__dict__)
     def __setstate__(self, state):
-        self.__dict__().update(state)
+        self.__dict__.update(state)
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
 class reduce_4tuple(list):
     def __reduce__(self):
-        return (reduce_4tuple, (), self.__dict__(), iter(self))
+        return (reduce_4tuple, (), self.__dict__, iter(self))
     def __eq__(self, other):
         return (list(self) == list(other) and
                 self.__dict__ == other.__dict__)
 
 class reduce_5tuple(dict):
     def __reduce__(self):
-        return (reduce_5tuple, (), self.__dict__(), None, self.items())
+        return (reduce_5tuple, (), self.__dict__, None, self.items())
     def __eq__(self, other):
         return (dict(self) == dict(other) and
                 self.__dict__ == other.__dict__)

--- a/test/unit/test_deepcopy.py
+++ b/test/unit/test_deepcopy.py
@@ -1,0 +1,689 @@
+"""
+This file was modified from cpython.
+Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016 Python Software Foundation; All Rights Reserved
+"""
+import copy, types
+# import copy_reg
+# import weakref
+# import abc
+from operator import le, lt, ge, gt, eq, ne
+
+import unittest
+
+order_comparisons = le, lt, ge, gt
+equality_comparisons = eq, ne
+comparisons = order_comparisons + equality_comparisons
+n = []
+class _deep_reduce_ex:
+    def __reduce_ex__(self, proto):
+        n.append(1)
+        print "append to n"
+        return ""
+    def __reduce__(self):
+        self.fail("shouldn't call this")
+
+class Deepcopy_Deepcopy:
+    def __init__(self, foo):
+        self.foo = foo
+    def __deepcopy__(self, memo=None):
+        return Deepcopy_Deepcopy(self.foo)
+e = []
+
+class deep_reduce:
+    def __reduce__(self):
+        e.append(1)
+        print "append to e"
+        return ""
+
+class Inst_Deepcopy:
+    def __init__(self, foo):
+        self.foo = foo
+    def __deepcopy__(self, memo):
+        return Inst_Deepcopy(copy.deepcopy(self.foo, memo))
+    def __eq__(self, other):
+        return self.foo == other.foo
+
+class reconstruct_nostate(object):
+    def __reduce__(self):
+        return (reconstruct_nostate, ())
+
+class reconstruct_state():
+    def __reduce__(self):
+        return (reconstruct_state, (), self.__dict__)
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__()
+
+class reconstruct_state_setstate(object):
+    def __reduce__(self):
+        return (reconstruct_state_setstate, (), self.__dict__())
+    def __setstate__(self, state):
+        self.__dict__().update(state)
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+class reduce_4tuple(list):
+    def __reduce__(self):
+        return (reduce_4tuple, (), self.__dict__(), iter(self))
+    def __eq__(self, other):
+        return (list(self) == list(other) and
+                self.__dict__ == other.__dict__)
+
+class reduce_5tuple(dict):
+    def __reduce__(self):
+        return (reduce_5tuple, (), self.__dict__(), None, self.items())
+    def __eq__(self, other):
+        return (dict(self) == dict(other) and
+                self.__dict__ == other.__dict__)
+
+class TestCopy(unittest.TestCase):
+# # The deepcopy() method
+
+    def test_deepcopy_basic(self):
+        x = 42
+        y = copy.deepcopy(x)
+        self.assertEqual(y, x)
+
+    def test_deepcopy_memo(self):
+        # Tests of reflexive objects are under type-specific sections below.
+        # This tests only repetitions of objects.
+        x = []
+        x = [x, x]
+        y = copy.deepcopy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        self.assertIsNot(y[0], x[0])
+        self.assertIs(y[0], y[1])
+
+    def test_deepcopy_issubclass(self):
+        # XXX Note: there's no way to test the TypeError coming out of
+        # issubclass() -- this can only happen when an extension
+        # module defines a "type" that doesn't formally inherit from
+        # type.
+        # class Meta(type):
+        class Meta():
+            pass
+        class C(Meta):
+            pass
+        self.assertEqual(copy.deepcopy(C), C)
+
+    def test_deepcopy_deepcopy(self):
+        x = Deepcopy_Deepcopy(42)
+        y = copy.deepcopy(x)
+        self.assertEqual(y.__class__, x.__class__)
+        self.assertEqual(y.foo, x.foo)
+
+    # def test_deepcopy_registry(self):
+    #   class C(object):
+    #       def __new__(cls, foo):
+    #           obj = object.__new__(cls)
+    #           obj.foo = foo
+    #           return obj
+    #   def pickle_C(obj):
+    #       return (C, (obj.foo,))
+    #   x = C(42)
+    #   self.assertRaises(TypeError, copy.deepcopy, x)
+    #   # copy_reg.pickle(C, pickle_C, C)
+    #   # y = copy.deepcopy(x)
+
+    def test_deepcopy_reduce_ex(self):
+        x = _deep_reduce_ex()
+        y = copy.deepcopy(x)
+        self.assertEqual(n, [])
+
+    # def test_deepcopy_reduce(self):
+    #   x = deep_reduce()
+    #   y = copy.deepcopy(x)
+    #   self.assertIs(y, x)
+    #   self.assertEqual(e, [1])
+
+    # def test_deepcopy_cant(self):
+    #   class C:
+    #       def __getattribute__(self, name):
+    #           if name.startswith("__reduce"):
+    #               raise AttributeError(name)
+    #           return object.__getattribute__(self, name)
+    #   x = C()
+    #   # print "Should have error here", copy.deepcopy(x)
+    #   self.assertRaises(TypeError, copy.deepcopy, x)
+
+    # # Type-specific _deepcopy_xxx() methods
+
+    def test_deepcopy_atomic(self):
+        class Classic:
+            pass
+        class NewStyle(object):
+            pass
+        def f():
+            pass
+        tests = [None, 42, 3.14, True, False, "hello"]
+        # not implemented yet : f.__code__, 2**100, 1j, NewStyle, max, "hello\u1234", Classic] 
+        for x in tests:
+            self.assertIs(copy.deepcopy(x), x)
+
+    def test_deepcopy_list(self):
+        x = [[1, 2], 3]
+        y = copy.deepcopy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(x, y)
+        self.assertIsNot(x[0], y[0])
+
+    def test_deepcopy_reflexive_list(self):
+        x = []
+        x.append(x)
+        y = copy.deepcopy(x)
+        # for op in comparisons:
+        #     self.assertRaises(RecursionError, op, y, x)
+        self.assertIsNot(y, x)
+        self.assertIs(y[0], y)
+        self.assertEqual(len(y), 1)
+
+    def test_deepcopy_set(self):
+        class FooSet:
+            def bar(self):
+                pass
+        a = set([1,2,3])
+        b = copy.deepcopy(a)
+        a = set([1,2,3])
+        b = copy.deepcopy(a)
+        self.assertTrue(a == b)
+        self.assertFalse(a is b)
+        mixed = set([(1,2), FooSet.bar])
+        mixedcopy = copy.deepcopy(mixed)
+        self.assertTrue(mixed == mixedcopy)
+        self.assertFalse(mixed is mixedcopy)
+        mixed.add(9)
+        mixedcopy2 = copy.deepcopy(mixed)
+        self.assertTrue(mixed == mixedcopy2)
+        self.assertFalse(mixed is mixedcopy2)
+
+    def test_deepcopy_empty_tuple(self):
+        x = ()
+        y = copy.deepcopy(x)
+        self.assertIs(x, y)
+
+    def test_deepcopy_tuple(self):
+        x = ([1, 2], 3)
+        y = copy.deepcopy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(x, y)
+        self.assertIsNot(x[0], y[0])
+
+    def test_deepcopy_tuple_of_immutables(self):
+        x = ((1, 2), 3)
+        y = copy.deepcopy(x)
+        self.assertIs(x, y)
+
+    # def test_deepcopy_reflexive_tuple(self):
+    #   x = ([],)
+    #   x[0].append(x)
+    #   print "here is x", x
+
+    #   print type(x[0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0][0])
+    #   y = copy.deepcopy(x)
+    #   # for op in comparisons:
+    #   #     self.assertRaises(RecursionError, op, y, x)
+    #   self.assertIsNot(y, x)
+    #   # self.assertIsNot(y[0], x[0])
+    #   # self.assertIs(y[0][0], y)
+
+    def test_deepcopy_dict(self):
+        x = {"foo": [1, 2], "bar": 3}
+        y = copy.deepcopy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(x, y)
+        self.assertIsNot(x["foo"], y["foo"])
+
+    def test_deepcopy_reflexive_dict(self):
+        x = {}
+        x['foo'] = x
+        y = copy.deepcopy(x)
+        # for op in order_comparisons:
+        #     self.assertRaises(TypeError, op, y, x)
+        # for op in equality_comparisons:
+            # self.assertRaises(RecursionError, op, y, x)
+        self.assertIsNot(y, x)
+        self.assertIs(y['foo'], y)
+        self.assertEqual(len(y), 1)
+
+    def test_deepcopy_keepalive(self):
+        memo = {}
+        x = []
+        y = copy.deepcopy(x, memo)
+        self.assertIs(memo[id(memo)][0], x)
+
+    def test_deepcopy_dont_memo_immutable(self):
+        memo = {}
+        x = [1, 2, 3, 4]
+        y = copy.deepcopy(x, memo)
+        self.assertEqual(y, x)
+        # There's the entry for the new list, and the keep alive.
+        self.assertEqual(len(memo), 6)
+
+        memo = {}
+        x = [(1, 2)]
+        y = copy.deepcopy(x, memo)
+        self.assertEqual(y, x)
+        # Tuples with immutable contents are immutable for deepcopy.
+        self.assertEqual(len(memo), 5)
+
+        memo = {}
+        n = [False, True, None, "string"]
+        o = copy.deepcopy(n, memo)
+        self.assertEqual(len(memo), 6)
+
+    def test_deepcopy_inst_vanilla(self):
+        class C:
+            def __init__(self, foo):
+                self.foo = foo
+            def __eq__(self, other):
+                return self.foo == other.foo
+        x = C([42])
+        y = copy.deepcopy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y.foo, x.foo)
+        # print "types", type(y), type(x), x.__class__, y.__class__
+
+    def test_deepcopy_inst_deepcopy(self):
+        x = Inst_Deepcopy([42])
+        y = copy.deepcopy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        self.assertIsNot(y.foo, x.foo)
+
+    def test_deepcopy_inst_getinitargs(self):
+        class C:
+            def __init__(self, foo):
+                self.foo = foo
+            def __getinitargs__(self):
+                return (self.foo,)
+            def __eq__(self, other):
+                return self.foo == other.foo
+        x = C([42])
+        self.assertRaises(NotImplementedError, copy.deepcopy, x)
+
+        # y = copy.deepcopy(x)
+        # self.assertEqual(y, x)
+        # self.assertIsNot(y, x)
+        # self.assertIsNot(y.foo, x.foo)
+
+#   # def test_deepcopy_inst_getnewargs(self):
+#   #   class C(int):
+#   #       def __new__(cls, foo):
+#   #           self = int.__new__(cls)
+#   #           self.foo = foo
+#   #           return self
+#   #       def __getnewargs__(self):
+#   #           return self.foo,
+#   #       def __eq__(self, other):
+#   #           return self.foo == other.foo
+#   #   x = C(42)
+#   #   y = copy.deepcopy(x)
+#   #   self.assertIsInstance(y, C)
+#   #   print isinstance(y, C)
+#   #   self.assertEqual(y, x)
+#   #   self.assertIsNot(y, x)
+#   #   self.assertEqual(y.foo, x.foo)
+#   #   self.assertIsNot(y.foo, x.foo)
+
+#   # def test_deepcopy_inst_getnewargs_ex(self):
+#   #   class C(int):
+#   #       def __new__(cls, *, foo):
+#   #           self = int.__new__(cls)
+#   #           self.foo = foo
+#   #           return self
+#   #       def __getnewargs_ex__(self):
+#   #           return (), {'foo': self.foo}
+#   #       def __eq__(self, other):
+#   #           return self.foo == other.foo
+#   #   x = C(foo=[42])
+#   #   y = copy.deepcopy(x)
+#   #   self.assertIsInstance(y, C)
+#   #   self.assertEqual(y, x)
+#   #   self.assertIsNot(y, x)
+#   #   self.assertEqual(y.foo, x.foo)
+#   #   self.assertIsNot(y.foo, x.foo)
+
+#   def test_deepcopy_inst_getstate(self):
+#       class C:
+#           def __init__(self, foo):
+#               self.foo = foo
+#           def __getstate__(self):
+#               return {"foo": self.foo}
+#           def __eq__(self, other):
+#               return self.foo == other.foo
+#       x = C([42])
+#       y = copy.deepcopy(x)
+#       self.assertEqual(y, x)
+#       self.assertIsNot(y, x)
+#       self.assertIsNot(y.foo, x.foo)
+
+#   def test_deepcopy_inst_setstate(self):
+#       class C:
+#           def __init__(self, foo):
+#               self.foo = foo
+#           def __setstate__(self, state):
+#               self.foo = state["foo"]
+#           def __eq__(self, other):
+#               return self.foo == other.foo
+#       x = C([42])
+#       y = copy.deepcopy(x)
+#       self.assertEqual(y, x)
+#       self.assertIsNot(y, x)
+#       self.assertIsNot(y.foo, x.foo)
+
+#   # def test_deepcopy_inst_getstate_setstate(self):
+#   #   class C:
+#   #       def __init__(self, foo):
+#   #           self.foo = foo
+#   #       def __getstate__(self):
+#   #           return self.foo
+#   #       def __setstate__(self, state):
+#   #           self.foo = state
+#   #       def __eq__(self, other):
+#   #           return self.foo == other.foo
+#   #   x = C([42])
+#   #   y = copy.deepcopy(x)
+#   #   self.assertEqual(y, x)
+#   #   self.assertIsNot(y, x)
+#   #   self.assertIsNot(y.foo, x.foo)
+#   #   # State with boolean value is false (issue #25718)
+#   #   x = C([])
+#   #   y = copy.deepcopy(x)
+#   #   self.assertEqual(y, x)
+#   #   self.assertIsNot(y, x)
+#   #   self.assertIsNot(y.foo, x.foo)
+
+#   def test_deepcopy_reflexive_inst(self):
+#       class C:
+#           pass
+#       x = C()
+#       x.foo = x
+#       y = copy.deepcopy(x)
+#       self.assertIsNot(y, x)
+#       self.assertIs(y.foo, y)
+
+    # def test_deepcopy_range(self):
+    #   class I(int):
+    #       pass
+    #   x = range(I(10))
+    #   y = copy.deepcopy(x)
+    #   self.assertIsNot(y, x)
+    #   self.assertEqual(y, x)
+    #   self.assertIsNot(y.stop, x.stop)
+    #   self.assertEqual(y.stop, x.stop)
+    #   self.assertIsInstance(y.stop, I)
+
+#   # # _reconstruct()
+
+    # def test_reconstruct_string(self):
+    #   class C:
+    #       def __reduce__(self):
+    #           return ""
+    #   x = C()
+    #   y = copy.copy(x)
+        # self.assertIs(y, x)
+        # y = copy.deepcopy(x)
+        # self.assertIs(y, x)
+
+
+    def test_reconstruct_nostate(self):
+        x = reconstruct_nostate()
+        x.foo = 42
+        y = copy.copy(x)
+        # self.assertIs(y.__class__, x.__class__)
+        y = copy.deepcopy(x)
+        # self.assertIs(y.__class__, x.__class__)
+
+    def test_reconstruct_state(self):
+        x = reconstruct_state()
+        x.foo = [42]
+        y = copy.copy(x)
+        # self.assertEqual(y, x)
+        y = copy.deepcopy(x)
+        # self.assertEqual(y, x)
+        self.assertIsNot(y.foo, x.foo)
+
+    def test_reconstruct_state_setstate(self):
+        x = reconstruct_state_setstate()
+        x.foo = [42]
+        # y = copy.copy(x)
+        self.assertRaises(NotImplementedError, copy.copy, x)
+        # self.assertEqual(y, x)
+        # y = copy.deepcopy(x)
+        # self.assertEqual(y, x)
+        # self.assertIsNot(y.foo, x.foo)
+
+    def test_reconstruct_reflexive(self):
+        class C(object):
+            pass
+        x = C()
+        x.foo = x
+        y = copy.deepcopy(x)
+        self.assertIsNot(y, x)
+        self.assertIs(y.foo, y)
+
+#     # Additions for Python 2.3 and pickle protocol 2
+
+    # def test_reduce_4tuple(self):
+    #   x = reduce_4tuple([[1, 2], 3])
+    #   y = copy.copy(x)
+    #   self.assertEqual(x, y)
+    #   self.assertIsNot(x, y)
+    #   self.assertIs(x[0], y[0])
+    #   y = copy.deepcopy(x)
+    #   self.assertEqual(x, y)
+    #   self.assertIsNot(x, y)
+    #   self.assertIsNot(x[0], y[0])
+
+    # def test_reduce_5tuple(self):
+
+    #   x = reduce_5tuple([("foo", [1, 2]), ("bar", 3)])
+    #   y = copy.copy(x)
+    #   # self.assertEqual(x, y)
+    #   self.assertIsNot(x, y)
+    #   self.assertIs(x["foo"], y["foo"])
+    #   y = copy.deepcopy(x)
+    #   # self.assertEqual(x, y)
+    #   self.assertIsNot(x, y)
+    #   self.assertIsNot(x["foo"], y["foo"])
+
+    def test_copy_slots(self):
+        class C:
+            __slots__ = ["foo"]
+        x = C()
+        x.foo = [42]
+        y = copy.copy(x)
+        self.assertIs(x.foo, y.foo)
+
+    def test_deepcopy_slots(self):
+        class C(object):
+            __slots__ = ["foo"]
+        x = C()
+        x.foo = [42]
+        y = copy.deepcopy(x)
+        self.assertEqual(x.foo, y.foo)
+        self.assertIsNot(x.foo, y.foo)
+
+    # def test_deepcopy_dict_subclass(self):
+    #   class C(dict):
+    #       def __init__(self, d=None):
+    #           if not d:
+    #               d = {}
+    #           self._keys = list(d.keys())
+    #           super().__init__(d)
+    #       def __setitem__(self, key, item):
+    #           super().__setitem__(key, item)
+    #           if key not in self._keys:
+    #               self._keys.append(key)
+    #   x = C(d={'foo':0})
+    #   y = copy.deepcopy(x)
+    #   self.assertEqual(x, y)
+    #   self.assertEqual(x._keys, y._keys)
+    #   self.assertIsNot(x, y)
+    #   x['bar'] = 1
+    #   self.assertNotEqual(x, y)
+    #   self.assertNotEqual(x._keys, y._keys)
+
+    # def test_copy_list_subclass(self):
+    #   class C(list):
+    #       pass
+    #   x = C([[1, 2], 3])
+    #   x.foo = [4, 5]
+    #   y = copy.copy(x)
+    #   self.assertEqual(list(x), list(y))
+    #   self.assertEqual(x.foo, y.foo)
+    #   self.assertIs(x[0], y[0])
+    #   self.assertIs(x.foo, y.foo)
+
+    # def test_deepcopy_list_subclass(self):
+    #   class C(list):
+    #       pass
+    #   x = C([[1, 2], 3])
+    #   x.foo = [4, 5]
+    #   y = copy.deepcopy(x)
+    #   self.assertEqual(list(x), list(y))
+    #   self.assertEqual(x.foo, y.foo)
+    #   self.assertIsNot(x[0], y[0])
+    #   self.assertIsNot(x.foo, y.foo)
+
+    # def test_copy_tuple_subclass(self):
+    #   class C(tuple):
+    #       pass
+    #   x = C([1, 2, 3])
+    #   # self.assertEqual(tus
+    # def test_deepcopy_tuple_subclass(self):
+#         class C(tuple):
+#             pass
+#         x = C([[1, 2], 3])
+#         self.assertEqual(tuple(x), ([1, 2], 3))
+#         y = copy.deepcopy(x)
+#         self.assertEqual(tuple(y), ([1, 2], 3))
+#         self.assertIsNot(x, y)
+#         self.assertIsNot(x[0], y[0])
+
+    # def test_getstate_exc(self):
+    #   class EvilState(object):
+    #       def __getstate__(self):
+    #           raise ValueError("ain't got no stickin' state")
+    #   self.assertRaises(ValueError, copy.copy, EvilState())
+
+    def test_copy_function(self):
+        self.assertEqual(copy.copy(global_foo), global_foo)
+        def foo(x, y): return x+y
+        self.assertEqual(copy.copy(foo), foo)
+        bar = lambda: None
+        self.assertEqual(copy.copy(bar), bar)
+
+    def test_deepcopy_function(self):
+        self.assertEqual(copy.deepcopy(global_foo), global_foo)
+        def foo(x, y): return x+y
+        self.assertEqual(copy.deepcopy(foo), foo)
+        bar = lambda: None
+        self.assertEqual(copy.deepcopy(bar), bar)
+
+#     def _check_weakref(self, _copy):
+#         class C(object):
+#             pass
+#         obj = C()
+#         x = weakref.ref(obj)
+#         y = _copy(x)
+#         self.assertIs(y, x)
+#         del obj
+#         y = _copy(x)
+#         self.assertIs(y, x)
+
+#     def test_copy_weakref(self):
+#         self._check_weakref(copy.copy)
+
+#     def test_deepcopy_weakref(self):
+#         self._check_weakref(copy.deepcopy)
+
+    def _check_copy_weakdict(self, _dicttype):
+        class C(object):
+            pass
+        a, b, c, d = [C() for i in range(4)]
+        u = _dicttype()
+        u[a] = b
+        u[c] = d
+        v = copy.copy(u)
+        self.assertIsNot(v, u)
+        self.assertEqual(v, u)
+        self.assertEqual(v[a], b)
+        self.assertEqual(v[c], d)
+        self.assertEqual(len(v), 2)
+        del c, d
+        self.assertEqual(len(v), 1)
+        x, y = C(), C()
+        # The underlying containers are decoupled
+        v[x] = y
+
+        self.assertNotIn(x, u)
+
+    # def test_copy_weakkeydict(self):
+    #   self._check_copy_weakdict(weakref.WeakKeyDictionary)
+
+    # def test_copy_weakvaluedict(self):
+    #   self._check_copy_weakdict(weakref.WeakValueDictionary)
+
+    # def test_deepcopy_weakkeydict(self):
+    #   class C(object):
+    #       def __init__(self, i):
+    #           self.i = i
+    #   a, b, c, d = [C(i) for i in range(4)]
+    #   u = weakref.WeakKeyDictionary()
+    #   u[a] = b
+    #   u[c] = d
+    #   # Keys aren't copied, values are
+    #   v = copy.deepcopy(u)
+    #   self.assertNotEqual(v, u)
+    #   self.assertEqual(len(v), 2)
+    #   self.assertIsNot(v[a], b)
+    #   self.assertIsNot(v[c], d)
+    #   self.assertEqual(v[a].i, b.i)
+    #   self.assertEqual(v[c].i, d.i)
+    #   del c
+    #   self.assertEqual(len(v), 1)
+
+#     def test_deepcopy_weakvaluedict(self):
+#         class C(object):
+#             def __init__(self, i):
+#                 self.i = i
+#         a, b, c, d = [C(i) for i in range(4)]
+#         u = weakref.WeakValueDictionary()
+#         u[a] = b
+#         u[c] = d
+#         # Keys are copied, values aren't
+#         v = copy.deepcopy(u)
+#         self.assertNotEqual(v, u)
+#         self.assertEqual(len(v), 2)
+#         (x, y), (z, t) = sorted(v.items(), key=lambda pair: pair[0].i)
+#         self.assertIsNot(x, a)
+#         self.assertEqual(x.i, a.i)
+#         self.assertIs(y, b)
+#         self.assertIsNot(z, c)
+#         self.assertEqual(z.i, c.i)
+#         self.assertIs(t, d)
+#         del x, y, z, t
+#         del d
+#         self.assertEqual(len(v), 1)
+
+    def test_deepcopy_methods(self):
+        class potato:
+            def cut(self):
+                print "slices"
+        mashed = potato()
+        d1 = {"a": mashed.cut}
+        d2 = copy.deepcopy(d1)
+        # self.assertFalse(d1 == d2)
+        # self.assertFalse(d1 is d2)
+        # im = mashed.cut
+        # im_dc = copy.deepcopy(im)
+        # self.assertTrue(isinstance, (im, types.MethodType))
+        # self.assertFalse(im == im_dc)
+        # self.assertFalse(im is im_dc)
+
+def global_foo(x, y): return x+y
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is an implementation of the ```copy``` and ```types``` modules.  They are taken directly from CPython with minor modifications (and things commented out that Skulpt doesn't yet support).  There are also internal Skulpt updates to support the features the ```copy``` module requires, including the ```id``` builtin.

I'm not sure if we have already established the proper way to cite code from CPython.  Please speak up if you believe the copyright notices at the top of the relevant files are insufficient (or should be handled differently).  It does seem like perhaps the LICENSE file at least needs to be updated (regardless of anything to do with this pull request).