### PR TITLE
Update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2010 Scott Graham
+Copyright (c) 2009-2016 Scott Graham and contributors to the Skulpt Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -25,7 +25,7 @@ Portions of the code were written with the benefit of viewing code that's in
 the official "CPython" and "pypy" distribution and/or translated from code that's in the
 official "CPython" and "pypy" distribution. As such, they are:
 
-    Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006 Python Software
+    Copyright (c) 2001 -- 2016 Python Software
     Foundation; All Rights Reserved"
 
 per:


### PR DESCRIPTION
OK, just for the sake of getting this started, I made these simple updates to the LICENSE file

I looked at a bunch of projects, and it seems most (including Python) do not have copyright notices for every file.  Lots of things in the standard lib do have comments that indicate their origins but no explicit claim of copyright.

I do think that when we basically just drop in a file from CPython or PyPy we ought to acknowledge those origins in the file.