### PR TITLE
Add npm scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 - pip install "GitPython>=0.2.0-beta1" --use-mirrors
 - mkdir -p vendors
 script:
-- npm run build -- -u
+- npm run build-min
 - npm test
 after_script:
 - ./dist-update.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,14 @@ python:
 - '2.6'
 install:
 - npm install npm@latest -g
-- npm install jscs -g
-- npm install jshint -g
 - npm install
 - jscs -V
 - jshint -v
 - pip install "GitPython>=0.2.0-beta1" --use-mirrors
 - mkdir -p vendors
 script:
-- ./skulpt.py dist
-- jshint src/*.js
-- jscs src/*.js
+- npm run build -- -u
+- npm test
 after_script:
 - ./dist-update.sh
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,13 @@ This is the contribute.md of our project. Great to have you here. Here are a few
 
 ## Team members
 
-The list of people who have contributed to Skulpt is too big and dynamic to be accurate 
+The list of people who have contributed to Skulpt is too big and dynamic to be accurate
 in a document like this.  Luckily Github does an excellent job of keeping track of
 [people who have contributed](https://github.com/skulpt/skulpt/graphs/contributors)
 
-[Brad Miller](https://github.com/bnmnetp) is the current owner of the project.  But see below for 
+[Brad Miller](https://github.com/bnmnetp) is the current owner of the project.  But see below for
 the full list of people with commit privileges.
- 
+
 ## Learn & listen
 
 This section includes ways to get started with your open source project. Include links to documentation and to different communication channels:
@@ -27,18 +27,18 @@ This section includes ways to get started with your open source project. Include
 This section includes advice on how to build new features for the project & what kind of process it includes.
 
 * First you should make a Fork. If you have never made a fork before please read this [github help article](https://help.github.com/articles/fork-a-repo)
-* Check out the document HACKING.rst  Although its a work in progress, it contains valuable information about Skulpt and how it is structured, some of the 
+* Check out the document HACKING.rst  Although its a work in progress, it contains valuable information about Skulpt and how it is structured, some of the
   naming conventions, and information to help you understand how it all works.
 * Create a feature branch using this command `git checkout -b feature_branch_name`
-* Once you have added a new feature make sure you develop some test cases and add them to the test bank. Even better would be to write the failing test first. 
-  You can add a test by copying the unit-test template file `./test/unit_tmpl.py` to `./test/unit` and give it a descriptive name. Make sure the functions in 
-  your test class start with `test`. [Here](https://docs.python.org/2/library/unittest.html) is some documentation on the unittest module (not everything is 
+* Once you have added a new feature make sure you develop some test cases and add them to the test bank. Even better would be to write the failing test first.
+  You can add a test by copying the unit-test template file `./test/unit_tmpl.py` to `./test/unit` and give it a descriptive name. Make sure the functions in
+  your test class start with `test`. [Here](https://docs.python.org/2/library/unittest.html) is some documentation on the unittest module (not everything is
   implemented in skulpt).
 * Before submitting a pull request please make sure you run ``./skulpt test`` and ``./skulpt dist`` this checks that there are no regressions.  
-  We have an automatic system to do regression testing, but if your pull request fails it is certain that it will not be accepted. 
+  We have an automatic system to do regression testing, but if your pull request fails it is certain that it will not be accepted.
 * Now you can push this branch to your fork on github (you can do this earlier too) with this command `git push -u origin feature_branch_name`. And create a Pull Request on github.
-* If the master branch gets updated before your pull request gets pulled in. You can do a `rebase` to base your commits off the new `master`. With a command 
-  that looks like `git rebase upstream/master`. Make sure you do a __force__ push to your branch `git push --force` because you've rewritten history, and all 
+* If the master branch gets updated before your pull request gets pulled in. You can do a `rebase` to base your commits off the new `master`. With a command
+  that looks like `git rebase upstream/master`. Make sure you do a __force__ push to your branch `git push --force` because you've rewritten history, and all
   your commits will appear in two fold if you don't
 
 We try to get to pull requests in a very timely way so they don't languish. Nothing is more frustrating than a project that just leaves pull requests sitting there for ages. Usually we get to them in a one or two days.
@@ -49,11 +49,11 @@ We try to get to pull requests in a very timely way so they don't languish. Noth
 * branch: `git checkout -b feature_branch_name`
 * add unit-test
 * commit: `git commit -m 'failing test'` (you can do this more often)
-* write code 
-* test: `./skulpt.py test` and `./skulpt.py dist`
+* write code
+* test: `npm test` and `npm run build`
 * commit: `git commit -m 'implement fix'` (you can do this more often)
 * push: `git push -u origin feature_branch_name`
-* pull-request: (on github) 
+* pull-request: (on github)
 
 
 
@@ -61,16 +61,16 @@ We try to get to pull requests in a very timely way so they don't languish. Noth
 ## Coding Style and Conventions
 
 Here are some coding conventions to keep in mind:
- 
-* ``Sk.ffi.remapToJs`` and ``Sk.ffi.remapToPy`` are your friends.  They take care of the details 
+
+* ``Sk.ffi.remapToJs`` and ``Sk.ffi.remapToPy`` are your friends.  They take care of the details
 of going from a Python type to a Javascript type and vice versa.  They are smart enough to work
-with common types and even work well recursively converting containers.  ``Sk.ffi.remapToJs`` is 
+with common types and even work well recursively converting containers.  ``Sk.ffi.remapToJs`` is
 **definitely preferred** over  ``foo.v``  
 * Use the ``pyCheckArgs`` function at the beginning of anything that will be exposed to a Python programmer.
 * Check the types of arguments when you know what they must be.
 * Explicitly return ``Sk.builtin.null.null$`` for functions and methds that should return ``None``
 * If you are adding a module or package to the library, respect the package/module conventions.
-    * modules should be named ``foo.js`` or ``foo.py`` 
+    * modules should be named ``foo.js`` or ``foo.py``
     * packages should be a directory with an ``__init__.js`` or ``__init__.py`` file, and possibly additional modules.
 
 
@@ -102,7 +102,7 @@ nice plugin called JSLintMate.  You can easily install [jshint](http://jshint.or
 
 ## Committers
 
-The committers are people who are responsible for reviewing and approving pull requests .  These are 
+The committers are people who are responsible for reviewing and approving pull requests .  These are
 generally people who have been around the project for a while and have "proven" themselves by contributing
 good code and ideas to the Skulpt.  This list may change over time as people gain or lose interest in
 Skulpt.  If you would like to volunteer contact Brad.
@@ -117,7 +117,7 @@ the review process I would recommend for committers is as follows:
 5.  Many of us have our own projects that exercise Skulpt to its limits. If you are particularly concerned about a PR then you may want to try out the built js files in your environment.
 6.  It is always appropriate to raise questions and have a group conversation about anything that looks particularly problematic or risky.
 7.  With the new style unit tests, You should ask the submitter to file issues for tests that they comment out.  This will let us track completeness over time.  Not every test needs its own issue.  Something like 'when blah feature is added enable  tests x,y,z in foo_test.py' should work.
- 
+
 The current group of committers is as follows:
 
 * [Brad Miller](https://github.com/bnmnetp)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ with common types and even work well recursively converting containers.  ``Sk.ff
 **definitely preferred** over  ``foo.v``  
 * Use the ``pyCheckArgs`` function at the beginning of anything that will be exposed to a Python programmer.
 * Check the types of arguments when you know what they must be.
-* Explicitly return ``Sk.builtin.null.null$`` for functions and methds that should return ``None``
+* Explicitly return ``Sk.builtin.none.none$`` for functions and methds that should return ``None``
 * If you are adding a module or package to the library, respect the package/module conventions.
     * modules should be named ``foo.js`` or ``foo.py``
     * packages should be a directory with an ``__init__.js`` or ``__init__.py`` file, and possibly additional modules.

--- a/HACKING.md
+++ b/HACKING.md
@@ -6,7 +6,7 @@ If you are reading this document, chances are you have used Skulpt in some form 
 What is Skulpt?
 ---------------
 
-Skulpt is a system that compiles Python (of the 2.6-ish variety) into Javascript.  But it's not Javascript that you can paste in to your browser and run.  Python and Javascript are very different languanges, their types are different, their scoping rules are different.  Python is designed to be run on Linux, or Windows, or Mac OS X, not in the browser! So, to provide a True Python experience Skulpt must provide a runtime environment in which the compiled code executes.  This runtime environment is provided by the skulpt.min.js and skulpt-stdlib.js files that you must include in your web page in order to make Skulpt work. 
+Skulpt is a system that compiles Python (of the 2.6-ish variety) into Javascript.  But it's not Javascript that you can paste in to your browser and run.  Python and Javascript are very different languanges, their types are different, their scoping rules are different.  Python is designed to be run on Linux, or Windows, or Mac OS X, not in the browser! So, to provide a True Python experience Skulpt must provide a runtime environment in which the compiled code executes.  This runtime environment is provided by the skulpt.min.js and skulpt-stdlib.js files that you must include in your web page in order to make Skulpt work.
 
 To give you some idea of what is going on behind the scenes with skulpt lets look at what happens when our friend "hello world" is is compiled from Python to Skulpt. We will revisit this program later and go into more detail, so for now, don't get bogged down in the detail, just have a look to see how much is really happening
 
@@ -73,7 +73,7 @@ To give you some idea of what is going on behind the scenes with skulpt lets loo
 
 So, 50 lines of Javascript for hello world eh?  That sounds kind of crazy, but you have to recognize that the environment with global variables, local variables, error handling, etc all has to happen even for the simplest program to run.  The parts of the program above that really print "hello world" are lines 26-29.  If you have a look at them you will see that we have to construct a string object from the string literal and then pass that off to some print function.
 
-In the example above `Sk.builtin.str` and `Sk.misceval.print_` are part of the Skulpt runtime.  It is usually the case that to extend Skulpt one of these runtime functions must be modified, or a new runtime function must be created and exposed so that it can be used in an ordinary Python program.  The rest of this manual will take you through the essential parts of Skulpt so you can feel comfortable working on and extending the runtime environment. 
+In the example above `Sk.builtin.str` and `Sk.misceval.print_` are part of the Skulpt runtime.  It is usually the case that to extend Skulpt one of these runtime functions must be modified, or a new runtime function must be created and exposed so that it can be used in an ordinary Python program.  The rest of this manual will take you through the essential parts of Skulpt so you can feel comfortable working on and extending the runtime environment.
 
 An important thing to keep in mind as you are trying to understand Skulpt is that it is heavily influenced by the implementation of CPython.  So although Python and Javascript are both object oriented languages many parts of the skulpt implementation are quite procedural.  For example using functions that take an object as their first parameter may seem strange as we should have just created a method on that object.  But in order to follow the CPython implementation this decision was made early on.
 
@@ -140,15 +140,15 @@ Perhaps one of the most important concepts to learn when starting to program Sku
 are always moving back and forth between Python objects and Javascript objects.  Much of your job
 as a skulpt hacker is to either create Python objects as part of a builtin or module function,
 or interact with objects that have been created by the users "regular" Python code.  Knowing when
-you are working with what is critical.  For example a Javascript string is not the same thing as a 
+you are working with what is critical.  For example a Javascript string is not the same thing as a
 python string.  A Python string is really an instance of ``Sk.builtin.str`` and a Javscript string is
-an instance of ``string``.  You can't compare the two directly, and you definitely cannot use them 
+an instance of ``string``.  You can't compare the two directly, and you definitely cannot use them
 interchangeably.
 
 Python  |  Skulpt              | Javascript
 --------|----------------------|-----------
 int     | Sk.builtin.int       | number
-float   | Sk.builtin.float     | number 
+float   | Sk.builtin.float     | number
 long    | Sk.builtin.lng       | NA
 complex | Sk.builtin.complex   | NA
 list    | Sk.builtin.list      | Array
@@ -168,7 +168,7 @@ When would you want to convert from Javascript to Python?  Very often, in your i
 
 
 In many places in the current codebase you will see the use of `somePythonObject.v`  Where `v` is the actual
-javascript value hidden away inside the Python object.  This is not the preferred way to obtain the mapping.  Use 
+javascript value hidden away inside the Python object.  This is not the preferred way to obtain the mapping.  Use
 the `Sk.ffi` API.
 
 Skulpt is divided into several namespaces, you have already seen a couple of them, so here is the list
@@ -314,7 +314,7 @@ Another Example Naming Conventions
     y = 2
     z = x + y
     print z
-    
+
 
 ### Javascript
 
@@ -502,10 +502,10 @@ program. With a little bit of sleuthing you find:
     /*    38 */                     //
     /*    39 */                     Sk.currLineNo = 2;
     /*    40 */                     Sk.currColNo = 0
