### PR TITLE
classmethod

### DIFF
--- a/src/classmethod.py
+++ b/src/classmethod.py
@@ -1,0 +1,12 @@
+class classmethod(object):
+    "Emulate PyClassMethod_Type() in Objects/funcobject.c"
+
+    def __init__(self, f):
+        self.f = f
+
+    def __get__(self, obj, klass=None):
+        if klass is None:
+            klass = type(obj)
+        def newfunc(*args):
+            return self.f(klass, *args)
+        return newfunc

--- a/src/compile.js
+++ b/src/compile.js
@@ -1471,9 +1471,14 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         }
     }
     if (hasFree) {
-        funcArgs.push("$free");
-        this.u.tempsToSave.push("$free");
+        if (vararg) {
+            this.u.varDeclsCode += "$free = arguments[arguments.length-1];"
+        } else {
+            funcArgs.push("$free");
+            this.u.tempsToSave.push("$free");
+        }
     }
+
     this.u.prefixCode += funcArgs.join(",");
 
     this.u.prefixCode += "){";
@@ -1565,18 +1570,9 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     //
     if (vararg) {
         start = funcArgs.length;
-        
-        if (hasFree) {
-            start -= 1;
-            // because the argument is overridden with the first of the varargs get $free from the arguments array
-        } 
 
         this.u.localnames.push(vararg.v);
         this.u.varDeclsCode += vararg.v + "=new Sk.builtins['tuple'](Array.prototype.slice.call(arguments," + start + (hasFree ? ",-1)" : ")") + "); /*vararg*/";
-    
-        if (hasFree) {
-            this.u.varDeclsCode += "$free = arguments[arguments.length-1];"
-        }
     }
 
     //

--- a/src/compile.js
+++ b/src/compile.js
@@ -1568,10 +1568,15 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         
         if (hasFree) {
             start -= 1;
+            // because the argument is overridden with the first of the varargs get $free from the arguments array
         } 
 
         this.u.localnames.push(vararg.v);
         this.u.varDeclsCode += vararg.v + "=new Sk.builtins['tuple'](Array.prototype.slice.call(arguments," + start + (hasFree ? ",-1)" : ")") + "); /*vararg*/";
+    
+        if (hasFree) {
+            this.u.varDeclsCode += "$free = arguments[arguments.length-1];"
+        }
     }
 
     //

--- a/src/compile.js
+++ b/src/compile.js
@@ -1565,8 +1565,13 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     //
     if (vararg) {
         start = funcArgs.length;
+        
+        if (hasFree) {
+            start -= 1;
+        } 
+
         this.u.localnames.push(vararg.v);
-        this.u.varDeclsCode += vararg.v + "=new Sk.builtins['tuple'](Array.prototype.slice.call(arguments," + start + ")); /*vararg*/";
+        this.u.varDeclsCode += vararg.v + "=new Sk.builtins['tuple'](Array.prototype.slice.call(arguments," + start + (hasFree ? ",-1)" : ")") + "); /*vararg*/";
     }
 
     //

--- a/src/function.js
+++ b/src/function.js
@@ -241,7 +241,12 @@ Sk.builtin.func.prototype.tp$call = function (args, kw) {
                 args.push(undefined);
             }
         }
-        args.push(this.func_closure);
+
+        if (this.func_code.toString().indexOf("($free)") != -1) { 
+            args.unshift(this.func_closure);
+        } else {
+            args.push(this.func_closure);
+        }
     }
 
     expectskw = this.func_code["co_kwargs"];

--- a/src/function.js
+++ b/src/function.js
@@ -242,11 +242,7 @@ Sk.builtin.func.prototype.tp$call = function (args, kw) {
             }
         }
 
-        if (this.func_code.toString().indexOf("($free)") != -1) { 
-            args.unshift(this.func_closure);
-        } else {
-            args.push(this.func_closure);
-        }
+        args.push(this.func_closure);
     }
 
     expectskw = this.func_code["co_kwargs"];

