### PR TITLE
Fix `brun` command

### DIFF
--- a/skulpt.py
+++ b/skulpt.py
@@ -881,7 +881,7 @@ def run_in_browser(fn, options, debug_mode=False):
 
     with open('support/run_template.html') as tpfile:
         page = tpfile.read()
-        page = page % dict(code=prog,scripts=scripts,debug_mode=str(debug_mode).lower())
+        page = page % dict(code=prog,scripts=scripts,debug_mode=str(debug_mode).lower(),root="")
 
     with open("{0}/run.html".format(RUN_DIR),"w") as htmlfile:
         htmlfile.write(page)


### PR DESCRIPTION
20d27cce65da744d9d810ff7be34ce8785d7fa59 broke the `./m brun` command, by requiring a `root` substitution in `run_template.html`. This patch fixes it by adding a trivial `root=""`.