-    /*    41 */ 
-    /*    42 */ 
+    /*    41 */
+    /*    42 */
     /*    43 */                     Sk.currFilename = './sd.py';
-    /*    44 */ 
+    /*    44 */
     /*    45 */                     var $loadname8 = $loc.sorted !== undefined ? $loc.sorted : Sk.misceval.loadname('sorted', $gbl);
     /*    46 */                     var $loadname9 = $loc.x !== undefined ? $loc.x : Sk.misceval.loadname('x', $gbl);
     /*    47 */                     var $call10 = Sk.misceval.call($loadname8, undefined, undefined, ['reverse', Sk.builtin.bool.true$], $loadname9);
@@ -564,7 +564,7 @@ module:
             Sk.builtin.pyCheckArgs("plotk", arguments, 0, Infinity, true, false)
             args = new Sk.builtins['tuple'](Array.prototype.slice.call(arguments, 1)); /*vararg*/
             kwargs = new Sk.builtins['dict'](kwa);
-    
+
             return new Sk.builtins['tuple']([args, kwargs]);
         };
         plotk_f['co_kwargs'] = true;
@@ -583,7 +583,7 @@ skulpt-stdlib.js. Looking around the distribution you will not
 immediately find skulpt.min.js because you need to build it. You get a
 sculpt.js file by using the skulpty.py script that comes with the distribution.
 running `./skulpt.py --help` will give you the full list of commands, but the two