--- a/test/unit/test_decorators.py
+++ b/test/unit/test_decorators.py
@@ -280,27 +280,27 @@ class TestDecorators(unittest.TestCase):
         self.assertEqual(d.foo(1), (d, 1))
         self.assertEqual(D.foo(d, 1), (d, 1))
 
-    # def test_classmethods(self):
-    #     # Testing class methods...
-    #     class C(object):
-    #         def foo(*a): return a
-    #         goo = classmethod(foo)
-    #     c = C()
-    #     self.assertEqual(C.goo(1), (C, 1))
-    #     self.assertEqual(c.goo(1), (C, 1))
-    #     self.assertEqual(c.foo(1), (c, 1))
-    #     class D(C):
-    #         pass
-    #     d = D()
-    #     self.assertEqual(D.goo(1), (D, 1))
-    #     self.assertEqual(d.goo(1), (D, 1))
-    #     self.assertEqual(d.foo(1), (d, 1))
-    #     self.assertEqual(D.foo(d, 1), (d, 1))
-    #     # Test for a specific crash (SF bug 528132)
-    #     def f(cls, arg): return (cls, arg)
-    #     ff = classmethod(f)
-    #     self.assertEqual(ff.__get__(0, int)(42), (int, 42))
-    #     self.assertEqual(ff.__get__(0)(42), (int, 42))
+    def test_classmethods(self):
+        # Testing class methods...
+        class C(object):
+            def foo(*a): return a
+            goo = classmethod(foo)
+        c = C()
+        self.assertEqual(C.goo(1), (C, 1))
+        self.assertEqual(c.goo(1), (C, 1))
+        self.assertEqual(c.foo(1), (c, 1))
+        class D(C):
+            pass
+        d = D()
+        self.assertEqual(D.goo(1), (D, 1))
+        self.assertEqual(d.goo(1), (D, 1))
+        self.assertEqual(d.foo(1), (d, 1))
+        self.assertEqual(D.foo(d, 1), (d, 1))
+        # Test for a specific crash (SF bug 528132)
+        def f(cls, arg): return (cls, arg)
+        ff = classmethod(f)
+        self.assertEqual(ff.__get__(0, int)(42), (int, 42))
+        self.assertEqual(ff.__get__(0)(42), (int, 42))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_decorators.py
+++ b/test/unit/test_decorators.py
@@ -280,6 +280,27 @@ class TestDecorators(unittest.TestCase):
         self.assertEqual(d.foo(1), (d, 1))
         self.assertEqual(D.foo(d, 1), (d, 1))
 
+    # def test_classmethods(self):
+    #     # Testing class methods...
+    #     class C(object):
+    #         def foo(*a): return a
+    #         goo = classmethod(foo)
+    #     c = C()
+    #     self.assertEqual(C.goo(1), (C, 1))
+    #     self.assertEqual(c.goo(1), (C, 1))
+    #     self.assertEqual(c.foo(1), (c, 1))
+    #     class D(C):
+    #         pass
+    #     d = D()
+    #     self.assertEqual(D.goo(1), (D, 1))
+    #     self.assertEqual(d.goo(1), (D, 1))
+    #     self.assertEqual(d.foo(1), (d, 1))
+    #     self.assertEqual(D.foo(d, 1), (d, 1))
+    #     # Test for a specific crash (SF bug 528132)
+    #     def f(cls, arg): return (cls, arg)
+    #     ff = classmethod(f)
+    #     self.assertEqual(ff.__get__(0, int)(42), (int, 42))
+    #     self.assertEqual(ff.__get__(0)(42), (int, 42))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Same deal as for the staticmethod except this one does not work.  It is exposing some strange closure bug that needs someone smarter than me to track down.

running the unit tests will reveal:

```
Ran 1 tests, passed: 1 failed: 0

Test threw exception in  TestDecorators.test_classmethods  (ExternalError: TypeError: Cannot read property 'tp$name' of undefined on line 11)
Ran 3 tests, passed: 2 failed: 1
```

The line 11 in question is line 11 in classmethod.py

Any ideas???
