### PR TITLE
fix reserved words in get and set attr

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -771,13 +771,14 @@ Sk.builtin.hash = function hash (value) {
 };
 
 Sk.builtin.getattr = function getattr (obj, name, default_) {
-    var ret;
+    var ret, mangledName;
     Sk.builtin.pyCheckArgs("getattr", arguments, 2, 3);
     if (!Sk.builtin.checkString(name)) {
         throw new Sk.builtin.TypeError("attribute name must be string");
     }
 
-    ret = obj.tp$getattr(name.v);
+    mangledName = Sk.fixReservedWords(Sk.ffi.remapToJs(name));
+    ret = obj.tp$getattr(mangledName);
     if (ret === undefined) {
         if (default_ !== undefined) {
             return default_;
@@ -796,7 +797,7 @@ Sk.builtin.setattr = function setattr (obj, name, value) {
             throw new Sk.builtin.TypeError("attribute name must be string");
         }
         if (obj.tp$setattr) {
-            obj.tp$setattr(Sk.ffi.remapToJs(name), value);
+            obj.tp$setattr(Sk.fixReservedWords(Sk.ffi.remapToJs(name)), value);
         } else {
             throw new Sk.builtin.AttributeError("object has no attribute " + Sk.ffi.remapToJs(name));
         }
@@ -1307,7 +1308,7 @@ Sk.builtin.iter = function iter (obj, sentinel) {
     Sk.builtin.pyCheckArgs("iter", arguments, 1, 2);
     if (arguments.length === 1) {
         if (!Sk.builtin.checkIterable(obj)) {
-            throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(obj) + 
+            throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(obj) +
                 "' object is not iterable");
         } else {
             return new Sk.builtin.iterator(obj);

--- a/src/compile.js
+++ b/src/compile.js
@@ -2347,3 +2347,9 @@ Sk.resetCompiler = function () {
 };
 
 goog.exportSymbol("Sk.resetCompiler", Sk.resetCompiler);
+
+Sk.fixReservedWords = fixReservedWords;
+goog.exportSymbol("Sk.fixReservedWords", Sk.fixReservedWords);
+
+Sk.fixReservedNames = fixReservedNames;
+goog.exportSymbol("Sk.fixReservedNames", Sk.fixReservedNames);

--- a/src/compile.js
+++ b/src/compile.js
@@ -223,6 +223,10 @@ function fixReservedNames (name) {
     return name;
 }
 
+function unfixReserved(name) {
+    return name.replace(/_\$r[wn]\$$/, "");
+}
+
 function mangleName (priv, ident) {
     var name = ident.v;
     var strpriv = null;
@@ -2353,3 +2357,6 @@ goog.exportSymbol("Sk.fixReservedWords", Sk.fixReservedWords);
 
 Sk.fixReservedNames = fixReservedNames;
 goog.exportSymbol("Sk.fixReservedNames", Sk.fixReservedNames);
+
+Sk.unfixReserved = unfixReserved;
+goog.exportSymbol("Sk.unfixReserved", Sk.unfixReserved);

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -693,9 +693,7 @@ Sk.misceval.loadname = function (name, other) {
         return bi;
     }
 
-    name = name.replace("_$rw$", "");
-    name = name.replace("_$rn$", "");
-    throw new Sk.builtin.NameError("name '" + name + "' is not defined");
+    throw new Sk.builtin.NameError("name '" + Sk.unfixReserved(name) + "' is not defined");
 };
 goog.exportSymbol("Sk.misceval.loadname", Sk.misceval.loadname);
 

--- a/src/object.js
+++ b/src/object.js
@@ -123,7 +123,7 @@ Sk.builtin.object.prototype.GenericSetAttr = function (name, value, canSuspend) 
         if (this instanceof Sk.builtin.object && !(this.ob$type.sk$klass) &&
             dict.mp$lookup(pyname) === undefined) {
             // Cannot add new attributes to a builtin object
-            throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + name + "'");
+            throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + name.replace("_$rw$", "") + "'");
         }
         dict.mp$ass_subscript(new Sk.builtin.str(name), value);
     } else if (typeof dict === "object") {

--- a/src/object.js
+++ b/src/object.js
@@ -123,7 +123,7 @@ Sk.builtin.object.prototype.GenericSetAttr = function (name, value, canSuspend) 
         if (this instanceof Sk.builtin.object && !(this.ob$type.sk$klass) &&
             dict.mp$lookup(pyname) === undefined) {
             // Cannot add new attributes to a builtin object
-            throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + name.replace("_$rw$", "") + "'");
+            throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + Sk.unfixReserved(name) + "'");
         }
         dict.mp$ass_subscript(new Sk.builtin.str(name), value);
     } else if (typeof dict === "object") {

--- a/test/unit/test_reserved_words.py
+++ b/test/unit/test_reserved_words.py
@@ -24,5 +24,12 @@ class Test_ReservedWords(unittest.TestCase):
         setattr(f, "this", True)
         self.assertTrue(f.this)
 
+    def test_error_message(self):
+        f = True
+        try:
+          setattr(f, "continue", True)
+        except AttributeError as e:
+          self.assertTrue("_$rw$" not in str(e))
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_reserved_words.py
+++ b/test/unit/test_reserved_words.py
@@ -1,0 +1,28 @@
+import unittest
+
+class TestFixture():
+    def default(self):
+        return True
+
+    def delete(self):
+        return True
+
+class Test_ReservedWords(unittest.TestCase):
+    def test_getattr(self):
+        f = TestFixture()
+        func_default = getattr(f, "default")
+        self.assertTrue(func_default())
+
+        func_delete = getattr(f, "delete")
+        self.assertTrue(func_delete())
+
+    def test_setattr(self):
+        f = TestFixture()
+        setattr(f, "typeof", True)
+        self.assertTrue(f.typeof)
+
+        setattr(f, "this", True)
+        self.assertTrue(f.this)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Use the same reserved words mangler for `get/setattr` as the compiler uses. So we can use `get/setattr` to get fields like `default` and `delete` from objects.