-that you probably most care about are `./skulpt.py dist` and `./skulpt.py docbi`
+that you probably most care about are `npm run build` and `npm run docbi`
 The dist command builds both skulpt.min.js and skulpt-stdlib.js docbi builds
 skulpt-stdlib.js and puts a new copy of it in the doc/static directory.
 Lets begin with a quick tour of the source tree:
@@ -604,9 +604,9 @@ Lets begin with a quick tour of the source tree:
     add modules to the simpler editor later in this article.
 -   test - this directory contains a bunch of files for testing the
     implementation in a batch mode. These tests are run whenever you run
-    `./skulpt.py dist`, or `./skulpt.py test`.
+    `npm run build`, or `npm test`.
 -   dist - This directory gets created and populated when you run the
-    `skulpt.py dist` command. It contains the built and compressed versions of
+    `npm run build` command. It contains the built and compressed versions of
     skulpt.min.js and skulpt-stdlib.js
 
 To illustrate how to make use of modules, here's an extended version of
@@ -617,23 +617,23 @@ my earlier hello world style example.
     <head>
     <script src="skulpt.min.js" type="text/javascript"></script>
     <script src="skulpt-stdlib.js" type="text/javascript"></script>
-    
+
     </head>
-    
+
     <body>
     <script type="text/javascript">
     function outf(text) {
        var mypre = document.getElementById("output");
        mypre.innerHTML = mypre.innerHTML + text;
     }
