### PR TITLE
Make dunder lookup use tp$getattr() again. Gives us better error messages.

### DIFF
--- a/src/type.js
+++ b/src/type.js
@@ -325,27 +325,27 @@ Sk.builtin.type = function (name, bases, dict) {
             return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
         };
         klass.prototype.tp$call = function (args, kw) {
-            return Sk.misceval.chain(Sk.abstr.gattr(this, "__call__", true), function(callf) {
+            return Sk.misceval.chain(this.tp$getattr("__call__", true), function(callf) {
+                if (callf === undefined) {
+                    throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(this) + "' object is not callable");
+                }
                 return Sk.misceval.applyOrSuspend(callf, undefined, undefined, kw, args);
             });
         };
         klass.prototype.tp$iter = function () {
-            var iterf = Sk.abstr.gattr(this, "__iter__", false);
+            var iterf = this.tp$getattr("__iter__");
+            if (iterf === undefined) {
+                throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(this) + "' object is not iterable");
+            }
             return Sk.misceval.callsim(iterf);
         };
         klass.prototype.tp$iternext = function (canSuspend) {
             var self = this;
-            var r = Sk.misceval.chain(
-                Sk.misceval.tryCatch(function() {
-                    return Sk.abstr.gattr(self, "next", canSuspend);
-                }, function(e) {
-                    if (e instanceof Sk.builtin.AttributeError) {
-                        throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(self) + "' object is not iterable");
-                    } else {
-                        throw e;
-                    }
-                }),
-            function(/** {Object} */ iternextf) {
+            var r = Sk.misceval.chain(self.tp$getattr("next", canSuspend), function(/** {Object} */ iternextf) {
+                if (iternextf === undefined) {
+                    throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(self) + "' object is not iterable");
+                }
+
                 return Sk.misceval.tryCatch(function() {
                     return Sk.misceval.callsimOrSuspend(iternextf);
                 }, function(e) {
@@ -361,7 +361,7 @@ Sk.builtin.type = function (name, bases, dict) {
         };
 
         klass.prototype.tp$getitem = function (key, canSuspend) {
-            var getf = Sk.abstr.gattr(this, "__getitem__", canSuspend), r;
+            var getf = this.tp$getattr("__getitem__", canSuspend), r;
             if (getf !== undefined) {
                 r = Sk.misceval.applyOrSuspend(getf, undefined, undefined, undefined, [key]);
                 return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
@@ -369,7 +369,7 @@ Sk.builtin.type = function (name, bases, dict) {
             throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(this) + "' object does not support indexing");
         };
         klass.prototype.tp$setitem = function (key, value, canSuspend) {
-            var setf = Sk.abstr.gattr(this, "__setitem__", canSuspend), r;
+            var setf = this.tp$getattr("__setitem__", canSuspend), r;
             if (setf !== undefined) {
                 r = Sk.misceval.applyOrSuspend(setf, undefined, undefined, undefined, [key, value]);
                 return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);


### PR DESCRIPTION
tl;dr Fix "this object is not callable"/"not iterable" error messages.

This mostly reverses commit ae9fed464, which tried to accommodate dynamically provided dunder-functions by using Sk.abstr.gattr(). The correct fix (implemented in commit 2e43d47 / PR #634) was to make tp$getattr() do dynamic lookup properly. Using Sk.abstr.gattr() just made things complicated, and in particular made `__call__`/`__iter__` lookup failures come out as generic AttributeErrors rather than TypeErrors with helpful messages.

Reversing this means that we get better error messages (like "this object is not callable/iterable") again.