### PR TITLE
Make in-place operations fall back to normal binary ops

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -224,24 +224,14 @@ Sk.abstr.binary_iop_ = function (v, w, opname) {
         if (vop.call) {
             ret = vop.call(v, w);
         } else {  // assume that vop is an __xxx__ type method
-            ret = Sk.misceval.callsim(vop, v, w); //  added to be like not-in-place... is this okay?
+            ret = Sk.misceval.callsim(vop, v, w);
         }
         if (ret !== undefined && ret !== Sk.builtin.NotImplemented.NotImplemented$) {
             return ret;
         }
     }
-    wop = Sk.abstr.iboNameToSlotFunc_(w, opname);
-    if (wop !== undefined) {
-        if (wop.call) {
-            ret = wop.call(w, v);
-        } else { // assume that wop is an __xxx__ type method
-            ret = Sk.misceval.callsim(wop, w, v); //  added to be like not-in-place... is this okay?
-        }
-        if (ret !== undefined && ret !== Sk.builtin.NotImplemented.NotImplemented$) {
-            return ret;
-        }
-    }
-    Sk.abstr.binop_type_error(v, w, opname);
+    // If there wasn't an in-place operation, fall back to the binop
+    return Sk.abstr.binary_op_(v, w, opname);
 };
 Sk.abstr.unary_op_ = function (v, opname) {
     var ret;

--- a/test/unit/test_binop.py
+++ b/test/unit/test_binop.py
@@ -361,5 +361,39 @@ class RatTestCase(unittest.TestCase):
     # XXX Ran out of steam; TO DO: mod, future division
 
 
+
+class IntContainerNoOps(object):
+    def __init__(self, v):
+        self.v = v
+
+class IntContainerOps(IntContainerNoOps):
+    def __add__(self, x):
+        return self.__class__(self.v + x.v)
+
+class IntContainerIOps(IntContainerOps):
+    def __iadd__(self, x):
+        self.v += x.v
+        return self
+
+
+class IOpsTestCase(unittest.TestCase):
+    def check_ops(self, Cls, is_same = False):
+        self.assertEqual((Cls(2) + Cls(3)).v, 5)
+        # TODO other ops
+
+        x = Cls(2)
+        y = x
+        y += Cls(3)
+        self.assertEqual(y.v, 5)
+        self.assertIs(y, x) if is_same else self.assertIsNot(y, x)
+
+    def test_ops(self):
+        self.assertRaises(TypeError, lambda: IntContainerNoOps(2) + IntContainerNoOps(3))
+
+        self.check_ops(IntContainerOps, False)
+
+        #self.check_ops(IntContainerIOps, True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a fix for issue #465. It's a more general solution than PR #492, that lets us re-use the existing bin-op infrastructure (including `__radd__` and similar complexities). Tests included.