### PR TITLE
Support `__new__` in object construction

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -819,31 +819,11 @@ Sk.abstr.gattr = function (obj, nameJS, canSuspend) {
         throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + nameJS + "'");
     }
 
-
     if (obj.tp$getattr !== undefined) {
-        f = obj.tp$getattr("__getattribute__");
+        ret = obj.tp$getattr(nameJS, canSuspend);
     }
 
-    if (f !== undefined) {
-        ret = Sk.misceval.callsimOrSuspend(f, new Sk.builtin.str(nameJS));
-    }
-
-    ret = Sk.misceval.chain(ret, function(ret) {
-        var f;
-
-        if (ret === undefined && obj.tp$getattr !== undefined) {
-            ret = obj.tp$getattr(nameJS);
-
-            if (ret === undefined) {
-                f = obj.tp$getattr("__getattr__");
-
-                if (f !== undefined) {
-                    ret = Sk.misceval.callsimOrSuspend(f, new Sk.builtin.str(nameJS));
-                }
-            }
-        }
-        return ret;
-    }, function(r) {
+    ret = Sk.misceval.chain(ret, function(r) {
         if (r === undefined) {
             throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + nameJS + "'");
         }
@@ -854,6 +834,7 @@ Sk.abstr.gattr = function (obj, nameJS, canSuspend) {
 };
 goog.exportSymbol("Sk.abstr.gattr", Sk.abstr.gattr);
 
+
 Sk.abstr.sattr = function (obj, nameJS, data, canSuspend) {
     var objname = Sk.abstr.typeName(obj), r, setf;
 
@@ -861,16 +842,8 @@ Sk.abstr.sattr = function (obj, nameJS, data, canSuspend) {
         throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + nameJS + "'");
     }
 
-    if (obj.tp$getattr !== undefined) {
-        setf = obj.tp$getattr("__setattr__");
-        if (setf !== undefined) {
-            r = Sk.misceval.callsimOrSuspend(setf, new Sk.builtin.str(nameJS), data);
-            return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
-        }
-    }
-
     if (obj.tp$setattr !== undefined) {
-        obj.tp$setattr(nameJS, data);
+        return obj.tp$setattr(nameJS, data, canSuspend);
     } else {
         throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + nameJS + "'");
     }

--- a/src/function.js
+++ b/src/function.js
@@ -213,7 +213,7 @@ goog.exportSymbol("Sk.builtin.func", Sk.builtin.func);
 Sk.builtin.func.prototype.tp$name = "function";
 Sk.builtin.func.prototype.tp$descr_get = function (obj, objtype) {
     goog.asserts.assert(obj !== undefined && objtype !== undefined);
-    if (obj == null) {
+    if (obj === Sk.builtin.none.none$) {
         return this;
     }
     return new Sk.builtin.method(this, obj, objtype);

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1140,22 +1140,11 @@ Sk.misceval.applyOrSuspend = function (func, kwdict, varargseq, kws, args) {
 
     if (func === null || func instanceof Sk.builtin.none) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(func) + "' object is not callable");
-    } else if (typeof func === "function") {
-        // todo; i believe the only time this happens is the wrapper
-        // function around generators (that creates the iterator).
-        // should just make that a real function object and get rid
-        // of this case.
-        // alternatively, put it to more use, and perhaps use
-        // descriptors to create builtin.func's in other places.
-
-        // This actually happens for all builtin functions (in
-        // builtin.js, for example) as they are javascript functions,
+    } else if (typeof func === "function" && func.tp$call === undefined) {
+        // This happens in the wrapper functions around generators
+        // (that creates the iterator), and all the builtin functions
+        // (in builtin.js, for example) as they are javascript functions,
         // not Sk.builtin.func objects.
-
-        if (func.sk$klass) {
-            // klass wrapper around __init__ requires special handling
-            return func.apply(null, [kwdict, varargseq, kws, args, true]);
-        }
 
         if (varargseq) {
             for (it = varargseq.tp$iter(), i = it.tp$iternext(); i !== undefined; i = it.tp$iternext()) {
@@ -1204,14 +1193,6 @@ Sk.misceval.applyOrSuspend = function (func, kwdict, varargseq, kws, args) {
         //append kw args to args, filling in the default value where none is provided.
         return func.apply(null, args);
     } else {
-        fcall = func.__get__;
-        if (fcall !== undefined) {
-            fcall = Sk.misceval.callsimOrSuspend(func.__get__, func, func);
-            //args.unshift(func);
-            if (fcall.tp$call) {
-                return fcall.tp$call.call(fcall, args);
-            }
-        }
         fcall = func.tp$call;
         if (fcall !== undefined) {
             if (varargseq) {

--- a/src/object.js
+++ b/src/object.js
@@ -27,6 +27,9 @@ var _tryGetSubscript = function(dict, pyName) {
 };
 
 /**
+ * Get an attribute
+ * @param {string} name JS name of the attribute
+ * @param {boolean=} canSuspend Can we return a suspension?
  * @return {undefined}
  */
 Sk.builtin.object.prototype.GenericGetAttr = function (name, canSuspend) {
@@ -84,6 +87,12 @@ Sk.builtin.object.prototype.GenericPythonGetAttr = function(self, name) {
 };
 goog.exportSymbol("Sk.builtin.object.prototype.GenericPythonGetAttr", Sk.builtin.object.prototype.GenericPythonGetAttr);
 
+/**
+ * @param {string} name
+ * @param {undefined} value
+ * @param {boolean=} canSuspend
+ * @return {undefined}
+ */
 Sk.builtin.object.prototype.GenericSetAttr = function (name, value, canSuspend) {
     var objname = Sk.abstr.typeName(this);
     var pyname;
@@ -152,6 +161,7 @@ Sk.builtin.object.prototype.tp$name = "object";
  */
 Sk.builtin.object.prototype.ob$type = Sk.builtin.type.makeIntoTypeObj("object", Sk.builtin.object);
 Sk.builtin.object.prototype.ob$type.sk$klass = undefined;   // Nonsense for closure compiler
+Sk.builtin.object.prototype.tp$descr_set = undefined;   // Nonsense for closure compiler
 
 /** Default implementations of dunder methods found in all Python objects */
 /**

--- a/src/object.js
+++ b/src/object.js
@@ -170,10 +170,10 @@ Sk.builtin.object.prototype.tp$descr_set = undefined;   // Nonsense for closure 
  * @memberOf Sk.builtin.object.prototype
  * @instance
  */
-Sk.builtin.object.prototype["__new__"] = function (args) {
-    Sk.builtin.pyCheckArgs("__new__", args, 1, 1, false, false);
+Sk.builtin.object.prototype["__new__"] = function (cls) {
+    Sk.builtin.pyCheckArgs("__new__", arguments, 1, 1, false, false);
 
-    return new args[0]([], []);
+    return new cls([], []);
 };
 
 /**

--- a/src/type.js
+++ b/src/type.js
@@ -243,9 +243,9 @@ Sk.builtin.type = function (name, bases, dict) {
         };
 
         klass.prototype.tp$setattr = function(name, data, canSuspend) {
-            var r, setf = Sk.builtin.object.prototype.GenericGetAttr.call(this, "__setattr__");
+            var r, /** @type {(Object|undefined)} */ setf = Sk.builtin.object.prototype.GenericGetAttr.call(this, "__setattr__");
             if (setf !== undefined) {
-                r = Sk.misceval.callsimOrSuspend(setf, new Sk.builtin.str(name), data);
+                r = Sk.misceval.callsimOrSuspend(/** @type {Object} */ (setf), new Sk.builtin.str(name), data);
                 return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
             }
 
@@ -253,31 +253,31 @@ Sk.builtin.type = function (name, bases, dict) {
         };
 
         klass.prototype.tp$getattr = function(name, canSuspend) {
-            var r, getf;
+            var r, /** @type {(Object|undefined)} */ getf;
             // Convert AttributeErrors back into 'undefined' returns to match the tp$getattr
             // convention
             var callCatchUndefined = function() {
                 return Sk.misceval.tryCatch(function() {
-                    return Sk.misceval.callsimOrSuspend(getf, new Sk.builtin.str(name));
+                    return Sk.misceval.callsimOrSuspend(/** @type {Object} */ (getf), new Sk.builtin.str(name));
                 }, function (e) {
                     if (e instanceof Sk.builtin.AttributeError) {
                         return undefined;
                     } else {
                         throw e;
                     }
-                })
+                });
             };
 
             getf = Sk.builtin.object.prototype.GenericGetAttr.call(this, "__getattribute__");
 
             if (getf !== undefined) {
-                r = callCatchUndefined(getf);
+                r = callCatchUndefined();
             } else {
                 r = Sk.builtin.object.prototype.GenericGetAttr.call(this, name);
                 if (r === undefined) {
                     getf = Sk.builtin.object.prototype.GenericGetAttr.call(this, "__getattr__");
                     if (getf !== undefined) {
-                        r = callCatchUndefined(getf);
+                        r = callCatchUndefined();
                     }
                 }
             }

--- a/src/type.js
+++ b/src/type.js
@@ -121,6 +121,8 @@ Sk.builtin.type = function (name, bases, dict) {
             self["$d"] = new Sk.builtin.dict([]);
             self["$d"].mp$ass_subscript(new Sk.builtin.str("__dict__"), self["$d"]);
 
+            // TODO deal with __new__ properly. (Also, does this handle multiple inheritance?)
+
             if (klass.prototype.tp$base !== undefined) {
                 if (klass.prototype.tp$base.sk$klass) {
                     klass.prototype.tp$base.call(this, kwdict, varargseq, kws, args.slice(), canSuspend);
@@ -134,24 +136,15 @@ Sk.builtin.type = function (name, bases, dict) {
 
             init = Sk.builtin.type.typeLookup(self.ob$type, "__init__");
             if (init !== undefined) {
-                // return should be None or throw a TypeError otherwise
+                // TODO? return should be None or throw a TypeError otherwise
                 args.unshift(self);
-                s = Sk.misceval.applyOrSuspend(init, kwdict, varargseq, kws, args);
+                // Regardless, we make sure we unconditionally return self, whatever __init__() returns
+                s = Sk.misceval.chain(
+                    Sk.misceval.applyOrSuspend(init, kwdict, varargseq, kws, args),
+                    function() { return self; }
+                );
 
-                return (function doSusp(s) {
-                    if (s instanceof Sk.misceval.Suspension) {
-                        // TODO I (Meredydd) don't know whether we are ever called
-                        // from anywhere except Sk.misceval.applyOrSuspend().
-                        // If we're not, we don't need a canSuspend parameter at all.
-                        if (canSuspend) {
-                            return new Sk.misceval.Suspension(doSusp, s);
-                        } else {
-                            return Sk.misceval.retryOptionalSuspensionOrThrow(s);
-                        }
-                    } else {
-                        return self;
-                    }
-                })(s);
+                return canSuspend ? s : Sk.misceval.retryOptionalSuspensionOrThrow(s);
             }
 
             return self;
@@ -159,11 +152,10 @@ Sk.builtin.type = function (name, bases, dict) {
 
         var _name = Sk.ffi.remapToJs(name); // unwrap name string to js for latter use
 
-        var inheritsFromObject = false, inheritsBuiltin = false;
+        var inheritsBuiltin = false;
 
         if (bases.v.length === 0 && Sk.python3) {
             // new style class, inherits from object by default
-            inheritsFromObject = true;
             Sk.abstr.setUpInheritance(_name, klass, Sk.builtin.object);
         }
 
@@ -182,9 +174,6 @@ Sk.builtin.type = function (name, bases, dict) {
                 if (!parent.sk$klass && builtin_bases.indexOf(parent) < 0) {
                     builtin_bases.push(parent);
                 }
-
-                // This class inherits from Sk.builtin.object at some level
-                inheritsFromObject = true;
             }
         }
 
@@ -204,12 +193,6 @@ Sk.builtin.type = function (name, bases, dict) {
 
         klass.prototype.tp$name = _name;
         klass.prototype.ob$type = Sk.builtin.type.makeIntoTypeObj(_name, klass);
-
-        if (!inheritsFromObject) {
-            // old style class, does not inherit from object
-            klass.prototype.tp$getattr = Sk.builtin.object.prototype.GenericGetAttr;
-            klass.prototype.tp$setattr = Sk.builtin.object.prototype.GenericSetAttr;
-        }
 
         // set __module__ if not present (required by direct type(name, bases, dict) calls)
         var module_lk = new Sk.builtin.str("__module__");
@@ -238,7 +221,6 @@ Sk.builtin.type = function (name, bases, dict) {
         klass.prototype["$r"] = function () {
             var cname;
             var mod;
-            // TODO use Sk.abstr.gattr() here so __repr__ can be dynamically provided (eg by __getattr__())
             var reprf = this.tp$getattr("__repr__");
             if (reprf !== undefined && reprf.im_func !== Sk.builtin.object.prototype["__repr__"]) {
                 return Sk.misceval.apply(reprf, undefined, undefined, undefined, []);
@@ -259,8 +241,51 @@ Sk.builtin.type = function (name, bases, dict) {
                 return new Sk.builtin.str("<" + cname + _name + " object>");
             }
         };
+
+        klass.prototype.tp$setattr = function(name, data, canSuspend) {
+            var r, setf = Sk.builtin.object.prototype.GenericGetAttr.call(this, "__setattr__");
+            if (setf !== undefined) {
+                r = Sk.misceval.callsimOrSuspend(setf, new Sk.builtin.str(name), data);
+                return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
+            }
+
+            return Sk.builtin.object.prototype.GenericSetAttr.call(this, name, data);
+        };
+
+        klass.prototype.tp$getattr = function(name, canSuspend) {
+            var r, getf;
+            // Convert AttributeErrors back into 'undefined' returns to match the tp$getattr
+            // convention
+            var callCatchUndefined = function() {
+                return Sk.misceval.tryCatch(function() {
+                    return Sk.misceval.callsimOrSuspend(getf, new Sk.builtin.str(name));
+                }, function (e) {
+                    if (e instanceof Sk.builtin.AttributeError) {
+                        return undefined;
+                    } else {
+                        throw e;
+                    }
+                })
+            };
+
+            getf = Sk.builtin.object.prototype.GenericGetAttr.call(this, "__getattribute__");
+
+            if (getf !== undefined) {
+                r = callCatchUndefined(getf);
+            } else {
+                r = Sk.builtin.object.prototype.GenericGetAttr.call(this, name);
+                if (r === undefined) {
+                    getf = Sk.builtin.object.prototype.GenericGetAttr.call(this, "__getattr__");
+                    if (getf !== undefined) {
+                        r = callCatchUndefined(getf);
+                    }
+                }
+            }
+            
+            return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
+        };
+
         klass.prototype.tp$str = function () {
-            // TODO use Sk.abstr.gattr() here so __str__ can be dynamically provided (eg by __getattr__())
             var strf = this.tp$getattr("__str__");
             if (strf !== undefined && strf.im_func !== Sk.builtin.object.prototype["__str__"]) {
                 return Sk.misceval.apply(strf, undefined, undefined, undefined, []);
@@ -365,9 +390,10 @@ Sk.builtin.type = function (name, bases, dict) {
         };
 
         // Register skulpt shortcuts to magic methods defined by this class.
-        // TODO: This is somewhat problematic, as it means that dynamically defined
-        // methods (eg those returned by __getattr__()) cannot be used by these magic
-        // functions.
+        // Dynamically deflined methods (eg those returned by __getattr__())
+        // cannot be used by these magic functions; this is consistent with
+        // how CPython handles "new-style" classes:
+        // https://docs.python.org/2/reference/datamodel.html#special-method-lookup-for-old-style-classes
         var dunder, skulpt_name, canSuspendIdx;
         for (dunder in Sk.dunderToSkulpt) {
             skulpt_name = Sk.dunderToSkulpt[dunder];

--- a/src/type.js
+++ b/src/type.js
@@ -164,7 +164,7 @@ Sk.builtin.type = function (name, bases, dict) {
                 if (init !== undefined) {
                     args.unshift(self);
                     return Sk.misceval.applyOrSuspend(init, undefined, undefined, kws, args);
-                } else if (newf === undefined && (args.length != 0 || kws.length != 0) && !inheritsBuiltin) {
+                } else if (newf === undefined && (args.length !== 0 || kws.length !== 0) && !inheritsBuiltin) {
                     // We complain about spurious constructor arguments if neither __new__
                     // nor __init__ were overridden
                     throw new Sk.builtin.TypeError("__init__() got unexpected argument(s)");

--- a/test/run/t407.py.real
+++ b/test/run/t407.py.real
@@ -1,3 +1,3 @@
-['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
-['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
+['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']

--- a/test/run/t407.py.real.force
+++ b/test/run/t407.py.real.force
@@ -1,3 +1,3 @@
-['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
-['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
+['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__eq__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']

--- a/test/run/t551.py
+++ b/test/run/t551.py
@@ -32,6 +32,9 @@ print "a.x = " + str(a.x)
 
 a.x += 1
 
+# Should not touch __getattr__ or __setattr__ at all
+A.foo = "bar"
+
 
 class B(object):
   def __getattr__(self, attr):

--- a/test/unit/test_constructors.py
+++ b/test/unit/test_constructors.py
@@ -1,0 +1,72 @@
+import unittest
+
+class Tracer:
+    def reset():
+        Tracer.value = None
+
+
+class SimpleConstructor:
+    def __init__(self, x):
+        self.x = x
+        Tracer.value = x
+
+
+class InheritConstructor(SimpleConstructor):
+    pass
+
+
+class NewOverride(object):
+    def __new__(cls, x):
+        o = object.__new__(cls)
+        o.x = x
+        return o
+
+class InheritNewOverride(NewOverride):
+    pass
+
+
+class NewRedirect(object):
+    def __new__(cls):
+        return SimpleConstructor()
+
+
+class NoConstructors(object):
+    pass
+
+
+class ConstructorTests():
+
+    def test_init(self):
+        Tracer.reset()
+        sc = SimpleConstructor(42)
+        self.assertEqual(sc.x, 42)
+        self.assertEqual(Tracer.value, 42)
+
+        self.assertRaises(TypeError, lambda: SimpleConstructor())
+
+        Tracer.reset()
+        ic = InheritConstructor(42)
+        self.assertEqual(ic.x, 42)
+        self.assertEqual(Tracer.value, 42)
+
+        self.assertRaises(TypeError, lambda: InheritConstructor())
+
+    def test_new(self):
+        no = NewOverride(42)
+        self.assertEqual(no.x, 42)
+        self.assertIsInstance(no, NewOverride)
+        self.assertRaises(TypeError, lambda: NewOverride())
+
+        ino = InheritNewOverride(42)
+        self.assertIsInstance(no, InheritNewOverride)
+        self.assertEqual(ino.x, 42)
+
+        self.assertRaises(TypeError, lambda: InheritNewOverride())
+
+
+        redirected = NewRedirect()
+        self.assertIsInstance(redirected, SimpleConstructor)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_int.py
+++ b/test/unit/test_int.py
@@ -302,24 +302,29 @@ class IntTestCases(unittest.TestCase):
     #def test_intconversion(self):
 
     def test_int_subclass_with_int(self):
-        # skulpt does not support subclassing builtin types
+        # skulpt special-cases int() when called on something
+        # that's already an int.
         #class MyInt(int):
         class MyInt():
             def __int__(self):
                 return 42
 
-        # skulpt does not support subclassing builtin types
         #class BadInt(int):
         class BadInt():
             def __int__(self):
                 return 42.0
 
-        my_int = MyInt() #MyInt(7)
-        # not possible due to unsupported subclassing
-        #self.assertEqual(my_int, 7)
+        my_int = MyInt()
         self.assertEqual(int(my_int), 42)
 
         self.assertRaises(TypeError, int, BadInt())
+
+
+        class IntSubclass(int):
+            pass
+
+        my_int_2 = IntSubclass(42)
+        self.assertEqual(my_int_2, 42)
 
     def test_int_returns_int_subclass(self):
         class TruncReturnsIntSubclass:

--- a/test/unit/test_int.py
+++ b/test/unit/test_int.py
@@ -314,7 +314,7 @@ class IntTestCases(unittest.TestCase):
             def __int__(self):
                 return 42.0
 
-        my_int = MyInt(7)
+        my_int = MyInt() #MyInt(7)
         # not possible due to unsupported subclassing
         #self.assertEqual(my_int, 7)
         self.assertEqual(int(my_int), 42)


### PR DESCRIPTION
This PR supports the `__new__` method when constructing objects.

In order to make the tests pass, I also had to clean up our support for static/class methods and hand-rolled Python descriptors (I've made them use the proper descriptor system, which was already in use for methods, and removed the extraneous checks in function invocation).

This PR depends upon #634 because it also touches the attribute-lookup mechanism.
