### PR TITLE
handle promise in suspension correctly, use internal suspension data to resume

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -825,7 +825,7 @@ Sk.builtin.raw_input = function (prompt) {
 Sk.builtin.input = Sk.builtin.raw_input;
 
 Sk.builtin.jseval = function jseval (evalcode) {
-    goog.global["eval"](evalcode);
+    goog.global["eval"](Sk.ffi.remapToJs(evalcode));
 };
 
 Sk.builtin.jsmillis = function jsmillis () {

--- a/src/file.js
+++ b/src/file.js
@@ -124,7 +124,7 @@ Sk.builtin.file.prototype["read"] = new Sk.builtin.func(function (self, size) {
 
 Sk.builtin.file.$readline = function (self, size, prompt) {
     if (self.fileno === 0) {
-        var x, resolution, susp;
+        var x, susp;
 
         var lprompt = Sk.ffi.remapToJs(prompt);
 
@@ -136,18 +136,16 @@ Sk.builtin.file.$readline = function (self, size, prompt) {
             susp = new Sk.misceval.Suspension();
 
             susp.resume = function() {
-                return new Sk.builtin.str(resolution);
+                if (susp.data.error) {
+                    throw susp.data.error;
+                }
+
+                return new Sk.builtin.str(susp.data.result);
             };
 
             susp.data = {
                 type: "Sk.promise",
-                promise: x.then(function(value) {
-                    resolution = value;
-                    return value;
-                }, function(err) {
-                    resolution = "";
-                    return err;
-                })
+                promise: x
             };
 
             return susp;

--- a/test/unit/test_input.py
+++ b/test/unit/test_input.py
@@ -1,0 +1,32 @@
+__author__ = 'Albert-Jan'
+
+import unittest
+
+class InputFunTests(unittest.TestCase):
+
+    def setUp(self):
+        jseval("""
+            var oldInputFunTakesPrompt = Sk.inputfunTakesPrompt;
+            var oldInputFun = Sk.inputfun
+            Sk.inputfunTakesPrompt = true;
+            Sk.inputfun = function (prompt) { 
+                return new Promise(function (resolve, reject) {
+                    resolve(Sk.builtin.str(prompt + "testing"));
+                });
+            }
+        """)
+
+
+    def test_input_fun_should_return_promt_asynchronously(self):
+        res = input(">>> ")
+        self.assertEqual(res, ">>> testing")
+
+
+    def tearDown(self):
+        jseval("""
+            Sk.inputfunTakesPrompt = oldInputFunTakesPrompt;
+            Sk.inputfun = oldInputFun;
+        """)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_input.py
+++ b/test/unit/test_input.py
@@ -11,6 +11,9 @@ class InputFunTests(unittest.TestCase):
             Sk.inputfunTakesPrompt = true;
             Sk.inputfun = function (prompt) { 
                 return new Promise(function (resolve, reject) {
+                    if (prompt === "error") {
+                        throw new Sk.builtin.ValueError("aarrrggg");
+                    }
                     resolve(Sk.builtin.str(prompt + "testing"));
                 });
             }
@@ -20,6 +23,17 @@ class InputFunTests(unittest.TestCase):
     def test_input_fun_should_return_promt_asynchronously(self):
         res = input(">>> ")
         self.assertEqual(res, ">>> testing")
+
+
+    def test_error_on_input(self):
+        threw = False
+        try: 
+            res = input("error")
+        except ValueError as e:
+            self.assertIsInstance(e, ValueError)
+            threw = True
+
+        self.assertTrue(threw)
 
 
     def tearDown(self):

--- a/test/unit/test_input.py
+++ b/test/unit/test_input.py
@@ -20,7 +20,7 @@ class InputFunTests(unittest.TestCase):
         """)
 
 
-    def test_input_fun_should_return_promt_asynchronously(self):
+    def test_input_fun_should_return_prompt_asynchronously(self):
         res = input(">>> ")
         self.assertEqual(res, ">>> testing")
 


### PR DESCRIPTION
When you return a value from the reject handler of a promise the resulting promise is `resolved` not `rejected`. 

These changes make sure you can reject your `Sk.input` promise implementation.