### PR TITLE
Make closures work with keyword argument matching

### DIFF
--- a/src/function.js
+++ b/src/function.js
@@ -229,22 +229,6 @@ Sk.builtin.func.prototype.tp$call = function (args, kw) {
     var name;
     var numargs;
 
-    // note: functions expect 'this' to be globals to avoid having to
-    // slice/unshift onto the main args
-    if (this.func_closure) {
-        // todo; OK to modify?
-        if (this.func_code["$defaults"] && this.func_code["co_varnames"]) {
-            // Make sure all default arguments are in args before adding closure
-            numargs = args.length;
-            numvarnames = this.func_code["co_varnames"].length;
-            for (i = numargs; i < numvarnames; i++) {
-                args.push(undefined);
-            }
-        }
-
-        args.push(this.func_closure);
-    }
-
     expectskw = this.func_code["co_kwargs"];
     kwargsarr = [];
 
@@ -281,12 +265,29 @@ Sk.builtin.func.prototype.tp$call = function (args, kw) {
             }
         }
     }
+
+    if (this.func_closure) {
+        // todo; OK to modify?
+        if (this.func_code["co_varnames"]) {
+            // Make sure all default arguments are in args before adding closure
+            numargs = args.length;
+            numvarnames = this.func_code["co_varnames"].length;
+            for (i = numargs; i < numvarnames; i++) {
+                args.push(undefined);
+            }
+        }
+
+        args.push(this.func_closure);
+    }
+
     if (expectskw) {
         args.unshift(kwargsarr);
     }
 
     //print(JSON.stringify(args, null, 2));
 
+    // note: functions expect 'this' to be globals to avoid having to
+    // slice/unshift onto the main args
     return this.func_code.apply(this.func_globals, args);
 };
 

--- a/test/unit/test_calling.py
+++ b/test/unit/test_calling.py
@@ -56,5 +56,20 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, lambda: o.f1(*[1, 2, 3], **{'y', 4}))
 
 
+# Test the interaction of free variables with kwargs
+def make_adder():
+    c = 42
+    def f(x):
+        return x + c
+    return f
+
+class ClosureTestCase(unittest.TestCase):
+    def test_closure_with_kwargs(self):
+        adder = make_adder()
+
+        self.assertEqual(adder(x=42), 84)
+
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When a Skulpt function has free variables, it takes an extra argument (the parent's `$cell`) to look them up in.

Unfortunately, we were adding that extra argument *before* we matched keyword arguments with named arguments, which was leading to odd errors. This PR produces the correct behaviour, by adding the closure argument after keyword matching has been performed. Test included.