### PR TITLE
fix args.length check, add tmp.js to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/namedtests.js
 Vagrantfile
 v8.log
 src/internalpython.js
+/tmp.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 python:
 - '2.6'
 install:
-- npm install npm@latest -g
+- npm install npm@4 -g
 - npm install
 - jscs -V
 - jshint -v

--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -2048,7 +2048,7 @@ function generateTurtleModule(_target) {
                 instance = scopeGenerator ? scopeGenerator() : args.shift().instance,
                 i, result, susp, resolution, lengthError;
 
-            if (args < minArgs || args.length > maxArgs) {
+            if (args.length < minArgs || args.length > maxArgs) {
                 lengthError = minArgs === maxArgs ?
                     "exactly " + maxArgs :
                     "between " + minArgs + " and " + maxArgs;


### PR DESCRIPTION
turtle.js args.length check missing the a `.length` thus can't throw an error on args missing