### PR TITLE
error in repl.js with comments

### DIFF
--- a/repl/repl.js
+++ b/repl/repl.js
@@ -17,6 +17,7 @@ var compilableLines = [],
     defre = new RegExp("def.*|class.*"),
     //test for empty line.
     emptyline = new RegExp("^\\s*$"),
+    comment = new RegExp("^#.*"),
     //a regex to check if a line is an assignment
     //this regex checks whether or not a line starts with 
     //an identifier followed with some whitspace and then an = and then some more white space.
@@ -63,7 +64,7 @@ while (true) {
     //it's a onliner
     if (lines.length === 1) {
         //if it's a statement that should be printed (not containing an = or def or class or an empty line)
-        if (!assignment.test(lines[0]) && !defre.test(lines[0]) && !importre.test(lines[0]) && lines[0].length > 0) {
+        if (!assignment.test(lines[0]) && !defre.test(lines[0]) && !importre.test(lines[0]) && !comment.test(lines[0]) && lines[0].length > 0) {
             //if it doesn't contain print make sure it doesn't print None
             if (!re.test(lines[0])) {
 				//remove the statement


### PR DESCRIPTION
i had issues with lines starting with #-sign, so i figured out, how to add an additional regexp test. "^#.*" did the trick.