-    
+
     function builtinRead(x)
     {
         if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined)
             throw "File not found: '" + x + "'";
         return Sk.builtinFiles["files"][x];
     }
-    
+
     function runit() {
        var prog = document.getElementById("yourcode").value;
        var mypre = document.getElementById("output");
@@ -655,9 +655,9 @@ my earlier hello world style example.
     </textarea>
     <button onclick="runit()" type="button">Run</button>
     </form>
-    
+
     <pre id="output"></pre>
-    
+
     </body>
     </html>
 
@@ -757,8 +757,8 @@ function.js if you want more explanation of how the builtin.func method
 works.
 
 Well, I think this should be enough to get you going. It's worth
-repeating, if you made it this far, don't forget to call `./skulpt.py docbi` or
-`./skulpt.py dist` after you make changes in your module, it's easy to get into the
+repeating, if you made it this far, don't forget to call `npm run docbi` or
+`npm run build` after you make changes in your module, it's easy to get into the
 mode of thinking that the new javascript is automatically loaded. But
 skulpt-stdlib.js is not automatically rebuilt!
 
@@ -780,12 +780,12 @@ Here is the snippet that demonstrates
 
 
     var keywds = Sk.importModule("keyword", false, false);
-    
+
     mod.namedtuple = function (name, fields) {
         var nm = Sk.ffi.remapToJs(name);
         // fields could be a string or a tuple or list of strings
         var flds = Sk.ffi.remapToJs(fields);
-    
+
         if (typeof(flds) === 'string') {
             flds = flds.split(/\s+/);
         }
@@ -838,7 +838,7 @@ follow these handy instructions:
     <https://github.com/skulpt/skulpt/blob/master/src/import.js#L179>
     the line would like this:
     `finalcode += "\ndebugger;" + co.funcname + "(" + namestr + ");";`
--   run `./skulpt.py debugbrowser` wait until all tests have run
+-   run `npm run debugbrowser` wait until all tests have run
 -   startup the developer tools cmd+alt+i on a mac or F12 on a PC in
     chrome that is
 -   run the test I added before and it stops right before you enter the
@@ -960,7 +960,7 @@ in figuring out what skulpt is actually doing. Now you should run all of
 the unit tests to make sure you have broken anything else accidentally.
 This is really easy:
 
-    ./skulpt.py test
+    npm test
 
 If any tests fail it will be obvious that they did, and you'll have to
 do some investigation to figure out why. At the time of this writing you
@@ -1060,7 +1060,7 @@ directory. Like this:
     > git update-index --refresh
     > git rm --cached -r .
     > git reset --hard
-    
+
 
 Getting stack traces from an exception
 --------------------------------------

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ benefit.
 Building Skulpt is straightforward:
 
 1. Clone the repository from GitHub, ideally using your own fork if you're planning on making any contributions
-2. Install node.js
+2. Install node.js and Python 2 (required to run the build scripts)
 3. Install the required dependencies using `npm install`
 4. Navigate to the repository and run `npm run build`
 5. The tests should run and you will find `skulpt.min.js` and `skulpt-stdlib.js` in the `dist`folder

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Welcome to the Skulpt developer community! Check out the ideas list below. And t
 
 ### Ideas List
 
-We are coordinating sprints on some of the ideas below, builtins, stdlib, third party modules, and core performance [here](https://github.com/skulpt/skulpt/issues/400).  We always welcome interested developers becoming Primarily Repsonsible Persons (PRP) for features they're working on. 
+We are coordinating sprints on some of the ideas below, builtins, stdlib, third party modules, and core performance [here](https://github.com/skulpt/skulpt/issues/400).  We always welcome interested developers becoming Primarily Repsonsible Persons (PRP) for features they're working on.
 
 6. Expand the skulpt standard library to include more modules from the CPython standard library.  So far we have math, random, turtle, time (partial) random (partial) urllib (partial) unittest, image, DOM (partial) and re (partial).  Any of the partial modules could be completed, or many other CPython modules could be added.  Potential new modules from the standard library include:  functools, itertools, collections, datetime, operator, and string.  Many of these would be relatively easy projects for a less exeperienced student to take on.
 
@@ -53,7 +53,7 @@ Building Skulpt is straightforward:
 
 1. Clone the repository from GitHub, ideally using your own fork if you're planning on making any contributions
 2. Install node.js
-3. Install the jscs, jshint and jsdoc node modules using `npm install -g jscs jshint jsdoc` (you may need to use `sudo` to run this command)
+3. Install the required dependencies using `npm install`
 4. Navigate to the repository and run `./skulpt.py dist`
 5. The tests should run and you will find `skulpt.min.js` and `skulpt-stdlib.js` in the `dist`folder
 
@@ -87,5 +87,3 @@ As time goes on its getting more dangerous to try to acknowledge everyone who ha
 * Ben Wheeler for the new and improved turtle module
 * Scott Rixner and students for many bug fixes and improvements
 * Of course, The complete list is here:  https://github.com/skulpt/skulpt/graphs/contributors
-
-

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Building Skulpt is straightforward:
 1. Clone the repository from GitHub, ideally using your own fork if you're planning on making any contributions
 2. Install node.js
 3. Install the required dependencies using `npm install`
-4. Navigate to the repository and run `./skulpt.py dist`
+4. Navigate to the repository and run `npm run build`
 5. The tests should run and you will find `skulpt.min.js` and `skulpt-stdlib.js` in the `dist`folder
 
 

--- a/dist-update.sh
+++ b/dist-update.sh
@@ -38,9 +38,8 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_TEST_RESULT" == "0" ]]; then
     #build skulpt at this tag
     cd $HOME/skulpt
     git checkout tags/$TAG
-    npm install jscs
-    npm install git://github.com/jshint/jshint/
-    ./skulpt.py dist -u
+    npm install
+    npm run build -- -u
     #create zip and tarbals
     cd dist
     tar -czf skulpt-latest.tar.gz *.js
@@ -72,7 +71,7 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_TEST_RESULT" == "0" ]]; then
   #build skulpt
   cd skulpt
   git reset HEAD --hard
-  ./skulpt.py dist -u
+  npm run build -- -u
   cd dist
   cp *.js ../../dist/
 

--- a/dist-update.sh
+++ b/dist-update.sh
@@ -39,7 +39,7 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_TEST_RESULT" == "0" ]]; then
     cd $HOME/skulpt
     git checkout tags/$TAG
     npm install
-    npm run build -- -u
+    npm run build-min
     #create zip and tarbals
     cd dist
     tar -czf skulpt-latest.tar.gz *.js
@@ -71,7 +71,7 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_TEST_RESULT" == "0" ]]; then
   #build skulpt
   cd skulpt
   git reset HEAD --hard
-  npm run build -- -u
+  npm run build-min
   cd dist
   cp *.js ../../dist/
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,25 @@
   "description": "Skulpt is a Javascript implementation of Python 2.x. Python that runs in your browser!",
   "keywords": ["skulpt"],
   "scripts": {
-    "lint": "jshint ."
+    "testdebug": "./skulpt.py testdebug",
+    "regengooglocs": "./skulpt.py regengooglocs",
+    "regensymtabtests": "./skulpt.py regensymtabtests",
+    "rununits": "./skulpt.py rununits",
+    "vmwareregr": "./skulpt.py vmwareregr",
+    "regenparser": "./skulpt.py regenparser",
+    "regenasttests": "./skulpt.py regenasttests",
+    "regenruntests": "./skulpt.py regenruntests",
+    "upload": "./skulpt.py upload",
+    "doctest": "./skulpt.py doctest",
+    "doc": "./skulpt.py doc",
+    "browser": "./skulpt.py browser",
+    "debugbrowser": "./skulpt.py debugbrowser",
+    "vfs": "./skulpt.py vfs",
+    "host": "./skulpt.py host",
+    "repl": "./skulpt.py repl",
+
+    "build": "./skulpt.py dist",
+    "test": "./skulpt.py test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "repl": "./skulpt.py repl",
 
     "build": "./skulpt.py dist",
+    "build-min": "./skulpt.py dist -u",
     "test": "./skulpt.py test"
   },
   "repository": {

--- a/test/unit/test_list_sort.py
+++ b/test/unit/test_list_sort.py
@@ -2,7 +2,7 @@ __author__ = 'albertjan'
 
 # unit test files should be named test_<your name here>.py
 # this ensures they will automatically be included in the
-# ./skulpt.py test or ./skulpt.py dist testing procedures
+# npm test or npm run dist testing procedures
 #
 
 import unittest


### PR DESCRIPTION
Fixes #558.

* Removes the recommendation to `npm install -g`
* Adds npm scripts for the following commands:
    ```
    testdebug, regengooglocs, regensymtabtests, rununits, vmwareregr, regenparser, regenasttests, regenruntests, upload, doctest, doc, browser, debugbrowser, vfs, host, repl, test
    ```
* `npm run build` runs `./skulpt.py dist`

**Warning**: Passing parameters directly to `npm` scripts doesn’t work. Instead, use `--` and then pass the options.