### PR TITLE
Add `args` attribute to standard exceptions

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -80,6 +80,15 @@ Sk.builtin.BaseException.prototype.toString = function () {
     return this.tp$str().v;
 };
 
+// Create a descriptor to return the 'args' of an exception.
+// This is a hack to get around a weird mismatch between builtin
+// objects and proper types
+Sk.builtin.BaseException.prototype.args = {
+    "tp$descr_get": function(self, clstype) {
+        return self.args;
+    }
+};
+
 goog.exportSymbol("Sk.builtin.BaseException", Sk.builtin.BaseException);
 
 /**

--- a/test/unit/test_subclass.py
+++ b/test/unit/test_subclass.py
@@ -288,6 +288,13 @@ class SubclassTest(unittest.TestCase):
         self.assertRaises(TypeError, raiseMyTypeError)
         self.assertRaises(Exception, raiseMyTypeError)
 
+        try:
+            raise StandardError("test")
+            self.fail("Should never get here")
+        except StandardError as e:
+            self.assertIsInstance(e.args, tuple)
+            self.assertEqual("test", e.args[0])
+
         class MyStandardError(StandardError):
             def __str__(self):
                 return "My Standard Error"
@@ -297,6 +304,8 @@ class SubclassTest(unittest.TestCase):
             self.fail("Should never get here")
         except MyStandardError as e:
             self.assertEqual("My Standard Error", str(e))
+            self.assertIsInstance(e.args, tuple)
+            self.assertEqual("test", e.args[0])
 
         # Test multiple-class catch
         try:


### PR DESCRIPTION
The `args` attribute was missing from exceptions. This change adds it.

It works by adding an `args` descriptor that exposes the javascript `args` property (which is already a python tuple). I could also have overridden `__getattr__`; I thought this was cleaner.