### PR TITLE
Proposal to add Python 3 unit tests to skulpt

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 
     "build": "./skulpt.py dist",
     "build-min": "./skulpt.py dist -u",
-    "test": "./skulpt.py test"
+    "test": "./skulpt.py test",
+    "test3": "./skulpt.py test3"
   },
   "repository": {
     "type": "git",

--- a/skulpt.py
+++ b/skulpt.py
@@ -211,17 +211,20 @@ if os.environ.get("CI",False):
 
 #jsengine = "rhino"
 
-def test(debug_mode=False):
+def test(debug_mode=False, p3=False):
     """runs the unit tests."""
     if debug_mode:
         debugon = "--debug-mode"
     else:
         debugon = ""
-    buildNamedTestsFile()
-    ret1 = os.system("{0} {1} {2} -- {3}".format(jsengine, ' '.join(getFileList(FILE_TYPE_TEST)), ' '.join(TestFiles), debugon))
+    ret1 = 0
     ret2 = 0
     ret3 = 0
     ret4 = 0
+    if not p3:
+        buildNamedTestsFile()
+        ret1 = os.system("{0} {1} {2} -- {3}".format(jsengine, ' '.join(getFileList(FILE_TYPE_TEST)), ' '.join(TestFiles), debugon))
+
     if ret1 == 0:
         print "Running jshint"
         base_dirs = ["src", "debugger"]
@@ -237,31 +240,8 @@ def test(debug_mode=False):
         ret3 = os.system(jscscmd)
         #ret3 = os.system(jscscmd)
         print "Now running new unit tests"
-        ret4 = rununits(debug_mode=debug_mode)
+        ret4 = rununits(p3=p3, debug_mode=debug_mode)
     return ret1 | ret2 | ret3 | ret4
-
-def test3(debug_mode=False):
-    """runs the unit tests in python 3."""
-    if debug_mode:
-        debugon = "--debug-mode"
-    else:
-        debugon = ""
-    print "Running jshint"
-    base_dirs = ["src", "debugger"]
-    for base_dir in base_dirs:
-        if sys.platform == "win32":
-            jshintcmd = "{0} {1}".format("jshint", ' '.join(f for f in glob.glob(base_dir + "/*.js")))
-            jscscmd = "{0} {1} --reporter=inline".format("jscs", ' '.join(f for f in glob.glob(base_dir + "/*.js")))
-        else:
-            jshintcmd = "jshint " + base_dir + "/*.js"
-            jscscmd = "jscs " + base_dir + "/*.js --reporter=inline"
-    ret1 = os.system(jshintcmd)
-    print "Running JSCS"
-    ret2 = os.system(jscscmd)
-    print "Now running unit tests"
-    ret3 = rununits(p3=True, debug_mode=debug_mode)
-    return ret1 | ret2 | ret3
-
 
 def parse_time_args(argv):
     usageString = """
@@ -1334,9 +1314,11 @@ def main():
     if cmd == "test":
         test()
     elif cmd == "test3":
-        test3()
+        test(p3=True)
     elif cmd == "testdebug":
-        test(True)
+        test(debug_mode=True)
+    elif cmd == "test3debug":
+        test(debug_mode=True, p3=True)
     elif cmd == "dist":
         dist(options)
     elif cmd == "regengooglocs":

--- a/skulpt.py
+++ b/skulpt.py
@@ -240,6 +240,29 @@ def test(debug_mode=False):
         ret4 = rununits(debug_mode=debug_mode)
     return ret1 | ret2 | ret3 | ret4
 
+def test3(debug_mode=False):
+    """runs the unit tests in python 3."""
+    if debug_mode:
+        debugon = "--debug-mode"
+    else:
+        debugon = ""
+    print "Running jshint"
+    base_dirs = ["src", "debugger"]
+    for base_dir in base_dirs:
+        if sys.platform == "win32":
+            jshintcmd = "{0} {1}".format("jshint", ' '.join(f for f in glob.glob(base_dir + "/*.js")))
+            jscscmd = "{0} {1} --reporter=inline".format("jscs", ' '.join(f for f in glob.glob(base_dir + "/*.js")))
+        else:
+            jshintcmd = "jshint " + base_dir + "/*.js"
+            jscscmd = "jscs " + base_dir + "/*.js --reporter=inline"
+    ret1 = os.system(jshintcmd)
+    print "Running JSCS"
+    ret2 = os.system(jscscmd)
+    print "Now running unit tests"
+    ret3 = rununits(p3=True, debug_mode=debug_mode)
+    return ret1 | ret2 | ret3
+
+
 def parse_time_args(argv):
     usageString = """
 
@@ -1067,7 +1090,13 @@ def shell(fn):
 
 
 def rununits(opt=False, p3=False, debug_mode=False):
-    testFiles = ['test/unit/'+f for f in os.listdir('test/unit') if '.py' in f]
+    if p3:
+        unit_dir = 'test/unit3'
+        p3on = 'true'
+    else:
+        unit_dir = 'test/unit'
+        p3on = 'false'
+    testFiles = [unit_dir + '/' + f for f in os.listdir(unit_dir) if '.py' in f]
     jstestengine = jsengine.replace('--debugger', '')
     passTot = 0
     failTot = 0
@@ -1076,10 +1105,6 @@ def rununits(opt=False, p3=False, debug_mode=False):
             os.mkdir("support/tmp")
         f = open("support/tmp/run.js", "w")
         modname = os.path.splitext(os.path.basename(fn))[0]
-        if p3:
-            p3on = 'true'
-        else:
-            p3on = 'false'
         f.write("""
 var input = read('%s');
 print('%s');
@@ -1308,6 +1333,8 @@ def main():
 
     if cmd == "test":
         test()
+    elif cmd == "test3":
+        test3()
     elif cmd == "testdebug":
         test(True)
     elif cmd == "dist":

--- a/test/unit3/exiting_module.py
+++ b/test/unit3/exiting_module.py
@@ -1,0 +1,5 @@
+__author__ = "leszek"
+
+if __name__ != "__main__":
+    # Exit when this module is imported
+    exit()

--- a/test/unit3/simpleMath.py
+++ b/test/unit3/simpleMath.py
@@ -1,0 +1,14 @@
+__author__ = 'millbr02'
+
+
+import unittest
+
+
+class SimpleMath(unittest.TestCase):
+    def testOne(self):
+        x = 2 + 2
+        self.assertEqual(x, 4)
+        self.assertEqual(type(x), int)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/string_functions.py
+++ b/test/unit3/string_functions.py
@@ -1,0 +1,208 @@
+__author__ = "gerbal"
+
+# unit test files should be named test_<your name here>.py
+# this ensures they will automatically be included in the
+# ./skulpt.py test or ./skulpt.py dist testing procedures
+#
+
+# These tests are a modification of the cPython buffer tests
+
+
+import unittest
+
+class string_functions(unittest.TestCase):
+    def test_islower(self):
+        self.assertFalse("".islower(), "islower")
+        self.assertTrue("a".islower(), "islower")
+        self.assertFalse("A".islower(), "islower")
+        self.assertFalse("\n".islower(), "islower")
+        self.assertTrue("abc".islower(), "islower")
+        self.assertFalse("aBc".islower(), "islower")
+        self.assertTrue("abc\n".islower(), "islower")
+        # self.assertRaises(TypeError, "abc".islower, 42) #
+
+    def test_isupper(self):
+        self.assertFalse("".isupper())
+        self.assertFalse("a".isupper())
+        self.assertTrue("A".isupper())
+        self.assertFalse("\n".isupper())
+        self.assertTrue("ABC".isupper())
+        self.assertFalse("AbC".isupper())
+        self.assertTrue("ABC\n".isupper())
+        # self.assertRaises(TypeError, "abc".isupper, 42) #
+
+    def test_istitle(self):
+        self.assertFalse("".istitle())
+        self.assertFalse("a".istitle())
+        self.assertTrue("A".istitle())
+        self.assertFalse("\n".istitle()) ##
+        self.assertTrue("A Titlecased Line".istitle()) ##
+        self.assertTrue("A\nTitlecased Line".istitle()) ##
+        self.assertTrue("A Titlecased, Line".istitle()) ##
+        self.assertFalse("Not a capitalized String".istitle())
+        self.assertFalse("Not\ta Titlecase String".istitle())
+        self.assertFalse("Not--a Titlecase String".istitle())
+        self.assertFalse("NOT".istitle())
+        # self.assertRaises(TypeError, "abc".istitle, 42) #
+
+    def test_isspace(self):
+        self.assertFalse("".isspace())
+        self.assertFalse("a".isspace())
+        self.assertTrue(" ".isspace())
+        self.assertTrue("\t".isspace())
+        self.assertTrue("\r".isspace())
+        self.assertTrue("\n".isspace())
+        self.assertTrue(" \t\r\n".isspace())
+        self.assertFalse(" \t\r\na".isspace())
+        # self.assertRaises(TypeError, "abc".isspace, 42) #
+
+    def test_isalpha(self):
+        self.assertFalse("".isalpha())
+        self.assertTrue("a".isalpha())
+        self.assertTrue("A".isalpha())
+        self.assertFalse("\n".isalpha())
+        self.assertTrue("abc".isalpha())
+        self.assertFalse("aBc123".isalpha())
+        self.assertFalse("abc\n".isalpha())
+        # self.assertRaises(TypeError, "abc".isalpha, 42)
+
+    def test_isalnum(self):
+        self.assertFalse("".isalnum())
+        self.assertTrue("a".isalnum())
+        self.assertTrue("A".isalnum())
+        self.assertFalse("\n".isalnum())
+        self.assertTrue("123abc456".isalnum())
+        self.assertTrue("a1b3c".isalnum())
+        self.assertFalse("aBc000 ".isalnum())
+        self.assertFalse("abc\n".isalnum())
+        # self.assertRaises(TypeError, "abc".isalnum, 42)
+
+    def test_isdigit(self):
+        self.assertFalse("".isdigit())
+        self.assertFalse("a".isdigit())
+        self.assertTrue("0".isdigit())
+        self.assertTrue("0123456789".isdigit())
+        self.assertFalse("0123456789a".isdigit())
+        # self.assertRaises(TypeError, "abc".isdigit, 42)
+
+    def test_lower(self):
+        self.assertEqual("hello", "HeLLo".lower())
+        self.assertEqual("hello", "hello".lower())
+        # self.assertRaises(TypeError, "hello".lower, 42)
+
+    def test_upper(self):
+        self.assertEqual("HELLO", "HeLLo".upper())
+        self.assertEqual("HELLO", "HELLO".upper())
+        # self.assertRaises(TypeError, "hello".upper, 42)
+
+    def test_capitalize(self):
+        self.assertEqual(" hello ", " hello ".capitalize())
+        self.assertEqual("Hello ", "Hello ".capitalize())
+        self.assertEqual("Hello ", "hello ".capitalize())
+        self.assertEqual("Aaaa", "aaaa".capitalize())
+        self.assertEqual("Aaaa", "AaAa".capitalize())
+        # self.assertRaises(TypeError, "hello".capitalize, 42)
+
+    def test_ljust(self):
+        self.assertEqual("abc       ", "abc".ljust(10))
+        self.assertEqual("abc   ", "abc".ljust(6))
+        self.assertEqual("abc", "abc".ljust(3))
+        self.assertEqual("abc", "abc".ljust(2))
+        self.assertEqual("abc*******", "abc".ljust(10, "*"))
+        # self.assertRaises(TypeError, "abc".ljust)
+
+    def test_rjust(self):
+        self.assertEqual("       abc", "abc".rjust(10))
+        self.assertEqual("   abc", "abc".rjust(6))
+        self.assertEqual("abc", "abc".rjust(3))
+        self.assertEqual("abc", "abc".rjust(2))
+        self.assertEqual("*******abc", "abc".rjust(10, "*"))
+        # self.assertRaises(TypeError, "abc".rjust)
+
+    def test_center(self):
+        self.assertEqual("   abc    ", "abc".center(10))
+        self.assertEqual(" abc  ", "abc".center(6))
+        self.assertEqual("abc", "abc".center(3))
+        self.assertEqual("abc", "abc".center(2))
+        self.assertEqual("***abc****", "abc".center(10, "*"))
+        # self.assertRaises(TypeError, "abc".center)
+
+    def test_swapcase(self):
+        self.assertEqual("hEllO CoMPuTErS", "HeLLo cOmpUteRs".swapcase())
+        # self.assertRaises(TypeError, "hello".swapcase, 42)
+
+    def test_zfill(self):
+        self.assertEqual("123", "123".zfill(2))
+        self.assertEqual("123", "123".zfill(3))
+        self.assertEqual("0123", "123".zfill(4))
+        self.assertEqual("+123", "+123".zfill(3))
+        self.assertEqual("+123", "+123".zfill(4))
+        self.assertEqual("+0123", "+123".zfill(5))
+        self.assertEqual("-123", "-123".zfill(3))
+        self.assertEqual("-123", "-123".zfill(4))
+        self.assertEqual("-0123", "-123".zfill(5))
+        self.assertEqual("000", "".zfill(3))
+        self.assertEqual("34", "34".zfill(1))
+        self.assertEqual("0034", "34".zfill(4))
+
+        # self.assertRaises(TypeError, "123".zfill)
+
+    def test_expandtabs(self):
+        self.assertEqual("abc\rab      def\ng       hi", "abc\rab\tdef\ng\thi".expandtabs())
+        self.assertEqual("abc\rab      def\ng       hi", "abc\rab\tdef\ng\thi".expandtabs(8))
+        self.assertEqual("abc\rab  def\ng   hi", "abc\rab\tdef\ng\thi".expandtabs(4))
+        self.assertEqual("abc\r\nab      def\ng       hi", "abc\r\nab\tdef\ng\thi".expandtabs())
+        self.assertEqual("abc\r\nab      def\ng       hi", "abc\r\nab\tdef\ng\thi".expandtabs(8))
+        self.assertEqual("abc\r\nab  def\ng   hi", "abc\r\nab\tdef\ng\thi".expandtabs(4))
+        self.assertEqual("abc\r\nab\r\ndef\ng\r\nhi", "abc\r\nab\r\ndef\ng\r\nhi".expandtabs(4))
+        # kwargs only supported in python 3
+        # self.assertEqual("abc\rab      def\ng       hi",
+        #                  "abc\rab\tdef\ng\thi".expandtabs(tabsize=8))
+        # self.assertEqual("abc\rab  def\ng   hi",
+        #                  "abc\rab\tdef\ng\thi".expandtabs(tabsize=4))
+
+        self.assertEqual("  a\n b", " \ta\n\tb".expandtabs(1))
+
+        # self.assertRaises(TypeError, "hello".expandtabs, 42, 42)
+        # # This test is only valid when sizeof(int) == sizeof(void*) == 4.
+        # if sys.maxsize < (1 << 32) and struct.calcsize("P") == 4:
+        #     self.assertRaises(OverflowError,
+        #                       "\ta\n\tb".expandtabs, sys.maxsize)
+
+    def test_title(self):
+        self.assertEqual(" Hello ", " hello ".title())
+        self.assertEqual("Hello ", "hello ".title())
+        self.assertEqual("Hello ", "Hello ".title())
+        self.assertEqual("Format This As Title String",
+                         "fOrMaT thIs aS titLe String".title())
+        self.assertEqual("Format,This-As*Title;String",
+                         "fOrMaT,thIs-aS*titLe;String".title())
+        self.assertEqual("Getint", "getInt".title())
+        # self.assertRaises(TypeError, "hello".title, 42)
+
+    def test_splitlines(self):
+        self.assertEqual(["abc", "def", "", "ghi"],
+                         "abc\ndef\n\rghi".splitlines())
+        self.assertEqual(["abc", "def", "", "ghi"],
+                         "abc\ndef\n\r\nghi".splitlines())
+        self.assertEqual(["abc", "def", "ghi"],
+                         "abc\ndef\r\nghi".splitlines())
+        self.assertEqual(["abc", "def", "ghi"],
+                         "abc\ndef\r\nghi\n".splitlines())
+        self.assertEqual(["abc", "def", "ghi", ""],
+                         "abc\ndef\r\nghi\n\r".splitlines())
+        self.assertEqual(["", "abc", "def", "ghi", ""],
+                         "\nabc\ndef\r\nghi\n\r".splitlines())
+        self.assertEqual(["", "abc", "def", "ghi", ""],
+                         "\nabc\ndef\r\nghi\n\r".splitlines(False))
+        self.assertEqual(["\n", "abc\n", "def\r\n", "ghi\n", "\r"],
+                         "\nabc\ndef\r\nghi\n\r".splitlines(True))
+        # self.assertEqual(["", "abc", "def", "ghi", ""],
+        #                  "\nabc\ndef\r\nghi\n\r".splitlines(keepends=False))
+        # self.assertEqual(["\n", "abc\n", "def\r\n", "ghi\n", "\r"],
+        #                  "\nabc\ndef\r\nghi\n\r".splitlines(keepends=True))
+
+        # self.assertRaises(TypeError, "abc".splitlines, 42, 42)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_abstract_numbers.py
+++ b/test/unit3/test_abstract_numbers.py
@@ -1,0 +1,33 @@
+"""Unit tests for numbers.py."""
+
+import math
+import operator
+import unittest
+
+class TestNumbers(unittest.TestCase):
+    def test_int(self):
+        # self.assertEqual(7, int(7).real)
+        # self.assertEqual(0, int(7).imag)
+        self.assertEqual(7, int(7).conjugate())
+        self.assertEqual(-7, int(-7).conjugate())
+        # self.assertEqual(7, int(7).numerator)
+        # self.assertEqual(1, int(7).denominator)
+
+    def test_float(self):
+        # self.assertEqual(7.3, float(7.3).real)
+        # self.assertEqual(0, float(7.3).imag)
+        self.assertEqual(7.3, float(7.3).conjugate())
+        self.assertEqual(-7.3, float(-7.3).conjugate())
+
+        c1, c2 = complex(3, 2), complex(4,1)
+        # XXX: This is not ideal, but see the comment in math_trunc().
+        self.assertRaises(TypeError, math.trunc, c1)
+        self.assertRaises(TypeError, operator.mod, c1, c2)
+        self.assertRaises(TypeError, divmod, c1, c2)
+        self.assertRaises(TypeError, operator.floordiv, c1, c2)
+        self.assertRaises(TypeError, float, c1)
+        self.assertRaises(TypeError, int, c1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_binop.py
+++ b/test/unit3/test_binop.py
@@ -1,0 +1,438 @@
+"""Tests for binary operators on subtypes of built-in types."""
+
+import unittest
+from operator import eq, le, ne
+
+def gcd(a, b):
+    """Greatest common divisor using Euclid's algorithm."""
+    while a:
+        a, b = b%a, a
+    return b
+
+def isint(x):
+    """Test whether an object is an instance of int."""
+    return isinstance(x, int)
+
+def isnum(x):
+    """Test whether an object is an instance of a built-in numeric type."""
+    for T in int, float, complex:
+        if isinstance(x, T):
+            return 1
+    return 0
+
+def isRat(x):
+    """Test wheter an object is an instance of the Rat class."""
+    return isinstance(x, Rat)
+
+class Rat(object):
+
+    """Rational number implemented as a normalized pair of ints."""
+
+    __slots__ = ['_Rat__num', '_Rat__den']
+
+    def __init__(self, num=0, den=1):
+        """Constructor: Rat([num[, den]]).
+
+        The arguments must be ints, and default to (0, 1)."""
+        if not isint(num):
+            raise TypeError("Rat numerator must be int (%r)" % num)
+        if not isint(den):
+            raise TypeError("Rat denominator must be int (%r)" % den)
+        # But the zero is always on
+        if den == 0:
+            raise ZeroDivisionError("zero denominator")
+        g = gcd(den, num)
+        self.__num = int(num//g)
+        self.__den = int(den//g)
+
+    def _get_num(self):
+        """Accessor function for read-only 'num' attribute of Rat."""
+        return self.__num
+    num = property(_get_num, None)
+
+    def _get_den(self):
+        """Accessor function for read-only 'den' attribute of Rat."""
+        return self.__den
+    den = property(_get_den, None)
+
+    def __repr__(self):
+        """Convert a Rat to a string resembling a Rat constructor call."""
+        return "Rat(%d, %d)" % (self.__num, self.__den)
+
+    def __str__(self):
+        """Convert a Rat to a string resembling a decimal numeric value."""
+        return str(float(self))
+
+    def __float__(self):
+        """Convert a Rat to a float."""
+        return self.__num*1.0/self.__den
+
+    def __int__(self):
+        """Convert a Rat to an int; self.den must be 1."""
+        if self.__den == 1:
+            try:
+                return int(self.__num)
+            except OverflowError:
+                raise OverflowError("%s too large to convert to int" %
+                                      repr(self))
+        raise ValueError("can't convert %s to int" % repr(self))
+
+    def __add__(self, other):
+        """Add two Rats, or a Rat and a number."""
+        if isint(other):
+            other = Rat(other)
+        if isRat(other):
+            return Rat(self.__num*other.__den + other.__num*self.__den,
+                       self.__den*other.__den)
+        if isnum(other):
+            return float(self) + other
+        return NotImplemented
+
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        """Subtract two Rats, or a Rat and a number."""
+        if isint(other):
+            other = Rat(other)
+        if isRat(other):
+            return Rat(self.__num*other.__den - other.__num*self.__den,
+                       self.__den*other.__den)
+        if isnum(other):
+            return float(self) - other
+        return NotImplemented
+
+    def __rsub__(self, other):
+        """Subtract two Rats, or a Rat and a number (reversed args)."""
+        if isint(other):
+            other = Rat(other)
+        if isRat(other):
+            return Rat(other.__num*self.__den - self.__num*other.__den,
+                       self.__den*other.__den)
+        if isnum(other):
+            return other - float(self)
+        return NotImplemented
+
+    def __mul__(self, other):
+        """Multiply two Rats, or a Rat and a number."""
+        if isRat(other):
+            return Rat(self.__num*other.__num, self.__den*other.__den)
+        if isint(other):
+            return Rat(self.__num*other, self.__den)
+        if isnum(other):
+            return float(self)*other
+        return NotImplemented
+
+    __rmul__ = __mul__
+
+    def __truediv__(self, other):
+        """Divide two Rats, or a Rat and a number."""
+        if isRat(other):
+            return Rat(self.__num*other.__den, self.__den*other.__num)
+        if isint(other):
+            return Rat(self.__num, self.__den*other)
+        if isnum(other):
+            return float(self) / other
+        return NotImplemented
+
+    def __rtruediv__(self, other):
+        """Divide two Rats, or a Rat and a number (reversed args)."""
+        if isRat(other):
+            return Rat(other.__num*self.__den, other.__den*self.__num)
+        if isint(other):
+            return Rat(other*self.__den, self.__num)
+        if isnum(other):
+            return other / float(self)
+        return NotImplemented
+
+    def __floordiv__(self, other):
+        """Divide two Rats, returning the floored result."""
+        if isint(other):
+            other = Rat(other)
+        elif not isRat(other):
+            return NotImplemented
+        x = self/other
+        return x.__num // x.__den
+
+    def __rfloordiv__(self, other):
+        """Divide two Rats, returning the floored result (reversed args)."""
+        x = other/self
+        return x.__num // x.__den
+
+    def __divmod__(self, other):
+        """Divide two Rats, returning quotient and remainder."""
+        if isint(other):
+            other = Rat(other)
+        elif not isRat(other):
+            return NotImplemented
+        x = self//other
+        return (x, self - other * x)
+
+    def __rdivmod__(self, other):
+        """Divide two Rats, returning quotient and remainder (reversed args)."""
+        if isint(other):
+            other = Rat(other)
+        elif not isRat(other):
+            return NotImplemented
+        return divmod(other, self)
+
+    def __mod__(self, other):
+        """Take one Rat modulo another."""
+        return divmod(self, other)[1]
+
+    def __rmod__(self, other):
+        """Take one Rat modulo another (reversed args)."""
+        return divmod(other, self)[1]
+
+    def __eq__(self, other):
+        """Compare two Rats for equality."""
+        if isint(other):
+            return self.__den == 1 and self.__num == other
+        if isRat(other):
+            return self.__num == other.__num and self.__den == other.__den
+        if isnum(other):
+            return float(self) == other
+        return NotImplemented
+
+class RatTestCase(unittest.TestCase):
+    """Unit tests for Rat class and its support utilities."""
+
+    def test_gcd(self):
+        self.assertEqual(gcd(10, 12), 2)
+        self.assertEqual(gcd(10, 15), 5)
+        self.assertEqual(gcd(10, 11), 1)
+        self.assertEqual(gcd(100, 15), 5)
+        self.assertEqual(gcd(-10, 2), -2)
+        self.assertEqual(gcd(10, -2), 2)
+        self.assertEqual(gcd(-10, -2), -2)
+        for i in range(1, 20):
+            for j in range(1, 20):
+                self.assertTrue(gcd(i, j) > 0)
+                self.assertTrue(gcd(-i, j) < 0)
+                self.assertTrue(gcd(i, -j) > 0)
+                self.assertTrue(gcd(-i, -j) < 0)
+
+    def test_constructor(self):
+        a = Rat(10, 15)
+        self.assertEqual(a.num, 2)
+        self.assertEqual(a.den, 3)
+        a = Rat(10, -15)
+        self.assertEqual(a.num, -2)
+        self.assertEqual(a.den, 3)
+        a = Rat(-10, 15)
+        self.assertEqual(a.num, -2)
+        self.assertEqual(a.den, 3)
+        a = Rat(-10, -15)
+        self.assertEqual(a.num, 2)
+        self.assertEqual(a.den, 3)
+        a = Rat(7)
+        self.assertEqual(a.num, 7)
+        self.assertEqual(a.den, 1)
+        try:
+            a = Rat(1, 0)
+        except ZeroDivisionError:
+            pass
+        else:
+            self.fail("Rat(1, 0) didn't raise ZeroDivisionError")
+        # for bad in "0", 0.0, 0j, (), [], {}, None, Rat, unittest:
+        #     try:
+        #         a = Rat(bad)
+        #     except TypeError:
+        #         pass
+        #     else:
+        #         self.fail("Rat(%r) didn't raise TypeError" % bad)
+        #     try:
+        #         a = Rat(1, bad)
+        #     except TypeError:
+        #         pass
+        #     else:
+        #         self.fail("Rat(1, %r) didn't raise TypeError" % bad)
+
+    def test_add(self):
+        self.assertEqual(Rat(2, 3) + Rat(1, 3), 1)
+        self.assertEqual(Rat(2, 3) + 1, Rat(5, 3))
+        self.assertEqual(1 + Rat(2, 3), Rat(5, 3))
+        self.assertEqual(1.0 + Rat(1, 2), 1.5)
+        self.assertEqual(Rat(1, 2) + 1.0, 1.5)
+
+    def test_sub(self):
+        self.assertEqual(Rat(7, 2) - Rat(7, 5), Rat(21, 10))
+        self.assertEqual(Rat(7, 5) - 1, Rat(2, 5))
+        self.assertEqual(1 - Rat(3, 5), Rat(2, 5))
+        self.assertEqual(Rat(3, 2) - 1.0, 0.5)
+        self.assertEqual(1.0 - Rat(1, 2), 0.5)
+
+    def test_mul(self):
+        self.assertEqual(Rat(2, 3) * Rat(5, 7), Rat(10, 21))
+        self.assertEqual(Rat(10, 3) * 3, 10)
+        self.assertEqual(3 * Rat(10, 3), 10)
+        self.assertEqual(Rat(10, 5) * 0.5, 1.0)
+        self.assertEqual(0.5 * Rat(10, 5), 1.0)
+
+    def test_div(self):
+        # self.assertEqual(Rat(10, 3) / Rat(5, 7), Rat(14, 3))
+        # self.assertEqual(Rat(10, 3) / 3, Rat(10, 9))
+        # self.assertEqual(2 / Rat(5), Rat(2, 5))
+        self.assertEqual(3.0 * Rat(1, 2), 1.5)
+        self.assertEqual(Rat(1, 2) * 3.0, 1.5)
+
+    # def test_floordiv(self):
+    #     self.assertEqual(Rat(10) // Rat(4), 2)
+    #     self.assertEqual(Rat(10, 3) // Rat(4, 3), 2)
+    #     self.assertEqual(Rat(10) // 4, 2)
+    #     self.assertEqual(10 // Rat(4), 2)
+
+    def test_eq(self):
+        self.assertEqual(Rat(10), Rat(20, 2))
+        self.assertEqual(Rat(10), 10)
+        self.assertEqual(10, Rat(10))
+        self.assertEqual(Rat(10), 10.0)
+        self.assertEqual(10.0, Rat(10))
+
+    def test_true_div(self):
+        # self.assertEqual(Rat(10, 3) / Rat(5, 7), Rat(14, 3))
+        # self.assertEqual(Rat(10, 3) / 3, Rat(10, 9))
+        # self.assertEqual(2 / Rat(5), Rat(2, 5))
+        self.assertEqual(3.0 * Rat(1, 2), 1.5)
+        self.assertEqual(Rat(1, 2) * 3.0, 1.5)
+        # self.assertEqual(eval('1/2'), 0.5)
+
+    # XXX Ran out of steam; TO DO: divmod, div, future division
+
+
+class OperationLogger:
+    """Base class for classes with operation logging."""
+    def __init__(self, logger):
+        self.logger = logger
+    def log_operation(self, *args):
+        self.logger(*args)
+
+def op_sequence(op, *classes):
+    """Return the sequence of operations that results from applying
+    the operation `op` to instances of the given classes."""
+    log = []
+    instances = []
+    for c in classes:
+        instances.append(c(log.append))
+
+    try:
+        op(*instances)
+    except TypeError:
+        pass
+    return log
+
+class A(OperationLogger):
+    def __eq__(self, other):
+        self.log_operation('A.__eq__')
+        return NotImplemented
+    def __le__(self, other):
+        self.log_operation('A.__le__')
+        return NotImplemented
+    def __ge__(self, other):
+        self.log_operation('A.__ge__')
+        return NotImplemented
+
+class B(OperationLogger):
+    def __eq__(self, other):
+        self.log_operation('B.__eq__')
+        return NotImplemented
+    def __le__(self, other):
+        self.log_operation('B.__le__')
+        return NotImplemented
+    def __ge__(self, other):
+        self.log_operation('B.__ge__')
+        return NotImplemented
+
+class C(B):
+    def __eq__(self, other):
+        self.log_operation('C.__eq__')
+        return NotImplemented
+    def __le__(self, other):
+        self.log_operation('C.__le__')
+        return NotImplemented
+    def __ge__(self, other):
+        self.log_operation('C.__ge__')
+        return NotImplemented
+
+class V(OperationLogger):
+    """Virtual subclass of B"""
+    def __eq__(self, other):
+        self.log_operation('V.__eq__')
+        return NotImplemented
+    def __le__(self, other):
+        self.log_operation('V.__le__')
+        return NotImplemented
+    def __ge__(self, other):
+        self.log_operation('V.__ge__')
+        return NotImplemented
+
+
+class OperationOrderTests(unittest.TestCase):
+    def test_comparison_orders(self):
+        self.assertEqual(op_sequence(eq, A, A), ['A.__eq__', 'A.__eq__'])
+        self.assertEqual(op_sequence(eq, A, B), ['A.__eq__', 'B.__eq__'])
+        self.assertEqual(op_sequence(eq, B, A), ['B.__eq__', 'A.__eq__'])
+        # C is a subclass of B, so C.__eq__ is called first
+        # self.assertEqual(op_sequence(eq, B, C), ['C.__eq__', 'B.__eq__'])
+        self.assertEqual(op_sequence(eq, C, B), ['C.__eq__', 'B.__eq__'])
+
+        # self.assertEqual(op_sequence(le, A, A), ['A.__le__', 'A.__ge__'])
+        # self.assertEqual(op_sequence(le, A, B), ['A.__le__', 'B.__ge__'])
+        # self.assertEqual(op_sequence(le, B, A), ['B.__le__', 'A.__ge__'])
+        # self.assertEqual(op_sequence(le, B, C), ['C.__ge__', 'B.__le__'])
+        # self.assertEqual(op_sequence(le, C, B), ['C.__le__', 'B.__ge__'])
+
+        # self.assertTrue(issubclass(V, B))
+        # self.assertEqual(op_sequence(eq, B, V), ['B.__eq__', 'V.__eq__'])
+        # self.assertEqual(op_sequence(le, B, V), ['B.__le__', 'V.__ge__'])
+
+class SupEq(object):
+    """Class that can test equality"""
+    def __eq__(self, other):
+        return True
+
+class S(SupEq):
+    """Subclass of SupEq that should fail"""
+    __eq__ = None
+
+class F(object):
+    """Independent class that should fall back"""
+
+class X(object):
+    """Independent class that should fail"""
+    __eq__ = None
+
+class SN(SupEq):
+    """Subclass of SupEq that can test equality, but not non-equality"""
+    __ne__ = None
+
+class XN:
+    """Independent class that can test equality, but not non-equality"""
+    def __eq__(self, other):
+        return True
+    __ne__ = None
+
+class FallbackBlockingTests(unittest.TestCase):
+    """Unit tests for None method blocking"""
+
+    def test_fallback_rmethod_blocking(self):
+        e, f, s, x = SupEq(), F(), S(), X()
+        self.assertEqual(e, e)
+        self.assertEqual(e, f)
+        self.assertEqual(f, e)
+        # left operand is checked first
+        self.assertEqual(e, x)
+        self.assertRaises(TypeError, eq, x, e)
+        # S is a subclass, so it's always checked first
+        # self.assertRaises(TypeError, eq, e, s)
+        self.assertRaises(TypeError, eq, s, e)
+
+    def test_fallback_ne_blocking(self):
+        e, sn, xn = SupEq(), SN(), XN()
+        self.assertFalse(e != e)
+        self.assertRaises(TypeError, ne, e, sn)
+        self.assertRaises(TypeError, ne, sn, e)
+        # self.assertFalse(e != xn)
+        self.assertRaises(TypeError, ne, xn, e)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_bool.py
+++ b/test/unit3/test_bool.py
@@ -1,0 +1,324 @@
+# Test properties of bool promised by PEP 285
+
+import unittest
+
+
+class BoolTest(unittest.TestCase):
+
+    # def test_subclass(self):
+    #     try:
+    #         class C(bool):
+    #             pass
+    #     except TypeError:
+    #         pass
+    #     else:
+    #         self.fail("bool should not be subclassable")
+    #
+    #     self.assertRaises(TypeError, int.__new__, bool, 0)
+
+    # def test_repr(self):
+    #     self.assertEqual(repr(False), 'False')
+    #     self.assertEqual(repr(True), 'True')
+    #     self.assertEqual(eval(repr(False)), False)
+    #     self.assertEqual(eval(repr(True)), True)
+
+    def test_str(self):
+        self.assertEqual(str(False), 'False')
+        self.assertEqual(str(True), 'True')
+
+    def test_int(self):
+        self.assertEqual(int(False), 0)
+        # self.assertIsNot(int(False), False)
+        self.assertEqual(int(True), 1)
+        # self.assertIsNot(int(True), True)
+
+    def test_float(self):
+        self.assertEqual(float(False), 0.0)
+        self.assertIsNot(float(False), False)
+        self.assertEqual(float(True), 1.0)
+        self.assertIsNot(float(True), True)
+
+    def test_math(self):
+        self.assertEqual(+False, 0)
+        # self.assertIsNot(+False, False)
+        self.assertEqual(-False, 0)
+        # self.assertIsNot(-False, False)
+        self.assertEqual(abs(False), 0)
+        # self.assertIsNot(abs(False), False)
+        self.assertEqual(+True, 1)
+        # self.assertIsNot(+True, True)
+        self.assertEqual(-True, -1)
+        self.assertEqual(abs(True), 1)
+        # self.assertIsNot(abs(True), True)
+        self.assertEqual(~False, -1)
+        self.assertEqual(~True, -2)
+
+        self.assertEqual(False+2, 2)
+        self.assertEqual(True+2, 3)
+        self.assertEqual(2+False, 2)
+        self.assertEqual(2+True, 3)
+
+        self.assertEqual(False+False, 0)
+        # self.assertIsNot(False+False, False)
+        self.assertEqual(False+True, 1)
+        # self.assertIsNot(False+True, True)
+        self.assertEqual(True+False, 1)
+        # self.assertIsNot(True+False, True)
+        self.assertEqual(True+True, 2)
+
+        self.assertEqual(True-True, 0)
+        # self.assertIsNot(True-True, False)
+        self.assertEqual(False-False, 0)
+        # self.assertIsNot(False-False, False)
+        self.assertEqual(True-False, 1)
+        # self.assertIsNot(True-False, True)
+        self.assertEqual(False-True, -1)
+
+        self.assertEqual(True*1, 1)
+        self.assertEqual(False*1, 0)
+        # self.assertIsNot(False*1, False)
+
+        self.assertEqual(True/1, 1)
+        self.assertIsNot(True/1, True)
+        self.assertEqual(False/1, 0)
+        self.assertIsNot(False/1, False)
+
+        self.assertEqual(True%1, 0)
+        # self.assertIsNot(True%1, False)
+        self.assertEqual(True%2, 1)
+        # self.assertIsNot(True%2, True)
+        self.assertEqual(False%1, 0)
+        # self.assertIsNot(False%1, False)
+
+        for b in False, True:
+            for i in 0, 1, 2:
+                self.assertEqual(b**i, int(b)**i)
+                # self.assertIsNot(b**i, bool(int(b)**i))
+
+        for a in False, True:
+            for b in False, True:
+                self.assertIs(a&b, bool(int(a)&int(b)))
+                self.assertIs(a|b, bool(int(a)|int(b)))
+                self.assertIs(a^b, bool(int(a)^int(b)))
+                self.assertEqual(a&int(b), int(a)&int(b))
+                # self.assertIsNot(a&int(b), bool(int(a)&int(b)))
+                self.assertEqual(a|int(b), int(a)|int(b))
+                # self.assertIsNot(a|int(b), bool(int(a)|int(b)))
+                self.assertEqual(a^int(b), int(a)^int(b))
+                # self.assertIsNot(a^int(b), bool(int(a)^int(b)))
+                self.assertEqual(int(a)&b, int(a)&int(b))
+                # self.assertIsNot(int(a)&b, bool(int(a)&int(b)))
+                self.assertEqual(int(a)|b, int(a)|int(b))
+                # self.assertIsNot(int(a)|b, bool(int(a)|int(b)))
+                self.assertEqual(int(a)^b, int(a)^int(b))
+                # self.assertIsNot(int(a)^b, bool(int(a)^int(b)))
+
+        self.assertIs(1==1, True)
+        self.assertIs(1==0, False)
+        self.assertIs(0<1, True)
+        self.assertIs(1<0, False)
+        self.assertIs(0<=0, True)
+        self.assertIs(1<=0, False)
+        self.assertIs(1>0, True)
+        self.assertIs(1>1, False)
+        self.assertIs(1>=1, True)
+        self.assertIs(0>=1, False)
+        self.assertIs(0!=1, True)
+        self.assertIs(0!=0, False)
+
+        x = [1]
+        self.assertIs(x is x, True)
+        self.assertIs(x is not x, False)
+
+        self.assertIs(1 in x, True)
+        self.assertIs(0 in x, False)
+        self.assertIs(1 not in x, False)
+        self.assertIs(0 not in x, True)
+
+        x = {1: 2}
+        self.assertIs(x is x, True)
+        self.assertIs(x is not x, False)
+
+        self.assertIs(1 in x, True)
+        self.assertIs(0 in x, False)
+        self.assertIs(1 not in x, False)
+        self.assertIs(0 not in x, True)
+
+        self.assertIs(not True, False)
+        self.assertIs(not False, True)
+
+    def test_convert(self):
+        # self.assertRaises(TypeError, bool, 42, 42)
+        self.assertIs(bool(10), True)
+        self.assertIs(bool(1), True)
+        self.assertIs(bool(-1), True)
+        self.assertIs(bool(0), False)
+        self.assertIs(bool("hello"), True)
+        self.assertIs(bool(""), False)
+        # self.assertIs(bool(), False)
+
+    def test_format(self):
+        self.assertEqual("%d" % False, "0")
+        self.assertEqual("%d" % True, "1")
+        self.assertEqual("%x" % False, "0")
+        self.assertEqual("%x" % True, "1")
+
+    def test_hasattr(self):
+        self.assertIs(hasattr([], "append"), True)
+        self.assertIs(hasattr([], "wobble"), False)
+
+    def test_callable(self):
+        self.assertIs(callable(len), True)
+        self.assertIs(callable(1), False)
+
+    def test_isinstance(self):
+        self.assertIs(isinstance(True, bool), True)
+        self.assertIs(isinstance(False, bool), True)
+        self.assertIs(isinstance(True, int), True)
+        self.assertIs(isinstance(False, int), True)
+        self.assertIs(isinstance(1, bool), False)
+        self.assertIs(isinstance(0, bool), False)
+
+    # def test_issubclass(self):
+    #     self.assertIs(issubclass(bool, int), True)
+    #     self.assertIs(issubclass(int, bool), False)
+
+    def test_contains(self):
+        self.assertIs(1 in {}, False)
+        self.assertIs(1 in {1:1}, True)
+
+    def test_string(self):
+        self.assertIs("xyz".endswith("z"), True)
+        self.assertIs("xyz".endswith("x"), False)
+        self.assertIs("xyz0123".isalnum(), True)
+        self.assertIs("@#$%".isalnum(), False)
+        self.assertIs("xyz".isalpha(), True)
+        self.assertIs("@#$%".isalpha(), False)
+        self.assertIs("0123".isdigit(), True)
+        self.assertIs("xyz".isdigit(), False)
+        self.assertIs("xyz".islower(), True)
+        self.assertIs("XYZ".islower(), False)
+        # self.assertIs("0123".isdecimal(), True)
+        # self.assertIs("xyz".isdecimal(), False)
+        self.assertIs("0123".isnumeric(), True)
+        self.assertIs("xyz".isnumeric(), False)
+        self.assertIs(" ".isspace(), True)
+        self.assertIs("\xa0".isspace(), True)
+        # self.assertIs("\u3000".isspace(), True)
+        self.assertIs("XYZ".isspace(), False)
+        self.assertIs("X".istitle(), True)
+        self.assertIs("x".istitle(), False)
+        self.assertIs("XYZ".isupper(), True)
+        self.assertIs("xyz".isupper(), False)
+        self.assertIs("xyz".startswith("x"), True)
+        self.assertIs("xyz".startswith("z"), False)
+
+    def test_boolean(self):
+        self.assertEqual(True & 1, 1)
+        self.assertNotIsInstance(True & 1, bool)
+        self.assertIs(True & True, True)
+
+        self.assertEqual(True | 1, 1)
+        self.assertNotIsInstance(True | 1, bool)
+        self.assertIs(True | True, True)
+
+        self.assertEqual(True ^ 1, 0)
+        self.assertNotIsInstance(True ^ 1, bool)
+        self.assertIs(True ^ True, False)
+
+    def test_types(self):
+        # types are always true.
+        for t in [bool, complex, dict, float, int, list, object,
+                  set, str, tuple, type]:
+            self.assertIs(bool(t), True)
+
+    def test_operator(self):
+        import operator
+        self.assertIs(operator.truth(0), False)
+        self.assertIs(operator.truth(1), True)
+        # self.assertIs(operator.not_(1), False)
+        # self.assertIs(operator.not_(0), True)
+        self.assertIs(operator.contains([], 1), False)
+        self.assertIs(operator.contains([1], 1), True)
+        self.assertIs(operator.lt(0, 0), False)
+        self.assertIs(operator.lt(0, 1), True)
+        self.assertIs(operator.is_(True, True), True)
+        self.assertIs(operator.is_(True, False), False)
+        self.assertIs(operator.is_not(True, True), False)
+        self.assertIs(operator.is_not(True, False), True)
+
+    # def test_marshal(self):
+    #     import marshal
+    #     self.assertIs(marshal.loads(marshal.dumps(True)), True)
+    #     self.assertIs(marshal.loads(marshal.dumps(False)), False)
+    #
+    # def test_convert_to_bool(self):
+    #     # Verify that TypeError occurs when bad things are returned
+    #     # from __bool__().  This isn't really a bool test, but
+    #     # it's related.
+    #     check = lambda o: self.assertRaises(TypeError, bool, o)
+    #     class Foo(object):
+    #         def __bool__(self):
+    #             return self
+    #     check(Foo())
+    #
+    #     class Bar(object):
+    #         def __bool__(self):
+    #             return "Yes"
+    #     check(Bar())
+    #
+    #     class Baz(int):
+    #         def __bool__(self):
+    #             return self
+    #     check(Baz())
+    #
+    #     # __bool__() must return a bool not an int
+    #     class Spam(int):
+    #         def __bool__(self):
+    #             return 1
+    #     check(Spam())
+    #
+    #     class Eggs:
+    #         def __len__(self):
+    #             return -1
+    #     self.assertRaises(ValueError, bool, Eggs())
+
+    # def test_sane_len(self):
+    #     # this test just tests our assumptions about __len__
+    #     # this will start failing if __len__ changes assertions
+    #     for badval in ['illegal', -1, 1 << 32]:
+    #         class A:
+    #             def __len__(self):
+    #                 return badval
+    #         try:
+    #             bool(A())
+    #         except (Exception) as e_bool:
+    #             try:
+    #                 len(A())
+    #             except (Exception) as e_len:
+    #                 self.assertEqual(str(e_bool), str(e_len))
+
+    # def test_blocked(self):
+    #     class A:
+    #         __bool__ = None
+    #     self.assertRaises(TypeError, bool, A())
+    #
+    #     class B:
+    #         def __len__(self):
+    #             return 10
+    #         __bool__ = None
+    #     self.assertRaises(TypeError, bool, B())
+
+    # def test_real_and_imag(self):
+    #     self.assertEqual(True.real, 1)
+    #     self.assertEqual(True.imag, 0)
+    #     self.assertIs(type(True.real), int)
+    #     self.assertIs(type(True.imag), int)
+    #     self.assertEqual(False.real, 0)
+    #     self.assertEqual(False.imag, 0)
+    #     self.assertIs(type(False.real), int)
+    #     self.assertIs(type(False.imag), int)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_bug619.py
+++ b/test/unit3/test_bug619.py
@@ -1,0 +1,18 @@
+import unittest
+from time import sleep
+
+class SleepyLen():
+    def __len__(self):
+        sleep(1)
+        return 42
+
+class SelfDefinedSleepyLen(unittest.TestCase):
+
+    def test_len(self):
+        test = SleepyLen()
+
+        self.assertEqual(42, test.__len__())
+        self.assertEqual(42, len(test))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_builtin.py
+++ b/test/unit3/test_builtin.py
@@ -1,0 +1,1267 @@
+import unittest
+import random
+import sys
+
+
+def add_one(num):
+    """function for testing"""
+    if num != 2 and num != 6.0 and num != -151.5:
+        return num + 1
+
+str1 = 'ABCD'
+str2 = 'xy'
+str3 = 'ABCDE'
+str4 = 'abcde'
+lst1 = [1, 2, 3, 4, 5]
+lst2 = [2, 4, 6, 8, 10]
+lst3 = [-150, -151, -151.49, -151.50000, -151.500001, -152.0]
+gen1 = (letter for letter in str4)
+gen2 = (num for num in lst1)
+
+class Squares:
+    """class for testing, creates list of squares from 0 to i - 1"""
+
+    def __init__(self, max):
+        self.max = max
+        self.sofar = []
+
+    def __len__(self): return len(self.sofar)
+
+    def __getitem__(self, i):
+        if not 0 <= i < self.max: raise IndexError
+        n = len(self.sofar)
+        while n <= i:
+            self.sofar.append(n*n)
+            n += 1
+        return self.sofar[i]
+
+class BitBucket:
+    def write(self, line):
+        pass
+
+class TestFailingBool:
+    def __bool__(self):
+        raise RuntimeError
+
+class TestFailingIter:
+    def __iter__(self):
+        raise RuntimeError
+
+def filter_char(arg):
+    return ord(arg) > ord("d")
+
+def map_char(arg):
+    return chr(ord(arg) + 1)
+
+class AttrTest(unittest.TestCase):
+
+    def test_range_contains(self):
+        self.assertEqual(10 in range(11), True)
+        self.assertEqual(-4 in range(-10, -1), True)
+        self.assertEqual(1000000 in range(0, 1000001, 10), True)
+        self.assertEqual(range(-5, 0).__contains__(-3), True)
+        self.assertEqual(range(1000).__contains__(782), True)
+        self.assertEqual(range(-1, -8, -2).__contains__(-7), True)
+
+
+    # def test_generator_next(self):
+    #     self.assertRaises(AttributeError, lambda: gen1.next())
+    #     self.assertRaises(AttributeError, lambda: gen2.next())
+
+
+class BuiltinTest(unittest.TestCase):
+
+    def test_abs(self):
+        # int
+        self.assertEqual(abs(0), 0)
+        self.assertEqual(abs(1234), 1234)
+        self.assertEqual(abs(-1234), 1234)
+        self.assertTrue(abs(-sys.maxsize-1) > 0)
+        # float
+        self.assertEqual(abs(0.0), 0.0)
+        self.assertEqual(abs(3.14), 3.14)
+        self.assertEqual(abs(-3.14), 3.14)
+        # # str
+        # self.assertRaises(TypeError, abs, 'a')
+        # bool
+        self.assertEqual(abs(True), 1)
+        self.assertEqual(abs(False), 0)
+        # other
+        # self.assertRaises(TypeError, abs)
+        # self.assertRaises(TypeError, abs, None)
+        class AbsClass(object):
+            def __abs__(self):
+                return -5
+        self.assertEqual(abs(AbsClass()), -5)
+
+    def test_all(self):
+        self.assertEqual(all([2, 4, 6]), True)
+        self.assertEqual(all([2, None, 6]), False)
+        # self.assertRaises(RuntimeError, all, [2, TestFailingBool(), 6])
+        self.assertRaises(RuntimeError, all, TestFailingIter())
+        self.assertRaises(TypeError, all, 10)               # Non-iterable
+        self.assertRaises(TypeError, all)                   # No args
+        self.assertRaises(TypeError, all, [2, 4, 6], [])    # Too many args
+        self.assertEqual(all([]), True)                     # Empty iterator
+        self.assertEqual(all([0, TestFailingBool()]), False)# Short-circuit
+        S = [50, 60]
+        self.assertEqual(all(x > 42 for x in S), True)
+        S = [50, 40, 60]
+        self.assertEqual(all(x > 42 for x in S), False)
+
+    def test_any(self):
+        self.assertEqual(any([None, None, None]), False)
+        self.assertEqual(any([None, 4, None]), True)
+        # self.assertRaises(RuntimeError, any, [None, TestFailingBool(), 6])
+        self.assertRaises(RuntimeError, any, TestFailingIter())
+        self.assertRaises(TypeError, any, 10)               # Non-iterable
+        self.assertRaises(TypeError, any)                   # No args
+        self.assertRaises(TypeError, any, [2, 4, 6], [])    # Too many args
+        self.assertEqual(any([]), False)                    # Empty iterator
+        self.assertEqual(any([1, TestFailingBool()]), True) # Short-circuit
+        S = [40, 60, 30]
+        self.assertEqual(any(x > 42 for x in S), True)
+        S = [10, 20, 30]
+        self.assertEqual(any(x > 42 for x in S), False)
+
+    # def test_ascii(self):
+    #     self.assertEqual(ascii(''), '\'\'')
+    #     self.assertEqual(ascii(0), '0')
+    #     self.assertEqual(ascii(()), '()')
+    #     self.assertEqual(ascii([]), '[]')
+    #     self.assertEqual(ascii({}), '{}')
+    #     a = []
+    #     a.append(a)
+    #     self.assertEqual(ascii(a), '[[...]]')
+    #     a = {}
+    #     a[0] = a
+    #     self.assertEqual(ascii(a), '{0: {...}}')
+    #     # Advanced checks for unicode strings
+    #     def _check_uni(s):
+    #         self.assertEqual(ascii(s), repr(s))
+    #     _check_uni("'")
+    #     _check_uni('"')
+    #     _check_uni('"\'')
+    #     _check_uni('\0')
+    #     _check_uni('\r\n\t .')
+    #     # Unprintable non-ASCII characters
+    #     _check_uni('\x85')
+    #     _check_uni('\u1fff')
+    #     _check_uni('\U00012fff')
+    #     # Lone surrogates
+    #     _check_uni('\ud800')
+    #     _check_uni('\udfff')
+    #     # Issue #9804: surrogates should be joined even for printable
+    #     # wide characters (UCS-2 builds).
+    #     self.assertEqual(ascii('\U0001d121'), "'\\U0001d121'")
+    #     # All together
+    #     s = "'\0\"\n\r\t abcd\x85é\U00012fff\uD800\U0001D121xxx."
+    #     self.assertEqual(ascii(s),
+    #         r"""'\'\x00"\n\r\t abcd\x85\xe9\U00012fff\ud800\U0001d121xxx.'""")
+
+    def test_bin(self):
+        self.assertEqual(bin(0), '0b0')
+        self.assertEqual(bin(1), '0b1')
+        self.assertEqual(bin(-1), '-0b1')
+        self.assertEqual(bin(2**65), '0b1' + '0' * 65)
+        self.assertEqual(bin(2**65-1), '0b' + '1' * 65)
+        self.assertEqual(bin(-(2**65)), '-0b1' + '0' * 65)
+        self.assertEqual(bin(-(2**65-1)), '-0b' + '1' * 65)
+
+    def test_callable(self):
+        self.assertTrue(callable(len))
+        self.assertFalse(callable("a"))
+        self.assertTrue(callable(callable))
+        self.assertTrue(callable(lambda x, y: x + y))
+        # self.assertFalse(callable(__builtins__))
+        def f(): pass
+        self.assertTrue(callable(f))
+
+        class C1:
+            def meth(self): pass
+        self.assertTrue(callable(C1))
+        c = C1()
+        self.assertTrue(callable(c.meth))
+        self.assertFalse(callable(c))
+
+    def test_chr(self):
+        self.assertEqual(chr(97), 'a')
+        # self.assertEqual(chr(1114111), '􏿿')
+        # self.assertEqual(chr(256), 'Ā')
+        self.assertEqual(chr(255), 'ÿ')
+
+    # def test_construct_singletons(self):
+    #     for const in None, Ellipsis, NotImplemented:
+    #         tp = type(const)
+    #         self.assertIs(tp(), const)
+    #         self.assertRaises(TypeError, tp, 1, 2)
+    #         self.assertRaises(TypeError, tp, a=1, b=2)
+
+    def test_delattr(self):
+        sys.spam = 1
+        delattr(sys, 'spam')
+        self.assertRaises(TypeError, delattr)
+
+    def test_dir(self):
+        # dir(wrong number of arguments)
+        self.assertRaises(TypeError, dir, 42, 42)
+
+        # dir() - local scope
+        local_var = 1
+        # self.assertIn('local_var', dir())
+
+        # dir(module)
+        # self.assertIn('exit', dir(sys))
+
+        # dir(module_with_invalid__dict__)
+        # class Foo(types.ModuleType):
+        #     __dict__ = 8
+        # f = Foo("foo")
+        # self.assertRaises(TypeError, dir, f)
+
+        # dir(type)
+        # self.assertIn("strip", dir(str))
+        self.assertNotIn("__mro__", dir(str))
+
+        # dir(obj)
+        class Foo(object):
+            def __init__(self):
+                self.x = 7
+                self.y = 8
+                self.z = 9
+        f = Foo()
+        self.assertIn("y", dir(f))
+
+        # dir(obj_no__dict__)
+        # class Foo(object):
+        #     __slots__ = []
+        # f = Foo()
+        # self.assertIn("__repr__", dir(f))
+
+        # dir(obj_no__class__with__dict__)
+        # (an ugly trick to cause getattr(f, "__class__") to fail)
+        class Foo(object):
+            __slots__ = ["__class__", "__dict__"]
+            def __init__(self):
+                self.bar = "wow"
+        f = Foo()
+        # self.assertNotIn("__repr__", dir(f))
+        self.assertIn("bar", dir(f))
+
+        # dir(obj_using __dir__)
+        class Foo(object):
+            def __dir__(self):
+                return ["kan", "ga", "roo"]
+        f = Foo()
+        self.assertTrue(dir(f) == ["ga", "kan", "roo"])
+
+        # dir(obj__dir__tuple)
+        class Foo(object):
+            def __dir__(self):
+                return ("b", "c", "a")
+        res = dir(Foo())
+        self.assertIsInstance(res, list)
+        self.assertTrue(res == ["a", "b", "c"])
+
+        # dir(obj__dir__not_sequence)
+        class Foo(object):
+            def __dir__(self):
+                return 7
+        f = Foo()
+        self.assertRaises(TypeError, dir, f)
+
+        # dir(traceback)
+        # try:
+        #     raise IndexError
+        # except:
+        #     self.assertEqual(len(dir(sys.exc_info()[2])), 4)
+
+        # test that object has a __dir__()
+        # self.assertEqual(sorted([].__dir__()), dir([]))
+
+
+    def test_divmod(self):
+        self.assertEqual(divmod(12, 7), (1, 5))
+        self.assertEqual(divmod(-12, 7), (-2, 2))
+        self.assertEqual(divmod(12, -7), (-2, -2))
+        self.assertEqual(divmod(-12, -7), (1, -5))
+
+        self.assertEqual(divmod(-sys.maxsize-1, -1), (sys.maxsize+1, 0))
+
+        for num, denom, exp_result in [ (3.25, 1.0, (3.0, 0.25)),
+                                        (-3.25, 1.0, (-4.0, 0.75)),
+                                        (3.25, -1.0, (-4.0, -0.75)),
+                                        (-3.25, -1.0, (3.0, -0.25))]:
+            result = divmod(num, denom)
+            self.assertAlmostEqual(result[0], exp_result[0])
+            self.assertAlmostEqual(result[1], exp_result[1])
+
+        # self.assertRaises(TypeError, divmod)
+
+        # class X:
+        #     def __getitem__(self, key):
+        #         raise ValueError
+        # self.assertRaises(ValueError, eval, "foo", {}, X())
+
+
+    # def test_eval(self):
+    #     self.assertEqual(eval('1+1'), 2)
+    #     self.assertEqual(eval(' 1+1\n'), 2)
+    #     globals = {'a': 1, 'b': 2}
+    #     locals = {'b': 200, 'c': 300}
+    #     self.assertEqual(eval('a', globals) , 1)
+    #     self.assertEqual(eval('a', globals, locals), 1)
+    #     self.assertEqual(eval('b', globals, locals), 200)
+    #     self.assertEqual(eval('c', globals, locals), 300)
+    #     globals = {'a': 1, 'b': 2}
+    #     locals = {'b': 200, 'c': 300}
+    #     self.assertEqual(eval('"\xe5"', globals), "\xe5")
+    #     self.assertRaises(TypeError, eval)
+    #     self.assertRaises(TypeError, eval, ())
+
+    def test_filter(self):
+        self.assertEqual(list(filter(lambda c: 'a' <= c <= 'z', 'Hello World')), list('elloorld'))
+        self.assertEqual(list(filter(None, [1, 'hello', [], [3], '', None, 9, 0])), [1, 'hello', [3], 9])
+        self.assertEqual(list(filter(lambda x: x > 0, [1, -3, 9, 0, 2])), [1, 9, 2])
+        self.assertEqual(list(filter(None, Squares(10))), [1, 4, 9, 16, 25, 36, 49, 64, 81])
+        self.assertEqual(list(filter(lambda x: x%2, Squares(10))), [1, 9, 25, 49, 81])
+        self.assertEqual(list(filter(add_one, lst1)), [1, 3, 4, 5])
+        # self.assertEqual(str(filter(add_one, lst1))[:7], "<filter")
+        self.assertEqual(list(filter(add_one, lst2)), [4, 8, 10])
+        # self.assertEqual(str(filter(add_one, lst2))[:7], "<filter")
+        self.assertEqual(list(filter(add_one, lst3)), [-150, -151, -151.49, -151.500001, -152])
+        # self.assertEqual(str(filter(add_one, lst3))[:7], "<filter")
+        def identity(item):
+            return 1
+        filter(identity, Squares(5))
+        self.assertRaises(TypeError, filter)
+        class BadSeq(object):
+            def __getitem__(self, index):
+                if index<4:
+                    return 42
+                raise ValueError
+        # self.assertRaises(ValueError, list, filter(lambda x: x, BadSeq()))
+        def badfunc():
+            pass
+        # self.assertRaises(TypeError, list, filter(badfunc, range(5)))
+
+        # test bltinmodule.c::filtertuple()
+        self.assertEqual(list(filter(None, (1, 2))), [1, 2])
+        self.assertEqual(list(filter(lambda x: x>=3, (1, 2, 3, 4))), [3, 4])
+        # self.assertRaises(TypeError, list, filter(42, (1, 2)))
+
+    def test_format(self):
+        # Test the basic machinery of the format() builtin.  Don't test
+        #  the specifics of the various formatters
+        # self.assertEqual(format(3, ''), '3')
+
+        # Returns some classes to use for various tests.  There's
+        #  an old-style version, and a new-style version
+        def classes_new():
+            class A(object):
+                def __init__(self, x):
+                    self.x = x
+                def __format__(self, format_spec):
+                    return str(self.x) + format_spec
+            class DerivedFromA(A):
+                pass
+
+            class Simple(object): pass
+            class DerivedFromSimple(Simple):
+                def __init__(self, x):
+                    self.x = x
+                def __format__(self, format_spec):
+                    return str(self.x) + format_spec
+            class DerivedFromSimple2(DerivedFromSimple): pass
+            return A, DerivedFromA, DerivedFromSimple, DerivedFromSimple2
+
+        def class_test(A, DerivedFromA, DerivedFromSimple, DerivedFromSimple2):
+            self.assertEqual(format(A(3), 'spec'), '3spec')
+            self.assertEqual(format(DerivedFromA(4), 'spec'), '4spec')
+            self.assertEqual(format(DerivedFromSimple(5), 'abc'), '5abc')
+            self.assertEqual(format(DerivedFromSimple2(10), 'abcdef'),
+                             '10abcdef')
+
+        class_test(*classes_new())
+
+        # def empty_format_spec(value):
+        #     # test that:
+        #     #  format(x, '') == str(x)
+        #     #  format(x) == str(x)
+        #     self.assertEqual(format(value, ""), str(value))
+        #     self.assertEqual(format(value), str(value))
+        #
+        # # for builtin types, format(x, "") == str(x)
+        # empty_format_spec(17**13)
+        # empty_format_spec(1.0)
+        # empty_format_spec(3.1415e104)
+        # empty_format_spec(-3.1415e104)
+        # empty_format_spec(3.1415e-104)
+        # empty_format_spec(-3.1415e-104)
+        # empty_format_spec(object)
+        # empty_format_spec(None)
+
+        # TypeError because self.__format__ returns the wrong type
+        class BadFormatResult:
+            def __format__(self, format_spec):
+                return 1.0
+        self.assertRaises(TypeError, format, BadFormatResult(), "")
+
+        # TypeError because format_spec is not unicode or str
+        self.assertRaises(TypeError, format, object(), 4)
+        self.assertRaises(TypeError, format, object(), object())
+
+        # # tests for object.__format__ really belong elsewhere, but
+        # #  there's no good place to put them
+        # x = object().__format__('')
+        # self.assertTrue(x.startswith('<object object at'))
+        #
+        # # first argument to object.__format__ must be string
+        # self.assertRaises(TypeError, object().__format__, 3)
+        # self.assertRaises(TypeError, object().__format__, object())
+        # self.assertRaises(TypeError, object().__format__, None)
+
+        # --------------------------------------------------------------------
+        # Issue #7994: object.__format__ with a non-empty format string is
+        # disallowed
+        # class A:
+        #     def __format__(self, fmt_str):
+        #         return format('', fmt_str)
+        #
+        # self.assertEqual(format(A()), '')
+        # self.assertEqual(format(A(), ''), '')
+        # self.assertEqual(format(A(), 's'), '')
+
+    # def test_general_eval(self):
+    #     # Tests that general mappings can be used for the locals argument
+    #
+    #     class M:
+    #         "Test mapping interface versus possible calls from eval()."
+    #         def __getitem__(self, key):
+    #             if key == 'a':
+    #                 return 12
+    #             raise KeyError
+    #         def keys(self):
+    #             return list('xyz')
+    #
+    #     m = M()
+    #     g = globals()
+    #     self.assertEqual(eval('a', g, m), 12)
+    #     self.assertRaises(NameError, eval, 'b', g, m)
+    #     self.assertEqual(eval('dir()', g, m), list('xyz'))
+    #     self.assertEqual(eval('globals()', g, m), g)
+    #     self.assertEqual(eval('locals()', g, m), m)
+    #     self.assertRaises(TypeError, eval, 'a', m)
+    #     class A:
+    #         "Non-mapping"
+    #         pass
+    #     m = A()
+    #     self.assertRaises(TypeError, eval, 'a', g, m)
+    #
+    #     # Verify that dict subclasses work as well
+    #     class D(dict):
+    #         def __getitem__(self, key):
+    #             if key == 'a':
+    #                 return 12
+    #             return dict.__getitem__(self, key)
+    #         def keys(self):
+    #             return list('xyz')
+    #
+    #     d = D()
+    #     self.assertEqual(eval('a', g, d), 12)
+    #     self.assertRaises(NameError, eval, 'b', g, d)
+    #     self.assertEqual(eval('dir()', g, d), list('xyz'))
+    #     self.assertEqual(eval('globals()', g, d), g)
+    #     self.assertEqual(eval('locals()', g, d), d)
+    #
+    #     # Verify locals stores (used by list comps)
+    #     eval('[locals() for i in (2,3)]', g, d)
+    #     eval('[locals() for i in (2,3)]', g, collections.UserDict())
+    #
+    #     class SpreadSheet:
+    #         "Sample application showing nested, calculated lookups."
+    #         _cells = {}
+    #         def __setitem__(self, key, formula):
+    #             self._cells[key] = formula
+    #         def __getitem__(self, key):
+    #             return eval(self._cells[key], globals(), self)
+    #
+    #     ss = SpreadSheet()
+    #     ss['a1'] = '5'
+    #     ss['a2'] = 'a1*6'
+    #     ss['a3'] = 'a2*7'
+    #     self.assertEqual(ss['a3'], 210)
+    #
+    #     # Verify that dir() catches a non-list returned by eval
+    #     # SF bug #1004669
+    #     class C:
+    #         def __getitem__(self, item):
+    #             raise KeyError(item)
+    #         def keys(self):
+    #             return 1 # used to be 'a' but that's no longer an error
+    #     self.assertRaises(TypeError, eval, 'dir()', globals(), C())
+    #
+    #     class frozendict_error(Exception):
+    #         pass
+    #
+    #     class frozendict(dict):
+    #         def __setitem__(self, key, value):
+    #             raise frozendict_error("frozendict is readonly")
+
+    def test_getattr(self):
+        self.assertTrue(getattr(sys, 'stdout') is sys.stdout)
+        self.assertRaises(TypeError, getattr, sys, 1)
+        self.assertRaises(TypeError, getattr, sys, 1, "foo")
+        self.assertRaises(TypeError, getattr)
+        # self.assertRaises(AttributeError, getattr, sys, chr(sys.maxunicode))
+        # unicode surrogates are not encodable to the default encoding (utf8)
+        self.assertRaises(AttributeError, getattr, 1, "\uDAD1\uD51E")
+
+    def test_hasattr(self):
+        self.assertTrue(hasattr(sys, 'stdout'))
+        self.assertRaises(TypeError, hasattr, sys, 1)
+        self.assertRaises(TypeError, hasattr)
+        # self.assertEqual(False, hasattr(sys, chr(sys.maxunicode)))
+
+        # Check that hasattr propagates all exceptions outside of
+        # AttributeError.
+        class A:
+            def __getattr__(self, what):
+                raise SystemExit
+        self.assertRaises(SystemExit, hasattr, A(), "b")
+        class B:
+            def __getattr__(self, what):
+                raise ValueError
+        self.assertRaises(ValueError, hasattr, B(), "b")
+
+    def test_hex(self):
+        self.assertEqual(hex(16), '0x10')
+        self.assertEqual(hex(-16), '-0x10')
+        self.assertRaises(TypeError, hex, {})
+
+    def test_id(self):
+        id(None)
+        id(1)
+        id(1.0)
+        id('spam')
+        id((0,1,2,3))
+        id([0,1,2,3])
+        id({'spam': 1, 'eggs': 2, 'ham': 3})
+
+    # def test_import(self):
+    #     __import__('sys')
+    #     __import__('time')
+    #     __import__('string')
+    #     __import__(name='sys')
+    #     __import__(name='time', level=0)
+    #     self.assertRaises(ImportError, __import__, 'spamspam')
+    #     self.assertRaises(TypeError, __import__, 1, 2, 3, 4)
+    #     self.assertRaises(ValueError, __import__, '')
+    #     self.assertRaises(TypeError, __import__, 'sys', name='sys')
+
+    # Test input() later, alphabetized as if it were raw_input
+
+    def test_iter(self):
+        self.assertRaises(TypeError, iter)
+        # self.assertRaises(TypeError, iter, 42, 42)
+        lists = [("1", "2"), ["1", "2"], "12"]
+        for l in lists:
+            i = iter(l)
+            self.assertEqual(next(i), '1')
+            self.assertEqual(next(i), '2')
+            self.assertRaises(StopIteration, next, i)
+
+    def test_isinstance(self):
+        class C:
+            pass
+        class D(C):
+            pass
+        class E:
+            pass
+        c = C()
+        d = D()
+        e = E()
+        self.assertTrue(isinstance(c, C))
+        self.assertTrue(isinstance(d, C))
+        self.assertTrue(not isinstance(e, C))
+        self.assertTrue(not isinstance(c, D))
+        self.assertTrue(not isinstance('foo', E))
+        self.assertRaises(TypeError, isinstance, E, 'foo')
+        self.assertRaises(TypeError, isinstance)
+
+    def test_issubclass(self):
+        class C:
+            pass
+        class D(C):
+            pass
+        class E:
+            pass
+        c = C()
+        d = D()
+        e = E()
+        self.assertTrue(issubclass(D, C))
+        self.assertTrue(issubclass(C, C))
+        self.assertTrue(not issubclass(C, D))
+        # self.assertRaises(TypeError, issubclass, 'foo', E)
+        self.assertRaises(TypeError, issubclass, E, 'foo')
+        self.assertRaises(TypeError, issubclass)
+
+    def test_len(self):
+        self.assertEqual(len('123'), 3)
+        self.assertEqual(len(()), 0)
+        self.assertEqual(len((1, 2, 3, 4)), 4)
+        self.assertEqual(len([1, 2, 3, 4]), 4)
+        self.assertEqual(len({}), 0)
+        self.assertEqual(len({'a':1, 'b': 2}), 2)
+        class BadSeq:
+            def __len__(self):
+                raise ValueError
+        self.assertRaises(ValueError, len, BadSeq())
+        class InvalidLen:
+            def __len__(self):
+                return None
+        self.assertRaises(TypeError, len, InvalidLen())
+        # class FloatLen:
+        #     def __len__(self):
+        #         return 4.5
+        # self.assertRaises(TypeError, len, FloatLen())
+        # class HugeLen:
+        #     def __len__(self):
+        #         return sys.maxsize + 1
+        # self.assertRaises(OverflowError, len, HugeLen())
+        # class NoLenMethod(object): pass
+        # self.assertRaises(TypeError, len, NoLenMethod())
+
+    def test_map(self):
+        self.assertEqual(
+            list(map(lambda x: x*x, range(1,4))),
+            [1, 4, 9]
+        )
+        try:
+            from math import sqrt
+        except ImportError:
+            def sqrt(x):
+                return pow(x, 0.5)
+        self.assertEqual(
+            list(map(lambda x: list(map(sqrt, x)), [[16, 4], [81, 9]])),
+            [[4.0, 2.0], [9.0, 3.0]]
+        )
+        self.assertEqual(
+            list(map(lambda x, y: x+y, [1,3,2], [9,1,4])),
+            [10, 4, 6]
+        )
+
+        def plus(*v):
+            accu = 0
+            for i in v: accu = accu + i
+            return accu
+        self.assertEqual(
+            list(map(plus, [1, 3, 7])),
+            [1, 3, 7]
+        )
+        self.assertEqual(
+            list(map(plus, [1, 3, 7], [4, 9, 2])),
+            [1+4, 3+9, 7+2]
+        )
+        self.assertEqual(
+            list(map(plus, [1, 3, 7], [4, 9, 2], [1, 1, 0])),
+            [1+4+1, 3+9+1, 7+2+0]
+        )
+        self.assertEqual(
+            list(map(int, Squares(10))),
+            [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
+        )
+        def Max(a, b):
+            if a is None:
+                return b
+            if b is None:
+                return a
+            return max(a, b)
+        # self.assertEqual(
+        #     list(map(Max, Squares(3), Squares(2))),
+        #     [0, 1]
+        # )
+        self.assertRaises(TypeError, map)
+        self.assertRaises(TypeError, map, lambda x: x, 42)
+        class BadSeq:
+            def __iter__(self):
+                raise ValueError
+                yield None
+        # self.assertRaises(ValueError, list, map(lambda x: x, BadSeq()))
+        def badfunc(x):
+            raise RuntimeError
+        # self.assertRaises(RuntimeError, list, map(badfunc, range(5)))
+
+
+    def test_max(self):
+        self.assertEqual(max('123123'), '3')
+        self.assertEqual(max(1, 2, 3), 3)
+        self.assertEqual(max((1, 2, 3, 1, 2, 3)), 3)
+        self.assertEqual(max([1, 2, 3, 1, 2, 3]), 3)
+
+        self.assertEqual(max(1, 2, 3.0), 3.0)
+        self.assertEqual(max(1, 2.0, 3), 3)
+        self.assertEqual(max(1.0, 2, 3), 3)
+
+        self.assertRaises(TypeError, max)
+        self.assertRaises(TypeError, max, 42)
+        self.assertRaises(ValueError, max, ())
+
+        class BadSeq:
+            def __getitem__(self, index):
+                raise ValueError
+
+        self.assertRaises(ValueError, max, BadSeq())
+
+        # self.assertEqual(max((), default=None), None)  # zero elem iterable
+        # self.assertEqual(max((1,), default=None), 1)  # one elem iterable
+        # self.assertEqual(max((1, 2), default=None), 2)  # two elem iterable
+
+        data = [random.randrange(200) for i in range(100)]
+        keys = dict((elem, random.randrange(50)) for elem in data)
+        f = keys.__getitem__
+        # self.assertEqual(max(data, key=f),
+        #                  sorted(reversed(data), key=f)[-1])
+
+        class BadSeq:
+            def __getitem__(self, i):
+                if i == 5:
+                    raise ValueError
+                else:
+                    return i
+        # self.assertRaises(ValueError, list, zip(BadSeq(), BadSeq()))
+
+    def test_min(self):
+        self.assertEqual(min('123123'), '1')
+        self.assertEqual(min(1, 2, 3), 1)
+        self.assertEqual(min((1, 2, 3, 1, 2, 3)), 1)
+        self.assertEqual(min([1, 2, 3, 1, 2, 3]), 1)
+
+        self.assertEqual(min(1, 2, 3.0), 1)
+        self.assertEqual(min(1, 2.0, 3), 1)
+        self.assertEqual(min(1.0, 2, 3), 1.0)
+
+        self.assertRaises(TypeError, min)
+        self.assertRaises(TypeError, min, 42)
+        self.assertRaises(ValueError, min, ())
+
+    def test_neg(self):
+        x = -sys.maxsize-1
+        # self.assertTrue(isinstance(x, int))
+        self.assertEqual(-x, sys.maxsize+1)
+
+    def test_next(self):
+        it = iter(range(2))
+        self.assertEqual(next(it), 0)
+        self.assertEqual(next(it), 1)
+        self.assertRaises(StopIteration, next, it)
+        self.assertRaises(StopIteration, next, it)
+        self.assertEqual(next(it, 42), 42)
+
+        class Iter(object):
+            def __iter__(self):
+                return self
+            def __next__(self):
+                raise StopIteration
+
+        # it = iter(Iter())
+        # self.assertEqual(next(it, 42), 42)
+        # self.assertRaises(StopIteration, next, it)
+
+        def gen():
+            yield 1
+            return
+
+        it = gen()
+        self.assertEqual(next(it), 1)
+        self.assertRaises(StopIteration, next, it)
+        self.assertEqual(next(it, 42), 42)
+
+    def test_oct(self):
+        # self.assertEqual(oct(100), '0o144')
+        # self.assertEqual(oct(-100), '-0o144')
+        self.assertRaises(TypeError, oct, ())
+
+    def test_pow(self):
+        self.assertEqual(pow(0,0), 1)
+        self.assertEqual(pow(0,1), 0)
+        self.assertEqual(pow(1,0), 1)
+        self.assertEqual(pow(1,1), 1)
+
+        self.assertEqual(pow(2,0), 1)
+        self.assertEqual(pow(2,10), 1024)
+        self.assertEqual(pow(2,20), 1024*1024)
+        self.assertEqual(pow(2,30), 1024*1024*1024)
+
+        self.assertEqual(pow(-2,0), 1)
+        self.assertEqual(pow(-2,1), -2)
+        self.assertEqual(pow(-2,2), 4)
+        self.assertEqual(pow(-2,3), -8)
+
+        self.assertAlmostEqual(pow(0.,0), 1.)
+        self.assertAlmostEqual(pow(0.,1), 0.)
+        self.assertAlmostEqual(pow(1.,0), 1.)
+        self.assertAlmostEqual(pow(1.,1), 1.)
+
+        self.assertAlmostEqual(pow(2.,0), 1.)
+        self.assertAlmostEqual(pow(2.,10), 1024.)
+        self.assertAlmostEqual(pow(2.,20), 1024.*1024.)
+        self.assertAlmostEqual(pow(2.,30), 1024.*1024.*1024.)
+
+        self.assertAlmostEqual(pow(-2.,0), 1.)
+        self.assertAlmostEqual(pow(-2.,1), -2.)
+        self.assertAlmostEqual(pow(-2.,2), 4.)
+        self.assertAlmostEqual(pow(-2.,3), -8.)
+
+        for x in 2, 2.0:
+            for y in 10, 10.0:
+                for z in 1000, 1000.0:
+                    if isinstance(x, float) or \
+                       isinstance(y, float) or \
+                       isinstance(z, float):
+                        self.assertRaises(TypeError, pow, x, y, z)
+                    else:
+                        self.assertAlmostEqual(pow(x, y, z), 24.0)
+
+        # self.assertAlmostEqual(pow(-1, 0.5), 1j)
+        # self.assertAlmostEqual(pow(-1, 1/3), 0.5 + 0.8660254037844386j)
+
+        # self.assertRaises(ValueError, pow, -1, -2, 3)
+        # self.assertRaises(ValueError, pow, 1, 2, 0)
+        #
+        self.assertRaises(TypeError, pow)
+
+    def test_range(self):
+        # self.assertEqual(str(range(5)), 'range(0, 5)')
+        self.assertEqual(list(range(5)), [0, 1, 2, 3, 4])
+        # self.assertEqual(str(type(range(5))), "<class 'range'>")
+        # self.assertEqual(str(range(1, 5)), 'range(1, 5)')
+        self.assertEqual(list(range(1, 5)), [1, 2, 3, 4])
+        # self.assertEqual(str(type(range(1, 5))), "<class 'range'>")
+        # self.assertEqual(str(range(1, 8, 2)), 'range(1, 8, 2)')
+        self.assertEqual(list(range(1, 8, 2)), [1, 3, 5, 7])
+        # self.assertEqual(str(type(range(1, 8, 2))), "<class 'range'>")
+
+    def test_repr(self):
+        self.assertEqual(repr(''), '\'\'')
+        self.assertEqual(repr(0), '0')
+        self.assertEqual(repr(()), '()')
+        self.assertEqual(repr([]), '[]')
+        self.assertEqual(repr({}), '{}')
+        a = []
+        a.append(a)
+        self.assertEqual(repr(a), '[[...]]')
+        a = {}
+        a[0] = a
+        self.assertEqual(repr(a), '{0: {...}}')
+
+    def test_round(self):
+        self.assertEqual(round(0.0), 0.0)
+        self.assertEqual(type(round(0.0)), int)
+        self.assertEqual(round(1.0), 1.0)
+        self.assertEqual(round(10.0), 10.0)
+        self.assertEqual(round(1000000000.0), 1000000000.0)
+        self.assertEqual(round(1e20), 1e20)
+
+        # self.assertEqual(round(0.5), 0)
+        self.assertEqual(round(-0.5), 0)
+        self.assertEqual(round(1.5), 2)
+        # self.assertEqual(round(-1.5), -2)
+        self.assertEqual(round(0.49999999), 0)
+        self.assertEqual(round(-0.49999999), 0)
+        self.assertEqual(round(0.500000001), 1)
+        self.assertEqual(round(-0.500000001), -1)
+        # self.assertEqual(round(2.675, 2), 2.67)
+        self.assertEqual(round(-2.675, 2), -2.67)
+        self.assertEqual(round(12, -1), 10)
+        self.assertEqual(round(15, -1), 20)
+        self.assertEqual(round(18, -1), 20)
+        self.assertEqual(round(-12, -1), -10)
+        # self.assertEqual(round(-15, -1), -20)
+        self.assertEqual(round(-18, -1), -20)
+        # self.assertEqual(round(250, -2), 200)
+        self.assertEqual(round(251, -2), 300)
+        self.assertEqual(round(-250, -2), -200)
+        self.assertEqual(round(-251, -2), -300)
+
+        self.assertEqual(round(-1.0), -1.0)
+        self.assertEqual(round(-10.0), -10.0)
+        self.assertEqual(round(-1000000000.0), -1000000000.0)
+        self.assertEqual(round(-1e20), -1e20)
+
+        self.assertEqual(round(0.1), 0.0)
+        self.assertEqual(round(1.1), 1.0)
+        self.assertEqual(round(10.1), 10.0)
+        self.assertEqual(round(1000000000.1), 1000000000.0)
+
+        self.assertEqual(round(-1.1), -1.0)
+        self.assertEqual(round(-10.1), -10.0)
+        self.assertEqual(round(-1000000000.1), -1000000000.0)
+
+        self.assertEqual(round(0.9), 1.0)
+        self.assertEqual(round(9.9), 10.0)
+        self.assertEqual(round(999999999.9), 1000000000.0)
+
+        self.assertEqual(round(-0.9), -1.0)
+        self.assertEqual(round(-9.9), -10.0)
+        self.assertEqual(round(-999999999.9), -1000000000.0)
+
+        self.assertEqual(round(-8.0, -1), -10.0)
+        self.assertEqual(type(round(-8.0, -1)), float)
+
+        self.assertEqual(type(round(-8.0, 0)), float)
+        self.assertEqual(type(round(-8.0, 1)), float)
+
+        # Check even / odd rounding behaviour
+        self.assertEqual(round(5.5), 6)
+        # self.assertEqual(round(6.5), 6)
+        # self.assertEqual(round(-5.5), -6)
+        self.assertEqual(round(-6.5), -6)
+
+        # Check behavior on ints
+        self.assertEqual(round(0), 0)
+        self.assertEqual(round(8), 8)
+        self.assertEqual(round(-8), -8)
+        self.assertEqual(type(round(0)), int)
+        self.assertEqual(type(round(-8, -1)), int)
+        self.assertEqual(type(round(-8, 0)), int)
+        self.assertEqual(type(round(-8, 1)), int)
+
+        # # test new kwargs
+        # self.assertEqual(round(number=-8.0, ndigits=-1), -10.0)
+
+        self.assertRaises(TypeError, round)
+
+        # test generic rounding delegation for reals
+        class TestRound:
+            def __round__(self):
+                return 23
+
+        class TestNoRound:
+            pass
+
+        # self.assertEqual(round(TestRound()), 23)
+
+        self.assertRaises(TypeError, round, 1, 2, 3)
+        self.assertRaises(TypeError, round, TestNoRound())
+
+        t = TestNoRound()
+        t.__round__ = lambda *args: args
+        self.assertRaises(TypeError, round, t)
+        self.assertRaises(TypeError, round, t, 0)
+
+    def test_round_large(self):
+        # Issue #1869: integral floats should remain unchanged
+        self.assertEqual(round(5e15-1), 5e15-1)
+        self.assertEqual(round(5e15), 5e15)
+        self.assertEqual(round(5e15+1), 5e15+1)
+        self.assertEqual(round(5e15+2), 5e15+2)
+        self.assertEqual(round(5e15+3), 5e15+3)
+
+    def test_setattr(self):
+        setattr(sys, 'spam', 1)
+        self.assertEqual(sys.spam, 1)
+        self.assertRaises(TypeError, setattr, sys, 1, 'spam')
+        self.assertRaises(TypeError, setattr)
+
+    # test_str(): see test_unicode.py and test_bytes.py for str() tests.
+
+    def test_sum(self):
+        self.assertEqual(sum([]), 0)
+        self.assertEqual(sum(list(range(2,8))), 27)
+        self.assertEqual(sum(iter(list(range(2,8)))), 27)
+        self.assertEqual(sum(Squares(10)), 285)
+        self.assertEqual(sum(iter(Squares(10))), 285)
+        self.assertEqual(sum([[1], [2], [3]], []), [1, 2, 3])
+
+
+        self.assertRaises(TypeError, sum)
+        self.assertRaises(TypeError, sum, 42)
+        self.assertRaises(TypeError, sum, ['a', 'b', 'c'])
+        self.assertRaises(TypeError, sum, ['a', 'b', 'c'], '')
+        self.assertRaises(TypeError, sum, [[1], [2], [3]])
+        self.assertRaises(TypeError, sum, [{2:3}])
+        self.assertRaises(TypeError, sum, [{2:3}]*2, {2:3})
+
+        class BadSeq:
+            def __getitem__(self, index):
+                raise ValueError
+        self.assertRaises(ValueError, sum, BadSeq())
+
+        empty = []
+        sum(([x] for x in range(10)), empty)
+        self.assertEqual(empty, [])
+
+    def test_type(self):
+        self.assertEqual(type(''),  type('123'))
+        # self.assertNotEqual(type(''), type(()))
+
+    # # We don't want self in vars(), so these are static methods
+    #
+    # @staticmethod
+    # def get_vars_f0():
+    #     return vars()
+    #
+    # @staticmethod
+    # def get_vars_f2():
+    #     BuiltinTest.get_vars_f0()
+    #     a = 1
+    #     b = 2
+    #     return vars()
+    #
+    # class C_get_vars(object):
+    #     def getDict(self):
+    #         return {'a':2}
+    #     __dict__ = property(fget=getDict)
+    #
+    # def test_vars(self):
+    #     self.assertEqual(set(vars()), set(dir()))
+    #     self.assertEqual(set(vars(sys)), set(dir(sys)))
+    #     self.assertEqual(self.get_vars_f0(), {})
+    #     self.assertEqual(self.get_vars_f2(), {'a': 1, 'b': 2})
+    #     self.assertRaises(TypeError, vars, 42, 42)
+    #     self.assertRaises(TypeError, vars, 42)
+    #     self.assertEqual(vars(self.C_get_vars()), {'a':2})
+
+    def test_zip(self):
+        self.assertEqual(list(zip(str1, str2)), [('A', 'x'), ('B', 'y')])
+        # self.assertEqual(str(zip(str1, str2))[1:11], "zip object")
+        # self.assertEqual(str(type(zip(str1, str2))), "<class 'zip'>")
+        self.assertEqual(list(zip(lst1, str3, str4)), [(1, 'A', 'a'), (2, 'B', 'b'), (3, 'C', 'c'), (4, 'D', 'd'), (5, 'E', 'e')])
+        # self.assertEqual(str(zip(lst1, str3, str4))[1:11], "zip object")
+        # self.assertEqual(str(type(zip(lst1, str3, str4))), "<class 'zip'>")
+        lst1b, str3b, str4b = zip(*zip(lst1, str3, str4))
+        self.assertEqual(list(lst1b), lst1)
+        self.assertEqual(''.join(str3b), str3)
+        self.assertEqual(''.join(str4b), str4)
+        a = (1, 2, 3)
+        b = (4, 5, 6)
+        t = [(1, 4), (2, 5), (3, 6)]
+        self.assertEqual(list(zip(a, b)), t)
+        b = [4, 5, 6]
+        self.assertEqual(list(zip(a, b)), t)
+        b = (4, 5, 6, 7)
+        self.assertEqual(list(zip(a, b)), t)
+        class I:
+            def __getitem__(self, i):
+                if i < 0 or i > 2: raise IndexError
+                return i + 4
+        self.assertEqual(list(zip(a, I())), t)
+        self.assertEqual(list(zip()), [])
+        self.assertEqual(list(zip(*[])), [])
+        self.assertRaises(TypeError, zip, None)
+        class G:
+            pass
+        self.assertRaises(TypeError, zip, a, G())
+        self.assertRaises(RuntimeError, zip, a, TestFailingIter())
+
+        # Make sure zip doesn't try to allocate a billion elements for the
+        # result list when one of its arguments doesn't say how long it is.
+        # A MemoryError is the most likely failure mode.
+        class SequenceWithoutALength:
+            def __getitem__(self, i):
+                if i == 5:
+                    raise IndexError
+                else:
+                    return i
+        self.assertEqual(list(zip(SequenceWithoutALength(), range(2**23))), list(enumerate(range(5))))
+
+
+class DepreciatedTest(unittest.TestCase):
+
+    def test_basestring(self):
+        self.assertRaises(NameError, lambda: isinstance(str1, basestring))
+        self.assertRaises(NameError, lambda: isinstance(str4, basestring))
+        self.assertRaises(NameError, lambda: isinstance('ā', basestring))
+
+    def test_cmp(self):
+        self.assertRaises(NameError, lambda: cmp(4, 5))
+        self.assertRaises(NameError, lambda: cmp(-15.5, -9.743902))
+        self.assertRaises(NameError, lambda: cmp(22, -.0001))
+
+    # def test_execfile(self):
+    #     self.assertRaises(NameError, lambda: execfile("./filename"))
+    #
+    # def test_file(self):
+    #     self.assertRaises(NameError, lambda: isinstance("filename", file))
+    #
+    # def test_long(self):
+    #     self.assertRaises(NameError, lambda: long(8923.322))
+    #     self.assertRaises(NameError, lambda: long(-3289))
+    #
+    # def test_raw_input(self):
+    #     self.assertRaises(NameError, lambda: raw_input("What is your name?"))
+    #     self.assertRaises(NameError, lambda: raw_input("Who is your dog?"))
+    #
+    # def test_reduce(self):
+    #     self.assertRaises(NameError, lambda: reduce(lambda x, y: x + y, [1, 2, 3, 4, 5]))
+
+    def test_reload(self):
+        self.assertRaises(NameError, lambda: reload(math))
+
+    # def test_unichr(self):
+    #     self.assertRaises(NameError, lambda: unichr(97))
+    #     self.assertRaises(NameError, lambda: unichr(-2))
+
+    def test_unicode(self):
+        self.assertRaises(NameError, lambda: unicode('abcdef'))
+
+    # def test_xrange(self):
+    #     self.assertRaises(NameError, lambda: xrange(10))
+    #     self.assertRaises(NameError, lambda: xrange(0, 9, 2))
+    #     self.assertRaises(NameError, lambda: xrange(-10, 0))
+
+
+class DictMethodsTest(unittest.TestCase):
+
+    def test_dict_methods(self):
+        animals = {"cats": 1, "dogs": 2, "horses": 0}
+        # self.assertEqual(str(animals.keys())[:9], 'dict_keys')
+        self.assertEqual(list(animals.keys()), ['cats', 'dogs', 'horses'])
+        # self.assertEqual(str(animals.values())[:11], 'dict_values')
+        self.assertEqual(list(animals.values()), [1, 2, 0])
+        # self.assertEqual(str(animals.items())[:10], 'dict_items')
+        self.assertEqual(list(animals.items()), [('cats', 1), ('dogs', 2), ('horses', 0)])
+
+
+class DivTest(unittest.TestCase):
+
+    def test_int_div(self):
+        self.assertEqual(3 / 2, 1.5)
+        self.assertEqual(1 / 8, 0.125)
+        self.assertEqual(200 / -800, -0.25)
+
+
+# class ForLoopTest(unittest.TestCase):
+#
+#     def test_loop_vars(self):
+#         i = 1
+#         [i for i in range(5)]
+#         self.assertEqual(i, 1)
+#
+#
+# class TypeTest(unittest.TestCase):
+#
+#     def test_type_compare(self):
+#         self.assertRaises(TypeError, lambda: [1, 2] > 'foo')
+#         self.assertRaises(TypeError, lambda: (1, 2) > 'foo')
+#         self.assertRaises(TypeError, lambda: [1, 2] > (1, 2))
+
+
+class TestSorted(unittest.TestCase):
+
+    def test_baddecorator(self):
+        data = 'The quick Brown fox Jumped over The lazy Dog'.split()
+        self.assertRaises(TypeError, sorted, data, None, lambda x, y: 0)
+
+    def test_basic(self):
+        data = list(range(100))
+        copy = data[:]
+        random.shuffle(copy)
+        self.assertEqual(data, sorted(copy))
+        self.assertNotEqual(data, copy)
+
+        data.reverse()
+        random.shuffle(copy)
+        self.assertEqual(data, sorted(copy, key=lambda x: -x))
+        self.assertNotEqual(data, copy)
+        random.shuffle(copy)
+        self.assertEqual(data, sorted(copy, reverse=1))
+        self.assertNotEqual(data, copy)
+
+    def test_bad_arguments(self):
+        # Issue #29327: The first argument is positional-only.
+        sorted([])
+        self.assertRaises(TypeError, lambda: sorted(iterable=[]))
+        # Other arguments are keyword-only
+        sorted([], key=None)
+        # self.assertRaises(TypeError, lambda: sorted([], None))
+
+    def test_inputtypes(self):
+        s = 'abracadabra'
+        types = [list, tuple, str]
+        for T in types:
+            self.assertEqual(sorted(s), sorted(T(s)))
+
+        s = ''.join(set(s))  # unique letters only
+        types = [str, set, frozenset, list, tuple, dict.fromkeys]
+        # for T in types:
+        #     self.assertEqual(sorted(s), sorted(T(s)))
+
+class TestType(unittest.TestCase):
+
+
+    def test_new_type(self):
+        A = type('A', (), {})
+        self.assertEqual(A.__name__, 'A')
+        # self.assertEqual(A.__qualname__, 'A')
+        self.assertEqual(A.__module__, __name__)
+        # self.assertEqual(A.__bases__, (object,))
+        # self.assertIs(A.__base__, object)
+        x = A()
+        self.assertIs(type(x), A)
+        self.assertIs(x.__class__, A)
+
+        class B:
+            def ham(self):
+                return 'ham%d' % self
+        # C = type('C', (B, int), {'spam': lambda self: 'spam%s' % self})
+        # self.assertEqual(C.__name__, 'C')
+        # self.assertEqual(C.__qualname__, 'C')
+        # self.assertEqual(C.__module__, __name__)
+        # self.assertEqual(C.__bases__, (B, int))
+        # self.assertIs(C.__base__, int)
+        # self.assertIn('spam', C.__dict__)
+        # self.assertNotIn('ham', C.__dict__)
+        # x = C(42)
+        # self.assertEqual(x, 42)
+        # self.assertIs(type(x), C)
+        # self.assertIs(x.__class__, C)
+        # self.assertEqual(x.ham(), 'ham42')
+        # self.assertEqual(x.spam(), 'spam42')
+        # self.assertEqual(x.to_bytes(2, 'little'), b'\x2a\x00')
+
+    # def test_type_nokwargs(self):
+    #     self.assertRaises(TypeError, lambda: type('a', (), {}, x=5))
+    #     self.assertRaises(TypeError, lambda: type('a', (), dict={}))
+
+
+    def test_type_qualname(self):
+        A = type('A', (), {'__qualname__': 'B.C'})
+        self.assertEqual(A.__name__, 'A')
+        self.assertEqual(A.__qualname__, 'B.C')
+        self.assertEqual(A.__module__, __name__)
+        self.assertEqual(A.__qualname__, 'B.C')
+        A.__qualname__ = 'D.E'
+        self.assertEqual(A.__name__, 'A')
+        self.assertEqual(A.__qualname__, 'D.E')
+        self.assertEqual(A.__qualname__, 'D.E')
+
+    def test_bad_args(self):
+        # self.assertRaises(TypeError, lambda: type())
+        # self.assertRaises(TypeError, lambda: type('A', ()))
+        # self.assertRaises(TypeError, lambda: type('A', (), {}, ()))
+        # self.assertRaises(TypeError, lambda: type('A', (), dict={}))
+        self.assertRaises(TypeError, lambda: type('A', [], {}))
+        # self.assertRaises(TypeError, lambda: type('A', (), types.MappingProxyType({})))
+        # self.assertRaises(TypeError, lambda: type('A', (None,), {}))
+        # self.assertRaises(TypeError, lambda: type('A', (bool,), {}))
+        self.assertRaises(TypeError, lambda: type('A', (int, str), {}))
+
+
+    # def test_bad_slots(self):
+    #     self.assertRaises(TypeError, lambda: type('A', (int,), {'__slots__': 'x'}))
+    #     self.assertRaises(TypeError, lambda: type('A', (), {'__slots__': ''}))
+    #     self.assertRaises(TypeError, lambda: type('A', (), {'__slots__': '42'}))
+    #     self.assertRaises(TypeError, lambda: type('A', (), {'__slots__': 'x\x00y'}))
+    #     self.assertRaises(ValueError, lambda: type('A', (), {'__slots__': 'x', 'x': 0}))
+    #     self.assertRaises(TypeError, lambda: type('A', (), {'__slots__': ('__dict__', '__dict__')}))
+    #     self.assertRaises(TypeError, lambda: type('A', (), {'__slots__': ('__weakref__', '__weakref__')}))
+    #
+    #     class B:
+    #         pass
+    #     self.assertRaises(TypeError, lambda: type('A', (B,), {'__slots__': '__dict__'}))
+    #     self.assertRaises(TypeError, lambda: type('A', (B,), {'__slots__': '__weakref__'}))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_calling.py
+++ b/test/unit3/test_calling.py
@@ -1,0 +1,75 @@
+# Python test set -- built-in functions
+
+import unittest
+
+
+def f1(x, y, *args, **kwargs):
+    return (x, y, args, kwargs)
+
+def f2(x=None, y=None, *args, **kwargs):
+    return (x, y, args, kwargs)
+
+class C:
+    def f1(self, x, y, *args, **kwargs):
+        return (self, x, y, args, kwargs)
+
+    def f2(self, x=None, y=None, *args, **kwargs):
+        return (self, x, y, args, kwargs)
+
+
+class BuiltinTest(unittest.TestCase):
+
+    def test_simple_call(self):
+        self.assertEqual(f1(1, 2), (1, 2, (), {}))
+        self.assertRaises(TypeError, lambda: f1(1))
+        self.assertEqual(f2(1), (1, None, (), {}))
+
+        self.assertEqual(f1(1, 2, 3, 4), (1, 2, (3, 4), {}))
+        self.assertEqual(f1(1, y=2), (1, 2, (), {}))
+        self.assertEqual(f1(1, z=3, y=2), (1, 2, (), {'z': 3}))
+        self.assertRaises(TypeError, lambda: f1(1, 2, y=3))
+
+        self.assertEqual(f1(1, *[2, 3]), (1, 2, (3,), {}))
+        self.assertEqual(f1(**{'x': 1, 'y': 2}), (1, 2, (), {}))
+        self.assertEqual(f1(**{'x': 1, 'y': 2, 'z': 3}), (1, 2, (), {'z': 3}))
+        self.assertEqual(f1(*[1, 2, 3], **{'z': 4}), (1, 2, (3,), {'z': 4}))
+        self.assertRaises(TypeError, lambda: f1(*[1, 2, 3], **{'y', 4}))
+
+
+    def test_method_call(self):
+        o = C()
+
+        self.assertEqual(o.f1(1, 2), (o, 1, 2, (), {}))
+        self.assertRaises(TypeError, lambda: o.f1(1))
+        self.assertEqual(o.f2(1), (o, 1, None, (), {}))
+
+        self.assertEqual(o.f1(1, 2, 3, 4), (o, 1, 2, (3, 4), {}))
+        self.assertEqual(o.f1(1, y=2), (o, 1, 2, (), {}))
+        self.assertEqual(o.f1(1, z=3, y=2), (o, 1, 2, (), {'z': 3}))
+        self.assertRaises(TypeError, lambda: o.f1(1, 2, y=3))
+        self.assertRaises(TypeError, lambda: o.f1(1, 2, self=3))
+
+        self.assertEqual(o.f1(1, *[2, 3]), (o, 1, 2, (3,), {}))
+        self.assertEqual(o.f1(**{'x': 1, 'y': 2}), (o, 1, 2, (), {}))
+        self.assertEqual(o.f1(**{'x': 1, 'y': 2, 'z': 3}), (o, 1, 2, (), {'z': 3}))
+        self.assertEqual(o.f1(*[1, 2, 3], **{'z': 4}), (o, 1, 2, (3,), {'z': 4}))
+        self.assertRaises(TypeError, lambda: o.f1(*[1, 2, 3], **{'y', 4}))
+
+
+# Test the interaction of free variables with kwargs
+def make_adder():
+    c = 42
+    def f(x):
+        return x + c
+    return f
+
+class ClosureTestCase(unittest.TestCase):
+    def test_closure_with_kwargs(self):
+        adder = make_adder()
+
+        self.assertEqual(adder(x=42), 84)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_class.py
+++ b/test/unit3/test_class.py
@@ -1,0 +1,459 @@
+"Test the functionality of Python classes implementing operators."
+
+import unittest
+
+
+testmeths = [
+
+# Binary operations
+    "add",
+    "radd",
+    "sub",
+    "rsub",
+    "mul",
+    "rmul",
+    "matmul",
+    "rmatmul",
+    "truediv",
+    "rtruediv",
+    "floordiv",
+    "rfloordiv",
+    "mod",
+    "rmod",
+    "divmod",
+    "rdivmod",
+    "pow",
+    "rpow",
+    "rshift",
+    "rrshift",
+    "lshift",
+    "rlshift",
+    "and",
+    "rand",
+    "or",
+    "ror",
+    "xor",
+    "rxor",
+
+# List/dict operations
+    "contains",
+    "getitem",
+    "setitem",
+    "delitem",
+
+# Unary operations
+    "neg",
+    "pos",
+    "abs",
+
+# generic operations
+    "init",
+    ]
+
+# These need to return something other than None
+#    "hash",
+#    "str",
+#    "repr",
+#    "int",
+#    "float",
+
+# These are separate because they can influence the test of other methods.
+#    "getattr",
+#    "setattr",
+#    "delattr",
+
+callLst = []
+def trackCall(f):
+    def track(*args, **kwargs):
+        callLst.append((f.__name__, args))
+        return f(*args, **kwargs)
+    return track
+
+# Synthesize all the other AllTests methods from the names in testmeths.
+
+d = {}
+AllTests = type("AllTests", (object,), d)
+
+class ClassTests(unittest.TestCase):
+    def setUp(self):
+        callLst[:] = []
+
+    def assertCallStack(self, expected_calls):
+        actualCallList = callLst[:]  # need to copy because the comparison below will add
+                                     # additional calls to callLst
+        # if expected_calls != actualCallList:
+        #     self.fail("Expected call list:\n  %s\ndoes not match actual call list\n  %s" %
+        #               (expected_calls, actualCallList))
+
+    def testInit(self):
+        foo = AllTests()
+        self.assertCallStack([("__init__", (foo,))])
+
+    def testBinaryOps(self):
+        testme = AllTests()
+        # Binary operations
+
+        callLst[:] = []
+        self.assertCallStack([("__add__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__radd__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__sub__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rsub__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__mul__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rmul__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__matmul__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rmatmul__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__truediv__", (testme, 1))])
+
+
+        callLst[:] = []
+        self.assertCallStack([("__rtruediv__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__floordiv__", (testme, 1))])
+
+
+        callLst[:] = []
+        self.assertCallStack([("__rfloordiv__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__mod__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rmod__", (testme, 1))])
+
+
+        callLst[:] = []
+        self.assertCallStack([("__divmod__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rdivmod__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__pow__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rpow__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rshift__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rrshift__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__lshift__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rlshift__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__and__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rand__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__or__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__ror__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__xor__", (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([("__rxor__", (testme, 1))])
+
+    def testListAndDictOps(self):
+        testme = AllTests()
+
+        # List/dict operations
+
+        class Empty: pass
+
+        try:
+            1 in Empty()
+            self.fail('failed, should have raised TypeError')
+        except TypeError:
+            pass
+
+        callLst[:] = []
+        self.assertCallStack([('__contains__', (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([('__getitem__', (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([('__setitem__', (testme, 1, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([('__delitem__', (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([('__getitem__', (testme, slice(None, 42)))])
+
+        callLst[:] = []
+        self.assertCallStack([('__setitem__', (testme, slice(None, 42),
+                                               "The Answer"))])
+
+        callLst[:] = []
+        self.assertCallStack([('__delitem__', (testme, slice(None, 42)))])
+
+        callLst[:] = []
+        self.assertCallStack([('__getitem__', (testme, slice(2, 1024, 10)))])
+
+        callLst[:] = []
+        self.assertCallStack([('__setitem__', (testme, slice(2, 1024, 10),
+                                                                    "A lot"))])
+        callLst[:] = []
+        self.assertCallStack([('__delitem__', (testme, slice(2, 1024, 10)))])
+
+        callLst[:] = []
+        self.assertCallStack([('__getitem__', (testme, (slice(None, 42, None),
+                                                        slice(None, 24, None),
+                                                        24, 100)))])
+        callLst[:] = []
+        self.assertCallStack([('__setitem__', (testme, (slice(None, 42, None),
+                                                        slice(None, 24, None),
+                                                        24, 100), "Strange"))])
+        callLst[:] = []
+        self.assertCallStack([('__delitem__', (testme, (slice(None, 42, None),
+                                                        slice(None, 24, None),
+                                                        24, 100)))])
+
+    def testUnaryOps(self):
+        testme = AllTests()
+
+        callLst[:] = []
+        self.assertCallStack([('__neg__', (testme,))])
+        callLst[:] = []
+        self.assertCallStack([('__pos__', (testme,))])
+        callLst[:] = []
+        self.assertCallStack([('__abs__', (testme,))])
+        callLst[:] = []
+        self.assertCallStack([('__int__', (testme,))])
+        callLst[:] = []
+        self.assertCallStack([('__float__', (testme,))])
+        callLst[:] = []
+        self.assertCallStack([('__index__', (testme,))])
+        callLst[:] = []
+        self.assertCallStack([('__index__', (testme,))])
+
+
+    def testMisc(self):
+        testme = AllTests()
+
+        callLst[:] = []
+        hash(testme)
+        self.assertCallStack([('__hash__', (testme,))])
+
+        callLst[:] = []
+        repr(testme)
+        self.assertCallStack([('__repr__', (testme,))])
+
+        callLst[:] = []
+        str(testme)
+        self.assertCallStack([('__str__', (testme,))])
+
+        callLst[:] = []
+        testme == 1
+        self.assertCallStack([('__eq__', (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([('__lt__', (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([('__gt__', (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([('__ne__', (testme, 1))])
+
+        callLst[:] = []
+        self.assertCallStack([('__eq__', (1, testme))])
+
+        callLst[:] = []
+        self.assertCallStack([('__gt__', (1, testme))])
+
+        callLst[:] = []
+        self.assertCallStack([('__lt__', (1, testme))])
+
+        callLst[:] = []
+        1 != testme
+        self.assertCallStack([('__ne__', (1, testme))])
+
+
+    def testGetSetAndDel(self):
+        # Interfering tests
+        class ExtraTests(AllTests):
+            def __getattr__(self, *args):
+                return "SomeVal"
+
+            def __setattr__(self, *args):
+                pass
+
+            def __delattr__(self, *args):
+                pass
+
+        testme = ExtraTests()
+
+        callLst[:] = []
+        testme.spam
+        self.assertCallStack([('__getattr__', (testme, "spam"))])
+
+        callLst[:] = []
+        testme.eggs = "spam, spam, spam and ham"
+        self.assertCallStack([('__setattr__', (testme, "eggs",
+                                               "spam, spam, spam and ham"))])
+
+        callLst[:] = []
+        self.assertCallStack([('__delattr__', (testme, "cardinal"))])
+
+    # def testDel(self):
+    #     x = []
+    #
+    #     class DelTest:
+    #         def __del__(self):
+    #             x.append("crab people, crab people")
+    #     testme = DelTest()
+    #     del testme
+    #     import gc
+    #     gc.collect()
+    #     self.assertEqual(["crab people, crab people"], x)
+
+    def testBadTypeReturned(self):
+        # return values of some method are type-checked
+        class BadTypeClass:
+            def __int__(self):
+                return None
+            __float__ = __int__
+            __complex__ = __int__
+            __str__ = __int__
+            __repr__ = __int__
+            __bytes__ = __int__
+            __bool__ = __int__
+            __index__ = __int__
+        def index(x):
+            return [][x]
+
+        # self.assertRaises(TypeError, float, BadTypeClass())
+        self.assertRaises(TypeError, complex, BadTypeClass())
+        # self.assertRaises(TypeError, str, BadTypeClass())
+        # self.assertRaises(TypeError, repr, BadTypeClass())
+        self.assertRaises(TypeError, bin, BadTypeClass())
+        self.assertRaises(TypeError, oct, BadTypeClass())
+        self.assertRaises(TypeError, hex, BadTypeClass())
+        # self.assertRaises(TypeError, bool, BadTypeClass())
+        self.assertRaises(TypeError, index, BadTypeClass())
+
+
+    # def testHashStuff(self):
+    #     # Test correct errors from hash() on objects with comparisons but
+    #     #  no __hash__
+    #
+    #     class C0:
+    #         pass
+    #
+    #     hash(C0()) # This should work; the next two should raise TypeError
+    #
+    #     class C2:
+    #         def __eq__(self, other): return 1
+    #
+    #     self.assertRaises(TypeError, hash, C2())
+
+
+    # def testSFBug532646(self):
+    #     # Test for SF bug 532646
+    #
+    #     class A:
+    #         pass
+    #     A.__call__ = A()
+    #     a = A()
+    #
+    #     try:
+    #         a() # This should not segfault
+    #     except RecursionError:
+    #         pass
+    #     else:
+    #         self.fail("Failed to raise RecursionError")
+
+    # def testForExceptionsRaisedInInstanceGetattr2(self):
+    #     # Tests for exceptions raised in instance_getattr2().
+    #
+    #     def booh(self):
+    #         raise AttributeError("booh")
+    #
+    #     class A:
+    #         a = property(booh)
+    #     try:
+    #         A().a # Raised AttributeError: A instance has no attribute 'a'
+    #     except AttributeError as x:
+    #         if str(x) != "booh":
+    #             self.fail("attribute error for A().a got masked: %s" % x)
+    #
+    #     class E:
+    #         __eq__ = property(booh)
+    #     E() == E() # In debug mode, caused a C-level assert() to fail
+    #
+    #     class I:
+    #         __init__ = property(booh)
+    #     try:
+    #         # In debug mode, printed XXX undetected error and
+    #         #  raises AttributeError
+    #         I()
+    #     except AttributeError as x:
+    #         pass
+    #     else:
+    #         self.fail("attribute error for I.__init__ got masked")
+
+    def testHashComparisonOfMethods(self):
+        # Test comparison and hash of methods
+        class A:
+            def __init__(self, x):
+                self.x = x
+            def f(self):
+                pass
+            def g(self):
+                pass
+            def __eq__(self, other):
+                return self.x == other.x
+            def __hash__(self):
+                return self.x
+        class B(A):
+            pass
+
+        a1 = A(1)
+        a2 = A(2)
+        # self.assertEqual(a1.f, a1.f)
+        self.assertNotEqual(a1.f, a2.f)
+        self.assertNotEqual(a1.f, a1.g)
+        # self.assertEqual(a1.f, A(1).f)
+        # self.assertEqual(hash(a1.f), hash(a1.f))
+        # self.assertEqual(hash(a1.f), hash(A(1).f))
+
+        self.assertNotEqual(A.f, a1.f)
+        self.assertNotEqual(A.f, A.g)
+        self.assertEqual(B.f, A.f)
+        self.assertEqual(hash(B.f), hash(A.f))
+
+        # the following triggers a SystemError in 2.4
+        a = A(hash(A.f)^(-1))
+        hash(a.f)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_compare.py
+++ b/test/unit3/test_compare.py
@@ -1,0 +1,111 @@
+import unittest
+
+class Empty:
+    def __repr__(self):
+        return '<Empty>'
+
+class Cmp:
+    def __init__(self,arg):
+        self.arg = arg
+
+    def __repr__(self):
+        return '<Cmp %s>' % self.arg
+
+    def __eq__(self, other):
+        return self.arg == other
+
+class Anything:
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+class ComparisonTest(unittest.TestCase):
+    set1 = [2, 2.0, 2, 2+0j, Cmp(2.0)]
+    set2 = [[1], (3,), None, Empty()]
+    candidates = set1 + set2
+
+    def test_comparisons(self):
+        for a in self.candidates:
+            for b in self.candidates:
+                if ((a in self.set1) and (b in self.set1)) or a is b:
+                    self.assertEqual(a, b)
+                else:
+                    self.assertNotEqual(a, b)
+
+    def test_id_comparisons(self):
+        # Ensure default comparison compares id() of args
+        L = []
+        for i in range(10):
+            L.insert(len(L)//2, Empty())
+        for a in L:
+            for b in L:
+                self.assertEqual(a == b, id(a) == id(b),
+                                 'a=%r, b=%r' % (a, b))
+
+    def test_ne_defaults_to_not_eq(self):
+        a = Cmp(1)
+        b = Cmp(1)
+        c = Cmp(2)
+        self.assertIs(a == b, True)
+        # self.assertIs(a != b, False)
+        self.assertIs(a != c, True)
+
+    # def test_ne_high_priority(self):
+    #     """object.__ne__() should allow reflected __ne__() to be tried"""
+    #     calls = []
+    #     class Left:
+    #         # Inherits object.__ne__()
+    #         def __eq__(*args):
+    #             calls.append('Left.__eq__')
+    #             return NotImplemented
+    #     class Right:
+    #         def __eq__(*args):
+    #             calls.append('Right.__eq__')
+    #             return NotImplemented
+    #         def __ne__(*args):
+    #             calls.append('Right.__ne__')
+    #             return NotImplemented
+    #     Left() != Right()
+    #     self.assertSequenceEqual(calls, ['Left.__eq__', 'Right.__ne__'])
+
+    # def test_ne_low_priority(self):
+    #     """object.__ne__() should not invoke reflected __eq__()"""
+    #     calls = []
+    #     class Base:
+    #         # Inherits object.__ne__()
+    #         def __eq__(*args):
+    #             calls.append('Base.__eq__')
+    #             return NotImplemented
+    #     class Derived(Base):  # Subclassing forces higher priority
+    #         def __eq__(*args):
+    #             calls.append('Derived.__eq__')
+    #             return NotImplemented
+    #         def __ne__(*args):
+    #             calls.append('Derived.__ne__')
+    #             return NotImplemented
+    #     Base() != Derived()
+    #     self.assertSequenceEqual(calls, ['Derived.__ne__', 'Base.__eq__'])
+
+    def test_other_delegation(self):
+        """No default delegation between operations except __ne__()"""
+        ops = (
+            ('__eq__', lambda a, b: a == b),
+            ('__lt__', lambda a, b: a < b),
+            ('__le__', lambda a, b: a <= b),
+            ('__gt__', lambda a, b: a > b),
+            ('__ge__', lambda a, b: a >= b),
+        )
+
+    def test_issue_1393(self):
+        x = lambda: None
+        self.assertEqual(x, Anything())
+        self.assertEqual(Anything(), x)
+        y = object()
+        self.assertEqual(y, Anything())
+        self.assertEqual(Anything(), y)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_complex.py
+++ b/test/unit3/test_complex.py
@@ -1,0 +1,639 @@
+import unittest
+
+from random import random
+from math import atan2, isnan, copysign
+import operator
+
+INF = float("inf")
+NAN = float("nan")
+# These tests ensure that complex math does the right thing
+
+class ComplexTest(unittest.TestCase):
+
+    def assertAlmostEqual(self, a, b):
+        if isinstance(a, complex):
+            if isinstance(b, complex):
+                unittest.TestCase.assertAlmostEqual(self, a.real, b.real)
+                unittest.TestCase.assertAlmostEqual(self, a.imag, b.imag)
+            else:
+                unittest.TestCase.assertAlmostEqual(self, a.real, b)
+                unittest.TestCase.assertAlmostEqual(self, a.imag, 0.)
+        else:
+            if isinstance(b, complex):
+                unittest.TestCase.assertAlmostEqual(self, a, b.real)
+                unittest.TestCase.assertAlmostEqual(self, 0., b.imag)
+            else:
+                unittest.TestCase.assertAlmostEqual(self, a, b)
+
+    def assertCloseAbs(self, x, y, eps=1e-9):
+        """Return true iff floats x and y "are close"."""
+        # put the one with larger magnitude second
+        if abs(x) > abs(y):
+            x, y = y, x
+        if y == 0:
+            return abs(x) < eps
+        if x == 0:
+            return abs(y) < eps
+        # check that relative difference < eps
+        self.assertTrue(abs((x-y)/y) < eps)
+
+    def assertFloatsAreIdentical(self, x, y):
+        """assert that floats x and y are identical, in the sense that:
+        (1) both x and y are nans, or
+        (2) both x and y are infinities, with the same sign, or
+        (3) both x and y are zeros, with the same sign, or
+        (4) x and y are both finite and nonzero, and x == y
+
+        """
+        msg = 'floats {!r} and {!r} are not identical'
+
+        if isnan(x) or isnan(y):
+            if isnan(x) and isnan(y):
+                return
+        elif x == y:
+            if x != 0.0:
+                return
+            # both zero; check that signs match
+            elif copysign(1.0, x) == copysign(1.0, y):
+                return
+            else:
+                msg += ': zeros have different signs'
+        self.fail(msg.format(x, y))
+
+    def assertClose(self, x, y, eps=1e-9):
+        """Return true iff complexes x and y "are close"."""
+        self.assertCloseAbs(x.real, y.real, eps)
+        self.assertCloseAbs(x.imag, y.imag, eps)
+
+    def check_div(self, x, y):
+        """Compute complex z=x*y, and check that z/x==y and z/y==x."""
+        z = x * y
+        if x != 0:
+            q = z / x
+            self.assertClose(q, y)
+            q = z.__truediv__(x)
+            self.assertClose(q, y)
+        if y != 0:
+            q = z / y
+            self.assertClose(q, x)
+            q = z.__truediv__(y)
+            self.assertClose(q, x)
+
+    def test_truediv(self):
+        simple_real = [float(i) for i in range(-5, 6)]
+        simple_complex = [complex(x, y) for x in simple_real for y in simple_real]
+        for x in simple_complex:
+            for y in simple_complex:
+                self.check_div(x, y)
+
+        # A naive complex division algorithm (such as in 2.0) is very prone to
+        # nonsense errors for these (overflows and underflows).
+        self.check_div(complex(1e200, 1e200), 1+0j)
+        self.check_div(complex(1e-200, 1e-200), 1+0j)
+
+        # Just for fun.
+        for i in range(100):
+            self.check_div(complex(random(), random()),
+                           complex(random(), random()))
+
+        self.assertRaises(ZeroDivisionError, complex.__truediv__, 1+1j, 0+0j)
+        # self.assertRaises(OverflowError, pow, 1e200+1j, 1e200+1j)
+
+        self.assertAlmostEqual(complex.__truediv__(2+0j, 1+1j), 1-1j)
+        self.assertRaises(ZeroDivisionError, complex.__truediv__, 1+1j, 0+0j)
+
+        for denom_real, denom_imag in [(0, NAN), (NAN, 0), (NAN, NAN)]:
+            z = complex(0, 0) / complex(denom_real, denom_imag)
+            self.assertTrue(isnan(z.real))
+            self.assertTrue(isnan(z.imag))
+
+    def test_floordiv(self):
+        self.assertRaises(TypeError, complex.__floordiv__, 3+0j, 1.5+0j)
+        self.assertRaises(TypeError, complex.__floordiv__, 3+0j, 0+0j)
+
+    def test_richcompare(self):
+        self.assertIs(complex.__eq__(1+1j, 1<<10000), False)
+        self.assertIs(complex.__eq__(1+1j, 1+1j), True)
+        self.assertIs(complex.__eq__(1+1j, 2+2j), False)
+        self.assertIs(complex.__ne__(1+1j, 1+1j), False)
+        self.assertIs(complex.__ne__(1+1j, 2+2j), True)
+        for i in range(1, 100):
+            f = i / 100.0
+            self.assertIs(complex.__eq__(f+0j, f), True)
+            self.assertIs(complex.__ne__(f+0j, f), False)
+            self.assertIs(complex.__eq__(complex(f, f), f), False)
+            self.assertIs(complex.__ne__(complex(f, f), f), True)
+        # self.assertIs(complex.__lt__(1+1j, 2+2j), NotImplemented)
+        # self.assertIs(complex.__le__(1+1j, 2+2j), NotImplemented)
+        # self.assertIs(complex.__gt__(1+1j, 2+2j), NotImplemented)
+        # self.assertIs(complex.__ge__(1+1j, 2+2j), NotImplemented)
+        self.assertRaises(TypeError, operator.lt, 1+1j, 2+2j)
+        self.assertRaises(TypeError, operator.le, 1+1j, 2+2j)
+        self.assertRaises(TypeError, operator.gt, 1+1j, 2+2j)
+        self.assertRaises(TypeError, operator.ge, 1+1j, 2+2j)
+        self.assertIs(operator.eq(1+1j, 1+1j), True)
+        self.assertIs(operator.eq(1+1j, 2+2j), False)
+        self.assertIs(operator.ne(1+1j, 1+1j), False)
+        self.assertIs(operator.ne(1+1j, 2+2j), True)
+
+    # def test_richcompare_boundaries(self):
+    #     def check(n, deltas, is_equal, imag = 0.0):
+    #         for delta in deltas:
+    #             i = n + delta
+    #             z = complex(i, imag)
+    #             self.assertIs(complex.__eq__(z, i), is_equal(delta))
+    #             self.assertIs(complex.__ne__(z, i), not is_equal(delta))
+    #     # For IEEE-754 doubles the following should hold:
+    #     #    x in [2 ** (52 + i), 2 ** (53 + i + 1)] -> x mod 2 ** i == 0
+    #     # where the interval is representable, of course.
+    #     for i in range(1, 10):
+    #         pow = 52 + i
+    #         mult = 2 ** i
+    #         check(2 ** pow, range(1, 101), lambda delta: delta % mult == 0)
+    #         check(2 ** pow, range(1, 101), lambda delta: False, float(i))
+    #     check(2 ** 53, range(-100, 0), lambda delta: True)
+    #
+    def test_mod(self):
+        # % is no longer supported on complex numbers
+        self.assertRaises(TypeError, (1+1j).__mod__, 0+0j)
+        self.assertRaises(TypeError, lambda: (3.33+4.43j) % 0)
+        self.assertRaises(TypeError, (1+1j).__mod__, 4.3j)
+
+    def test_divmod(self):
+        self.assertRaises(TypeError, divmod, 1+1j, 1+0j)
+        self.assertRaises(TypeError, divmod, 1+1j, 0+0j)
+
+    def test_pow(self):
+        self.assertAlmostEqual(pow(1+1j, 0+0j), 1.0)
+        self.assertAlmostEqual(pow(0+0j, 2+0j), 0.0)
+        self.assertRaises(ZeroDivisionError, pow, 0+0j, 1j)
+        self.assertAlmostEqual(pow(1j, -1), 1/1j)
+        self.assertAlmostEqual(pow(1j, 200), 1)
+        self.assertRaises(ValueError, pow, 1+1j, 1+1j, 1+1j)
+
+        a = 3.33+4.43j
+        self.assertEqual(a ** 0j, 1)
+        self.assertEqual(a ** 0.+0.j, 1)
+
+        self.assertEqual(3j ** 0j, 1)
+        self.assertEqual(3j ** 0, 1)
+
+        try:
+            0j ** a
+        except ZeroDivisionError:
+            pass
+        else:
+            self.fail("should fail 0.0 to negative or complex power")
+
+        try:
+            0j ** (3-2j)
+        except ZeroDivisionError:
+            pass
+        else:
+            self.fail("should fail 0.0 to negative or complex power")
+
+        # The following is used to exercise certain code paths
+        self.assertEqual(a ** 105, a ** 105)
+        self.assertEqual(a ** -105, a ** -105)
+        self.assertEqual(a ** -30, a ** -30)
+
+        self.assertEqual(0.0j ** 0, 1)
+
+        b = 5.1+2.3j
+        self.assertRaises(ValueError, pow, a, b, 0)
+
+    def test_boolcontext(self):
+        for i in range(100):
+            self.assertTrue(complex(random() + 1e-6, random() + 1e-6))
+        self.assertTrue(not complex(0.0, 0.0))
+
+    def test_conjugate(self):
+        self.assertClose(complex(5.3, 9.8).conjugate(), 5.3-9.8j)
+
+    def test_constructor(self):
+        class OS:
+            def __init__(self, value): self.value = value
+            def __complex__(self): return self.value
+        class NS(object):
+            def __init__(self, value): self.value = value
+            def __complex__(self): return self.value
+        self.assertEqual(complex(OS(1+10j)), 1+10j)
+        self.assertEqual(complex(NS(1+10j)), 1+10j)
+        self.assertRaises(TypeError, complex, OS(None))
+        self.assertRaises(TypeError, complex, NS(None))
+        self.assertRaises(TypeError, complex, {})
+        self.assertRaises(TypeError, complex, NS(1.5))
+        self.assertRaises(TypeError, complex, NS(1))
+
+        self.assertAlmostEqual(complex("1+10j"), 1+10j)
+        self.assertAlmostEqual(complex(10), 10+0j)
+        self.assertAlmostEqual(complex(10.0), 10+0j)
+        self.assertAlmostEqual(complex(10), 10+0j)
+        self.assertAlmostEqual(complex(10+0j), 10+0j)
+        self.assertAlmostEqual(complex(1,10), 1+10j)
+        self.assertAlmostEqual(complex(1,10), 1+10j)
+        self.assertAlmostEqual(complex(1,10.0), 1+10j)
+        self.assertAlmostEqual(complex(1,10), 1+10j)
+        self.assertAlmostEqual(complex(1,10), 1+10j)
+        self.assertAlmostEqual(complex(1,10.0), 1+10j)
+        self.assertAlmostEqual(complex(1.0,10), 1+10j)
+        self.assertAlmostEqual(complex(1.0,10), 1+10j)
+        self.assertAlmostEqual(complex(1.0,10.0), 1+10j)
+        self.assertAlmostEqual(complex(3.14+0j), 3.14+0j)
+        self.assertAlmostEqual(complex(3.14), 3.14+0j)
+        self.assertAlmostEqual(complex(314), 314.0+0j)
+        self.assertAlmostEqual(complex(314), 314.0+0j)
+        self.assertAlmostEqual(complex(3.14+0j, 0j), 3.14+0j)
+        self.assertAlmostEqual(complex(3.14, 0.0), 3.14+0j)
+        self.assertAlmostEqual(complex(314, 0), 314.0+0j)
+        self.assertAlmostEqual(complex(314, 0), 314.0+0j)
+        self.assertAlmostEqual(complex(0j, 3.14j), -3.14+0j)
+        self.assertAlmostEqual(complex(0.0, 3.14j), -3.14+0j)
+        self.assertAlmostEqual(complex(0j, 3.14), 3.14j)
+        self.assertAlmostEqual(complex(0.0, 3.14), 3.14j)
+        self.assertAlmostEqual(complex("1"), 1+0j)
+        self.assertAlmostEqual(complex("1j"), 1j)
+        self.assertAlmostEqual(complex(),  0)
+        self.assertAlmostEqual(complex("-1"), -1)
+        self.assertAlmostEqual(complex("+1"), +1)
+        self.assertAlmostEqual(complex("(1+2j)"), 1+2j)
+        self.assertAlmostEqual(complex("(1.3+2.2j)"), 1.3+2.2j)
+        self.assertAlmostEqual(complex("3.14+1J"), 3.14+1j)
+        self.assertAlmostEqual(complex(" ( +3.14-6J )"), 3.14-6j)
+        self.assertAlmostEqual(complex(" ( +3.14-J )"), 3.14-1j)
+        self.assertAlmostEqual(complex(" ( +3.14+j )"), 3.14+1j)
+        self.assertAlmostEqual(complex("J"), 1j)
+        self.assertAlmostEqual(complex("( j )"), 1j)
+        self.assertAlmostEqual(complex("+J"), 1j)
+        self.assertAlmostEqual(complex("( -j)"), -1j)
+        self.assertAlmostEqual(complex('1e-500'), 0.0 + 0.0j)
+        self.assertAlmostEqual(complex('-1e-500j'), 0.0 - 0.0j)
+        self.assertAlmostEqual(complex('-1e-500+1e-500j'), -0.0 + 0.0j)
+
+        # class complex2(complex): pass
+        # self.assertAlmostEqual(complex(complex2(1+1j)), 1+1j)
+        # self.assertAlmostEqual(complex(real=17, imag=23), 17+23j)
+        # self.assertAlmostEqual(complex(real=17+23j), 17+23j)
+        # self.assertAlmostEqual(complex(real=17+23j, imag=23), 17+46j)
+        # self.assertAlmostEqual(complex(real=1+2j, imag=3+4j), -3+5j)
+
+        # check that the sign of a zero in the real or imaginary part
+        # is preserved when constructing from two floats.  (These checks
+        # are harmless on systems without support for signed zeros.)
+        def split_zeros(x):
+            """Function that produces different results for 0. and -0."""
+            return atan2(x, -1.)
+
+        self.assertEqual(split_zeros(complex(1., 0.).imag), split_zeros(0.))
+        self.assertEqual(split_zeros(complex(1., -0.).imag), split_zeros(-0.))
+        self.assertEqual(split_zeros(complex(0., 1.).real), split_zeros(0.))
+        self.assertEqual(split_zeros(complex(-0., 1.).real), split_zeros(-0.))
+
+        c = 3.14 + 1j
+        self.assertTrue(complex(c) is c)
+        del c
+
+        self.assertRaises(TypeError, complex, "1", "1")
+        self.assertRaises(TypeError, complex, 1, "1")
+
+        # SF bug 543840:  complex(string) accepts strings with \0
+        # Fixed in 2.3.
+        self.assertRaises(ValueError, complex, '1+1j\0j')
+
+        self.assertRaises(TypeError, int, 5+3j)
+        self.assertRaises(TypeError, int, 5+3j)
+        self.assertRaises(TypeError, float, 5+3j)
+        self.assertRaises(ValueError, complex, "")
+        self.assertRaises(TypeError, complex, None)
+        # self.assertRaisesRegex(TypeError, "not 'NoneType'", complex, None)
+        self.assertRaises(ValueError, complex, "\0")
+        self.assertRaises(ValueError, complex, "3\09")
+        self.assertRaises(TypeError, complex, "1", "2")
+        self.assertRaises(TypeError, complex, "1", 42)
+        self.assertRaises(TypeError, complex, 1, "2")
+        self.assertRaises(ValueError, complex, "1+")
+        self.assertRaises(ValueError, complex, "1+1j+1j")
+        self.assertRaises(ValueError, complex, "--")
+        self.assertRaises(ValueError, complex, "(1+2j")
+        self.assertRaises(ValueError, complex, "1+2j)")
+        self.assertRaises(ValueError, complex, "1+(2j)")
+        self.assertRaises(ValueError, complex, "(1+2j)123")
+        self.assertRaises(ValueError, complex, "x")
+        self.assertRaises(ValueError, complex, "1j+2")
+        self.assertRaises(ValueError, complex, "1e1ej")
+        self.assertRaises(ValueError, complex, "1e++1ej")
+        self.assertRaises(ValueError, complex, ")1+2j(")
+        # self.assertRaisesRegex(
+        #     TypeError,
+        #     "first argument must be a string or a number, not 'dict'",
+        #     complex, {1:2}, 1)
+        # self.assertRaisesRegex(
+        #     TypeError,
+        #     "second argument must be a number, not 'dict'",
+        #     complex, 1, {1:2})
+        # the following three are accepted by Python 2.6
+        self.assertRaises(ValueError, complex, "1..1j")
+        self.assertRaises(ValueError, complex, "1.11.1j")
+        self.assertRaises(ValueError, complex, "1e1.1j")
+
+        # check that complex accepts long unicode strings
+        self.assertEqual(type(complex("1"*500)), complex)
+        # check whitespace processing
+        # self.assertEqual(complex('\N{EM SPACE}(\N{EN SPACE}1+1j ) '), 1+1j)
+
+        class EvilExc(Exception):
+            pass
+
+        # class evilcomplex:
+        #     def __complex__(self):
+        #         raise EvilExc
+        #
+        # self.assertRaises(EvilExc, complex, evilcomplex())
+
+        class float2:
+            def __init__(self, value):
+                self.value = value
+            def __float__(self):
+                return self.value
+
+        self.assertAlmostEqual(complex(float2(42.)), 42)
+        # self.assertAlmostEqual(complex(real=float2(17.), imag=float2(23.)), 17+23j)
+        self.assertRaises(TypeError, complex, float2(None))
+
+        # class complex0(complex):
+        #     """Test usage of __complex__() when inheriting from 'complex'"""
+        #     def __complex__(self):
+        #         return 42j
+
+        # class complex1(complex):
+        #     """Test usage of __complex__() with a __new__() method"""
+        #     def __new__(self, value=0j):
+        #         return complex.__new__(self, 2*value)
+        #     def __complex__(self):
+        #         return self
+
+        # class complex2(complex):
+        #     """Make sure that __complex__() calls fail if anything other than a
+        #     complex is returned"""
+        #     def __complex__(self):
+        #         return None
+        #
+        # self.assertAlmostEqual(complex(complex0(1j)), 42j)
+        # self.assertAlmostEqual(complex(complex1(1j)), 2j)
+        # self.assertRaises(TypeError, complex, complex2(1j))
+    #
+    # def test_underscores(self):
+    #     # check underscores
+    #     for lit in VALID_UNDERSCORE_LITERALS:
+    #         if not any(ch in lit for ch in 'xXoObB'):
+    #             self.assertEqual(complex(lit), eval(lit))
+    #             self.assertEqual(complex(lit), complex(lit.replace('_', '')))
+    #     for lit in INVALID_UNDERSCORE_LITERALS:
+    #         if lit in ('0_7', '09_99'):  # octals are not recognized here
+    #             continue
+    #         if not any(ch in lit for ch in 'xXoObB'):
+    #             self.assertRaises(ValueError, complex, lit)
+    #
+    def test_hash(self):
+        for x in range(-30, 30):
+            self.assertEqual(hash(x), hash(complex(x, 0)))
+            x /= 3.0    # now check against floating point
+            self.assertEqual(hash(x), hash(complex(x, 0.)))
+
+    def test_abs(self):
+        nums = [complex(x/3., y/7.) for x in range(-9,9) for y in range(-9,9)]
+        for num in nums:
+            self.assertAlmostEqual((num.real**2 + num.imag**2)  ** 0.5, abs(num))
+
+    def test_repr_str(self):
+        def test(v, expected, test_fn=self.assertEqual):
+            test_fn(repr(v), expected)
+            test_fn(str(v), expected)
+
+        # test(1+6j, '(1+6j)')
+        # test(1-6j, '(1-6j)')
+
+        test(-(1+0j), '(-1+-0j)', test_fn=self.assertNotEqual)
+
+        # test(complex(1., INF), "(1+infj)")
+        # test(complex(1., -INF), "(1-infj)")
+        # test(complex(INF, 1), "(inf+1j)")
+        test(complex(-INF, INF), "(-inf+infj)")
+        # test(complex(NAN, 1), "(nan+1j)")
+        # test(complex(1, NAN), "(1+nanj)")
+        test(complex(NAN, NAN), "(nan+nanj)")
+
+        test(complex(0, INF), "infj")
+        test(complex(0, -INF), "-infj")
+        test(complex(0, NAN), "nanj")
+
+        self.assertEqual(1-6j,complex(repr(1-6j)))
+        self.assertEqual(1+6j,complex(repr(1+6j)))
+        self.assertEqual(-6j,complex(repr(-6j)))
+        self.assertEqual(6j,complex(repr(6j)))
+
+    # def test_negative_zero_repr_str(self):
+    #     def test(v, expected, test_fn=self.assertEqual):
+    #         test_fn(repr(v), expected)
+    #         test_fn(str(v), expected)
+    #
+    #     test(complex(0., 1.),   "1j")
+    #     test(complex(-0., 1.),  "(-0+1j)")
+    #     test(complex(0., -1.),  "-1j")
+    #     test(complex(-0., -1.), "(-0-1j)")
+    #
+    #     test(complex(0., 0.),   "0j")
+    #     test(complex(0., -0.),  "-0j")
+    #     test(complex(-0., 0.),  "(-0+0j)")
+    #     test(complex(-0., -0.), "(-0-0j)")
+
+    def test_neg(self):
+        self.assertEqual(-(1+6j), -1-6j)
+
+    def test_getnewargs(self):
+        self.assertEqual((1+2j).__getnewargs__(), (1.0, 2.0))
+        self.assertEqual((1-2j).__getnewargs__(), (1.0, -2.0))
+        self.assertEqual((2j).__getnewargs__(), (0.0, 2.0))
+        self.assertEqual((-0j).__getnewargs__(), (0.0, -0.0))
+        self.assertEqual(complex(0, INF).__getnewargs__(), (0.0, INF))
+        self.assertEqual(complex(INF, 0).__getnewargs__(), (INF, 0.0))
+
+    def test_plus_minus_0j(self):
+        # test that -0j and 0j literals are not identified
+        z1, z2 = 0j, -0j
+        self.assertEqual(atan2(z1.imag, -1.), atan2(0., -1.))
+        self.assertEqual(atan2(z2.imag, -1.), atan2(-0., -1.))
+
+    def test_negated_imaginary_literal(self):
+        z0 = -0j
+        z1 = -7j
+        z2 = -1e1000j
+        # Note: In versions of Python < 3.2, a negated imaginary literal
+        # accidentally ended up with real part 0.0 instead of -0.0, thanks to a
+        # modification during CST -> AST translation (see issue #9011).  That's
+        # fixed in Python 3.2.
+        self.assertFloatsAreIdentical(z0.real, -0.0)
+        self.assertFloatsAreIdentical(z0.imag, -0.0)
+        self.assertFloatsAreIdentical(z1.real, -0.0)
+        self.assertFloatsAreIdentical(z1.imag, -7.0)
+        self.assertFloatsAreIdentical(z2.real, -0.0)
+        self.assertFloatsAreIdentical(z2.imag, -INF)
+
+    def test_overflow(self):
+        self.assertEqual(complex("1e500"), complex(INF, 0.0))
+        self.assertEqual(complex("-1e500j"), complex(0.0, -INF))
+        self.assertEqual(complex("-1e500+1.8e308j"), complex(-INF, INF))
+
+    def test_repr_roundtrip(self):
+        vals = [0.0, 1e-500, 1e-315, 1e-200, 0.0123, 3.1415, 1e50, INF, NAN]
+        vals += [-v for v in vals]
+
+        # complex(repr(z)) should recover z exactly, even for complex
+        # numbers involving an infinity, nan, or negative zero
+        for x in vals:
+            for y in vals:
+                z = complex(x, y)
+                roundtrip = complex(repr(z))
+                self.assertFloatsAreIdentical(z.real, roundtrip.real)
+                self.assertFloatsAreIdentical(z.imag, roundtrip.imag)
+
+        # if we predefine some constants, then eval(repr(z)) should
+        # also work, except that it might change the sign of zeros
+        # inf, nan = float('inf'), float('nan')
+        # infj, nanj = complex(0.0, inf), complex(0.0, nan)
+        # for x in vals:
+        #     for y in vals:
+        #         z = complex(x, y)
+        #         roundtrip = eval(repr(z))
+        #         # adding 0.0 has no effect beside changing -0.0 to 0.0
+        #         self.assertFloatsAreIdentical(0.0 + z.real,
+        #                                       0.0 + roundtrip.real)
+        #         self.assertFloatsAreIdentical(0.0 + z.imag,
+        #                                       0.0 + roundtrip.imag)
+    #
+    # def test_format(self):
+    #     # empty format string is same as str()
+    #     self.assertEqual(format(1+3j, ''), str(1+3j))
+    #     self.assertEqual(format(1.5+3.5j, ''), str(1.5+3.5j))
+    #     self.assertEqual(format(3j, ''), str(3j))
+    #     self.assertEqual(format(3.2j, ''), str(3.2j))
+    #     self.assertEqual(format(3+0j, ''), str(3+0j))
+    #     self.assertEqual(format(3.2+0j, ''), str(3.2+0j))
+    #
+    #     # empty presentation type should still be analogous to str,
+    #     # even when format string is nonempty (issue #5920).
+    #     self.assertEqual(format(3.2+0j, '-'), str(3.2+0j))
+    #     self.assertEqual(format(3.2+0j, '<'), str(3.2+0j))
+    #     z = 4/7. - 100j/7.
+    #     self.assertEqual(format(z, ''), str(z))
+    #     self.assertEqual(format(z, '-'), str(z))
+    #     self.assertEqual(format(z, '<'), str(z))
+    #     self.assertEqual(format(z, '10'), str(z))
+    #     z = complex(0.0, 3.0)
+    #     self.assertEqual(format(z, ''), str(z))
+    #     self.assertEqual(format(z, '-'), str(z))
+    #     self.assertEqual(format(z, '<'), str(z))
+    #     self.assertEqual(format(z, '2'), str(z))
+    #     z = complex(-0.0, 2.0)
+    #     self.assertEqual(format(z, ''), str(z))
+    #     self.assertEqual(format(z, '-'), str(z))
+    #     self.assertEqual(format(z, '<'), str(z))
+    #     self.assertEqual(format(z, '3'), str(z))
+    #
+    #     self.assertEqual(format(1+3j, 'g'), '1+3j')
+    #     self.assertEqual(format(3j, 'g'), '0+3j')
+    #     self.assertEqual(format(1.5+3.5j, 'g'), '1.5+3.5j')
+    #
+    #     self.assertEqual(format(1.5+3.5j, '+g'), '+1.5+3.5j')
+    #     self.assertEqual(format(1.5-3.5j, '+g'), '+1.5-3.5j')
+    #     self.assertEqual(format(1.5-3.5j, '-g'), '1.5-3.5j')
+    #     self.assertEqual(format(1.5+3.5j, ' g'), ' 1.5+3.5j')
+    #     self.assertEqual(format(1.5-3.5j, ' g'), ' 1.5-3.5j')
+    #     self.assertEqual(format(-1.5+3.5j, ' g'), '-1.5+3.5j')
+    #     self.assertEqual(format(-1.5-3.5j, ' g'), '-1.5-3.5j')
+    #
+    #     self.assertEqual(format(-1.5-3.5e-20j, 'g'), '-1.5-3.5e-20j')
+    #     self.assertEqual(format(-1.5-3.5j, 'f'), '-1.500000-3.500000j')
+    #     self.assertEqual(format(-1.5-3.5j, 'F'), '-1.500000-3.500000j')
+    #     self.assertEqual(format(-1.5-3.5j, 'e'), '-1.500000e+00-3.500000e+00j')
+    #     self.assertEqual(format(-1.5-3.5j, '.2e'), '-1.50e+00-3.50e+00j')
+    #     self.assertEqual(format(-1.5-3.5j, '.2E'), '-1.50E+00-3.50E+00j')
+    #     self.assertEqual(format(-1.5e10-3.5e5j, '.2G'), '-1.5E+10-3.5E+05j')
+    #
+    #     self.assertEqual(format(1.5+3j, '<20g'),  '1.5+3j              ')
+    #     self.assertEqual(format(1.5+3j, '*<20g'), '1.5+3j**************')
+    #     self.assertEqual(format(1.5+3j, '>20g'),  '              1.5+3j')
+    #     self.assertEqual(format(1.5+3j, '^20g'),  '       1.5+3j       ')
+    #     self.assertEqual(format(1.5+3j, '<20'),   '(1.5+3j)            ')
+    #     self.assertEqual(format(1.5+3j, '>20'),   '            (1.5+3j)')
+    #     self.assertEqual(format(1.5+3j, '^20'),   '      (1.5+3j)      ')
+    #     self.assertEqual(format(1.123-3.123j, '^20.2'), '     (1.1-3.1j)     ')
+    #
+    #     self.assertEqual(format(1.5+3j, '20.2f'), '          1.50+3.00j')
+    #     self.assertEqual(format(1.5+3j, '>20.2f'), '          1.50+3.00j')
+    #     self.assertEqual(format(1.5+3j, '<20.2f'), '1.50+3.00j          ')
+    #     self.assertEqual(format(1.5e20+3j, '<20.2f'), '150000000000000000000.00+3.00j')
+    #     self.assertEqual(format(1.5e20+3j, '>40.2f'), '          150000000000000000000.00+3.00j')
+    #     self.assertEqual(format(1.5e20+3j, '^40,.2f'), '  150,000,000,000,000,000,000.00+3.00j  ')
+    #     self.assertEqual(format(1.5e21+3j, '^40,.2f'), ' 1,500,000,000,000,000,000,000.00+3.00j ')
+    #     self.assertEqual(format(1.5e21+3000j, ',.2f'), '1,500,000,000,000,000,000,000.00+3,000.00j')
+    #
+    #     # Issue 7094: Alternate formatting (specified by #)
+    #     self.assertEqual(format(1+1j, '.0e'), '1e+00+1e+00j')
+    #     self.assertEqual(format(1+1j, '#.0e'), '1.e+00+1.e+00j')
+    #     self.assertEqual(format(1+1j, '.0f'), '1+1j')
+    #     self.assertEqual(format(1+1j, '#.0f'), '1.+1.j')
+    #     self.assertEqual(format(1.1+1.1j, 'g'), '1.1+1.1j')
+    #     self.assertEqual(format(1.1+1.1j, '#g'), '1.10000+1.10000j')
+    #
+    #     # Alternate doesn't make a difference for these, they format the same with or without it
+    #     self.assertEqual(format(1+1j, '.1e'),  '1.0e+00+1.0e+00j')
+    #     self.assertEqual(format(1+1j, '#.1e'), '1.0e+00+1.0e+00j')
+    #     self.assertEqual(format(1+1j, '.1f'),  '1.0+1.0j')
+    #     self.assertEqual(format(1+1j, '#.1f'), '1.0+1.0j')
+    #
+    #     # Misc. other alternate tests
+    #     self.assertEqual(format((-1.5+0.5j), '#f'), '-1.500000+0.500000j')
+    #     self.assertEqual(format((-1.5+0.5j), '#.0f'), '-2.+0.j')
+    #     self.assertEqual(format((-1.5+0.5j), '#e'), '-1.500000e+00+5.000000e-01j')
+    #     self.assertEqual(format((-1.5+0.5j), '#.0e'), '-2.e+00+5.e-01j')
+    #     self.assertEqual(format((-1.5+0.5j), '#g'), '-1.50000+0.500000j')
+    #     self.assertEqual(format((-1.5+0.5j), '.0g'), '-2+0.5j')
+    #     self.assertEqual(format((-1.5+0.5j), '#.0g'), '-2.+0.5j')
+    #
+    #     # zero padding is invalid
+    #     self.assertRaises(ValueError, (1.5+0.5j).__format__, '010f')
+    #
+    #     # '=' alignment is invalid
+    #     self.assertRaises(ValueError, (1.5+3j).__format__, '=20')
+    #
+    #     # integer presentation types are an error
+    #     for t in 'bcdoxX':
+    #         self.assertRaises(ValueError, (1.5+0.5j).__format__, t)
+    #
+    #     # make sure everything works in ''.format()
+    #     self.assertEqual('*{0:.3f}*'.format(3.14159+2.71828j), '*3.142+2.718j*')
+    #
+    #     # issue 3382
+    #     self.assertEqual(format(complex(NAN, NAN), 'f'), 'nan+nanj')
+    #     self.assertEqual(format(complex(1, NAN), 'f'), '1.000000+nanj')
+    #     self.assertEqual(format(complex(NAN, 1), 'f'), 'nan+1.000000j')
+    #     self.assertEqual(format(complex(NAN, -1), 'f'), 'nan-1.000000j')
+    #     self.assertEqual(format(complex(NAN, NAN), 'F'), 'NAN+NANj')
+    #     self.assertEqual(format(complex(1, NAN), 'F'), '1.000000+NANj')
+    #     self.assertEqual(format(complex(NAN, 1), 'F'), 'NAN+1.000000j')
+    #     self.assertEqual(format(complex(NAN, -1), 'F'), 'NAN-1.000000j')
+    #     self.assertEqual(format(complex(INF, INF), 'f'), 'inf+infj')
+    #     self.assertEqual(format(complex(1, INF), 'f'), '1.000000+infj')
+    #     self.assertEqual(format(complex(INF, 1), 'f'), 'inf+1.000000j')
+    #     self.assertEqual(format(complex(INF, -1), 'f'), 'inf-1.000000j')
+    #     self.assertEqual(format(complex(INF, INF), 'F'), 'INF+INFj')
+    #     self.assertEqual(format(complex(1, INF), 'F'), '1.000000+INFj')
+    #     self.assertEqual(format(complex(INF, 1), 'F'), 'INF+1.000000j')
+    #     self.assertEqual(format(complex(INF, -1), 'F'), 'INF-1.000000j')
+
+# def test_main():
+#     support.run_unittest(ComplexTest)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_contains.py
+++ b/test/unit3/test_contains.py
@@ -1,0 +1,115 @@
+import unittest
+from time import sleep
+
+class base_set:
+    def __init__(self, el):
+        self.el = el
+
+class set(base_set):
+    def __contains__(self, el):
+        return self.el == el
+
+class seq(base_set):
+    def __getitem__(self, n):
+        return [self.el][n]
+
+
+class TestContains(unittest.TestCase):
+    def test_common_tests(self):
+        a = base_set(1)
+        b = set(1)
+        c = seq(1)
+        self.assertIn(1, b)
+        self.assertNotIn(0, b)
+        self.assertIn(1, c)
+        self.assertNotIn(0, c)
+        self.assertRaises(TypeError, lambda: 1 in a)
+        self.assertRaises(TypeError, lambda: 1 not in a)
+
+        # test char in string
+        self.assertIn('c', 'abc')
+        self.assertNotIn('d', 'abc')
+
+        self.assertIn('', '')
+        self.assertIn('', 'abc')
+
+        self.assertRaises(TypeError, lambda: None in 'abc')
+
+    # if have_unicode:
+    #     def test_char_in_unicode(self):
+    #         self.assertIn('c', unicode('abc'))
+    #         self.assertNotIn('d', unicode('abc'))
+
+    #         self.assertIn('', unicode(''))
+    #         self.assertIn(unicode(''), '')
+    #         self.assertIn(unicode(''), unicode(''))
+    #         self.assertIn('', unicode('abc'))
+    #         self.assertIn(unicode(''), 'abc')
+    #         self.assertIn(unicode(''), unicode('abc'))
+
+    #         self.assertRaises(TypeError, lambda: None in unicode('abc'))
+
+    #         # test Unicode char in Unicode
+    #         self.assertIn(unicode('c'), unicode('abc'))
+    #         self.assertNotIn(unicode('d'), unicode('abc'))
+
+    #         # test Unicode char in string
+    #         self.assertIn(unicode('c'), 'abc')
+    #         self.assertNotIn(unicode('d'), 'abc')
+
+    def test_builtin_sequence_types(self):
+        # a collection of tests on builtin sequence types
+        a = range(10)
+        for i in a:
+            self.assertIn(i, a)
+        self.assertNotIn(16, a)
+        self.assertNotIn(a, a)
+
+        a = tuple(a)
+        for i in a:
+            self.assertIn(i, a)
+        self.assertNotIn(16, a)
+        self.assertNotIn(a, a)
+
+        class Deviant1:
+            """Behaves strangely when compared
+            This class is designed to make sure that the contains code
+            works when the list is modified during the check.
+            """
+            aList = range(15)
+            def __cmp__(self, other):
+                if other == 12:
+                    self.aList.remove(12)
+                    self.aList.remove(13)
+                    self.aList.remove(14)
+                return 1
+
+        self.assertNotIn(Deviant1(), Deviant1.aList)
+
+        class Deviant2:
+            """Behaves strangely when compared
+            This class raises an exception during comparison.  That in
+            turn causes the comparison to fail with a TypeError.
+            """
+            def __cmp__(self, other):
+                if other == 4:
+                    raise RuntimeError("gotcha")
+                # changed from raise RuntimeError, "gotcha"
+
+        try:
+            self.assertNotIn(Deviant2(), a)
+        except TypeError:
+            pass
+
+
+    def test_suspending_generator(self):
+        def gen():
+            sleep(0.0001)
+            yield 42
+
+        self.assertIn(42, gen())
+        self.assertNotIn(43, gen())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_copy.py
+++ b/test/unit3/test_copy.py
@@ -1,0 +1,335 @@
+"""
+This file was modified from CPython.
+Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016 Python Software Foundation; All Rights Reserved
+"""
+import copy, unittest
+from operator import le, lt, ge, gt, eq, ne
+
+class C:
+    def __init__(self, foo):
+        self.foo = foo
+    def __copy__(self):
+        return C(self.foo)
+
+class ReduceEx(object):
+    def __reduce_ex__(self, proto):
+        c.append(1)
+        return ""
+    def __reduce__(self):
+        self.fail("shouldn't call this")
+c = []
+
+class Reduce(object):
+    def __reduce__(self):
+        d.append(1)
+        return ""
+d = []
+
+class InstVan:
+    def __init__(self, foo):
+        self.foo = foo
+    # def __eq__(self, other):
+    #   return self.foo == other.foo
+
+class Copy_eq:
+    def __init__(self, foo):
+        self.foo = foo
+    def __copy__(self):
+        return C(self.foo)
+    def __eq__(self, other):
+        return self.foo == other.foo
+
+class User_def:
+    def __init__(self, name):
+        self.name = name
+    def rename(self,newname):
+        self.name = newname
+
+class NewArgs(int):
+    def __new__(cls, foo):
+        self = int.__new__(cls)
+        self.foo = foo
+        return self
+    def __getnewargs__(self):
+        return self.foo,
+    def __eq__(self, other):
+        return self.foo == other.foo
+
+class TestCopy(unittest.TestCase):
+    def test_exceptions(self):
+        self.assertIs(copy.Error, copy.error)
+        self.assertTrue(issubclass(copy.Error, Exception))
+
+    # The copy() method
+
+    def test_copy_basic(self):
+        x = 42
+        y = copy.copy(x)
+        self.assertEqual(x, y)
+
+    def test_copy_copy(self):
+        x = C(42)
+        y = copy.copy(x)
+        self.assertEqual(y.__class__, x.__class__)
+        self.assertEqual(y.foo, x.foo)
+
+    def test_copy_inst(self):
+        x = User_def("One")
+        y = copy.copy(x)
+        self.assertEqual(x.name, "One")
+        self.assertFalse(x==y)
+        self.assertFalse(x is y)
+        self.assertTrue(x.name is y.name)
+        x.rename("Two")
+        self.assertFalse(x==y)
+        self.assertFalse(x is y)
+        self.assertEqual(x.name, "Two")
+        self.assertEqual(y.name, "One")
+
+    # def test_copy_cant(self):
+    #     class Cant:
+    #         def __getattribute__(self, name):
+    #             pass
+    #             # if name.startswith("__reduce"):
+    #             #   raise AttributeError(name)
+    #             # return object.__getattribute__(self, name)
+    #     x = Cant()
+    #     self.assertRaises(TypeError, copy.copy, x)
+
+    def test_copy_atomic(self):
+        class Classic:
+            pass
+        def f():
+            pass
+        # class WithMetaclass(metaclass=abc.ABCMeta):
+        #   pass
+        tests = [None, 42, 3.14, True, False,
+                 "hello", "hello\u1234", Classic]
+        #None, .../, NotImplemented,
+                 # 42, 2**100, 3.14, True, False, 1j,
+                 # "hello", "hello\u1234", f.__code__,
+                 # b"world", bytes(range(256)), slice(1, 10, 2),
+                 # NewStyle, Classic, max, WithMetaclass]
+        for x in tests:
+            self.assertIs(copy.copy(x), x)
+
+    def test_copy_list(self):
+        x = [1, 2, 3]
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        x = []
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+    def test_copy_mixed_set(self):
+        class FooSet:
+            def bar(self):
+                pass
+        a = set([1,2,3])
+        b = copy.deepcopy(a)
+        a = set([1,2,3])
+        b = copy.deepcopy(a)
+        self.assertTrue(a == b)
+        self.assertFalse(a is b)
+        mixed = set([(1,2), FooSet.bar])
+        mixedcopy = copy.deepcopy(mixed)
+        self.assertTrue(mixed == mixedcopy)
+        self.assertFalse(mixed is mixedcopy)
+        mixed.add(9)
+        mixedcopy2 = copy.deepcopy(mixed)
+        self.assertTrue(mixed == mixedcopy2)
+        self.assertFalse(mixed is mixedcopy2)
+        mixed.add(9)
+        self.assertFalse(mixed == mixedcopy)
+        mixedcopy2 = copy.copy(mixed)
+        self.assertTrue(mixed == mixedcopy2)
+
+    def test_copy_tuple(self):
+        x = (1, 2, 3)
+        self.assertIs(copy.copy(x), x)
+        x = ()
+        self.assertIs(copy.copy(x), x)
+        x = (1, 2, 3, [])
+        self.assertIs(copy.copy(x), x)
+
+    # def test_copy_registry(self):
+    #   class C:
+    #       def __new__(cls, foo):
+    #           obj = object.__new__(cls)
+    #           obj.foo = foo
+    #           return obj
+    #   def pickle_C(obj):
+    #       return (C, (obj.foo,))
+    #   x = C(42)
+    #   self.assertRaises(TypeError, copy.copy, x)
+        # copyreg.pickle(C, pickle_C, C)
+        # y = copy.copy(x)
+
+    def test_copy_reduce_ex(self):
+        x = ReduceEx()
+        y = copy.copy(x)
+        self.assertIs(y, x)
+        self.assertEqual(c, [1])
+
+    def test_copy_reduce(self):
+        x = Reduce()
+        y = copy.copy(x)
+        self.assertIs(y, x)
+        self.assertEqual(d, [1])
+
+    def test_copy_list(self):
+        x = [1, 2, 3]
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        x = []
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+    def test_copy_tuple(self):
+        x = (1, 2, 3)
+        self.assertIs(copy.copy(x), x)
+        x = ()
+        self.assertIs(copy.copy(x), x)
+        x = (1, 2, 3, [])
+        self.assertIs(copy.copy(x), x)
+
+    def test_copy_dict(self):
+        x = {"foo": 1, "bar": 2}
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        x = {}
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+
+    def test_copy_set(self):
+        x = {1, 2, 3}
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+        x = set()
+        y = copy.copy(x)
+        self.assertEqual(y, x)
+        self.assertIsNot(y, x)
+    # # def test_copy_frozenset(self):
+    # #     x = frozenset({1, 2, 3})
+    # #     self.assertIs(copy.copy(x), x)
+    # #     x = frozenset()
+    # #     self.assertIs(copy.copy(x), x)
+    
+    # # def test_copy_bytearray(self):
+    # #     x = bytearray(b'abc')
+    # #     y = copy.copy(x)
+    # #     self.assertEqual(y, x)
+    # #     self.assertIsNot(y, x)
+    # #     x = bytearray()
+    # #     y = copy.copy(x)
+    # #     self.assertEqual(y, x)
+    # #     self.assertIsNot(y, x)
+
+    def test_copy_inst_vanilla(self):
+        x = InstVan(42)
+        # print x == copy.copy(x)
+        self.assertFalse(copy.copy(x) == x)
+
+    def test_copy_inst_copy(self):
+        x = Copy_eq(42)
+        self.assertEqual(copy.copy(x), x)
+        
+    # def test_copy_inst_getinitargs(self):
+    #     class C:
+    #         def __init__(self, foo):
+    #             self.foo = foo
+    #         def __getinitargs__(self):
+    #             return (self.foo,)
+    #         def __eq__(self, other):
+    #             return self.foo == other.foo
+    #     x = C(42)
+    #     self.assertRaises(NotImplementedError, copy.copy, x)
+        # self.assertEqual(copy.copy(x), x)
+
+    # def test_copy_inst_getnewargs(self):
+    #   # class NewArgs(int):
+    #   #   def __new__(cls, foo):
+    #   #       self = int.__new__(cls)
+    #   #       self.foo = foo
+    #   #       return self
+    #   #   def __getnewargs__(self):
+    #   #       return self.foo,
+    #   #   def __eq__(self, other):
+    #   #       return self.foo == other.foo
+    #   x = NewArgs(42)
+    #   y = copy.copy(x)
+    #   self.assertIsInstance(y, NewArgs)
+    #   self.assertEqual(y, x)
+    #   self.assertIsNot(y, x)
+    #   self.assertEqual(y.foo, x.foo)
+    # def test_copy_inst_getnewargs_ex(self):
+    #   class C(int):
+    #       def __new__(cls, *, foo):
+    #           self = int.__new__(cls)
+    #           self.foo = foo
+    #           return self
+    #       def __getnewargs_ex__(self):
+    #           return (), {'foo': self.foo}
+    #       def __eq__(self, other):
+    #           return self.foo == other.foo
+    #   x = C(foo=42)
+    #   y = copy.copy(x)
+    #   self.assertIsInstance(y, C)
+    #   self.assertEqual(y, x)
+    #   self.assertIsNot(y, x)
+    #   self.assertEqual(y.foo, x.foo)
+
+    # def test_copy_inst_getstate(self):
+    #     class C:
+    #         def __init__(self, foo):
+    #             self.foo = foo
+    #         def __getstate__(self):
+    #             return {"foo": self.foo}
+    #         def __eq__(self, other):
+    #             return self.foo == other.foo
+    #     x = C(42)
+    #     y = copy.copy(x)
+    #     print y
+    #     self.assertRaises(NotImplementedError, copy.copy, x)
+    #     # self.assertEqual(copy.copy(x), x)
+
+
+    # def test_copy_inst_setstate(self):
+    #     class C:
+    #         def __init__(self, foo):
+    #             self.foo = foo
+    #         def __setstate__(self, state):
+    #             self.foo = state["foo"]
+    #         def __eq__(self, other):
+    #             return self.foo == other.foo
+    #     x = C(42)
+    #     self.assertRaises(NotImplementedError, copy.copy, x)
+
+    #   self.assertEqual(copy.copy(x), x)
+
+    # def test_copy_inst_getstate_setstate(self):
+    #     class C:
+    #         def __init__(self, foo):
+    #             self.foo = foo
+    #         def __getstate__(self):
+    #             return self.foo
+    #         def __setstate__(self, state):
+    #             self.foo = state
+    #         def __eq__(self, other):
+    #             return self.foo == other.foo
+    #     x = C(42)
+    #     self.assertRaises(NotImplementedError, copy.copy, x)
+
+        # self.assertEqual(copy.copy(x), x)
+        # # State with boolean value is false (issue #25718)
+        # x = C(0.0)
+        # self.assertEqual(copy.copy(x), x)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_copy.py
+++ b/test/unit3/test_copy.py
@@ -78,14 +78,14 @@ class TestCopy(unittest.TestCase):
         x = User_def("One")
         y = copy.copy(x)
         self.assertEqual(x.name, "One")
-        self.assertFalse(x==y)
-        self.assertFalse(x is y)
+        # self.assertFalse(x==y)
+        # self.assertFalse(x is y)
         self.assertTrue(x.name is y.name)
         x.rename("Two")
-        self.assertFalse(x==y)
-        self.assertFalse(x is y)
+        # self.assertFalse(x==y)
+        # self.assertFalse(x is y)
         self.assertEqual(x.name, "Two")
-        self.assertEqual(y.name, "One")
+        # self.assertEqual(y.name, "One")
 
     # def test_copy_cant(self):
     #     class Cant:
@@ -171,23 +171,23 @@ class TestCopy(unittest.TestCase):
         x = ReduceEx()
         y = copy.copy(x)
         self.assertIs(y, x)
-        self.assertEqual(c, [1])
+        # self.assertEqual(c, [1])
 
     def test_copy_reduce(self):
         x = Reduce()
         y = copy.copy(x)
         self.assertIs(y, x)
-        self.assertEqual(d, [1])
+        # self.assertEqual(d, [1])
 
     def test_copy_list(self):
         x = [1, 2, 3]
         y = copy.copy(x)
         self.assertEqual(y, x)
-        self.assertIsNot(y, x)
+        # self.assertIsNot(y, x)
         x = []
         y = copy.copy(x)
         self.assertEqual(y, x)
-        self.assertIsNot(y, x)
+        # self.assertIsNot(y, x)
     def test_copy_tuple(self):
         x = (1, 2, 3)
         self.assertIs(copy.copy(x), x)
@@ -200,21 +200,21 @@ class TestCopy(unittest.TestCase):
         x = {"foo": 1, "bar": 2}
         y = copy.copy(x)
         self.assertEqual(y, x)
-        self.assertIsNot(y, x)
+        # self.assertIsNot(y, x)
         x = {}
         y = copy.copy(x)
         self.assertEqual(y, x)
-        self.assertIsNot(y, x)
+        # self.assertIsNot(y, x)
 
     def test_copy_set(self):
         x = {1, 2, 3}
         y = copy.copy(x)
         self.assertEqual(y, x)
-        self.assertIsNot(y, x)
+        # self.assertIsNot(y, x)
         x = set()
         y = copy.copy(x)
         self.assertEqual(y, x)
-        self.assertIsNot(y, x)
+        # self.assertIsNot(y, x)
     # # def test_copy_frozenset(self):
     # #     x = frozenset({1, 2, 3})
     # #     self.assertIs(copy.copy(x), x)
@@ -231,10 +231,10 @@ class TestCopy(unittest.TestCase):
     # #     self.assertEqual(y, x)
     # #     self.assertIsNot(y, x)
 
-    def test_copy_inst_vanilla(self):
-        x = InstVan(42)
-        # print x == copy.copy(x)
-        self.assertFalse(copy.copy(x) == x)
+    # def test_copy_inst_vanilla(self):
+    #     x = InstVan(42)
+    #     print x == copy.copy(x)
+    #     self.assertFalse(copy.copy(x) == x)
 
     def test_copy_inst_copy(self):
         x = Copy_eq(42)

--- a/test/unit3/test_decorators.py
+++ b/test/unit3/test_decorators.py
@@ -1,0 +1,306 @@
+# Test case for property
+# more tests are in test_descr
+
+import sys
+import unittest
+
+class PropertyBase(Exception):
+    pass
+
+class PropertyGet(PropertyBase):
+    pass
+
+class PropertySet(PropertyBase):
+    pass
+
+class PropertyDel(PropertyBase):
+    pass
+
+class BaseClass(object):
+    def __init__(self):
+        self._spam = 5
+
+    @property
+    def spam(self):
+        """BaseClass.getter"""
+        return self._spam
+
+    @spam.setter
+    def spam(self, value):
+        self._spam = value
+
+    @spam.deleter
+    def spam(self):
+        pass
+        #del self._spam
+
+class SubClass(BaseClass):
+
+    @BaseClass.spam.getter
+    def spam(self):
+        """SubClass.getter"""
+        raise PropertyGet(self._spam)
+
+    @spam.setter
+    def spam(self, value):
+        raise PropertySet(self._spam)
+
+    @spam.deleter
+    def spam(self):
+        raise PropertyDel(self._spam)
+
+class PropertyDocBase(object):
+    _spam = 1
+    def _get_spam(self):
+        return self._spam
+    spam = property(_get_spam, doc="spam spam spam")
+
+class PropertyDocSub(PropertyDocBase):
+    @PropertyDocBase.spam.getter
+    def spam(self):
+        """The decorator does not use this doc string"""
+        return self._spam
+
+class PropertySubNewGetter(BaseClass):
+    @BaseClass.spam.getter
+    def spam(self):
+        """new docstring"""
+        return 5
+
+class PropertyNewGetter(object):
+    @property
+    def spam(self):
+        """original docstring"""
+        return 1
+    @spam.getter
+    def spam(self):
+        """new docstring"""
+        return 8
+
+class PropertyTests(unittest.TestCase):
+    def test_property_decorator_baseclass(self):
+        # see #1620
+        base = BaseClass()
+        self.assertEqual(base.spam, 5)
+        self.assertEqual(base._spam, 5)
+        base.spam = 10
+        self.assertEqual(base.spam, 10)
+        self.assertEqual(base._spam, 10)
+        # delattr(base, "spam")
+        # self.assertTrue(not hasattr(base, "spam"))
+        # self.assertTrue(not hasattr(base, "_spam"))
+        base.spam = 20
+        self.assertEqual(base.spam, 20)
+        self.assertEqual(base._spam, 20)
+
+    def test_property_decorator_subclass(self):
+        # see #1620
+        sub = SubClass()
+        self.assertRaises(PropertyGet, getattr, sub, "spam")
+        self.assertRaises(PropertySet, setattr, sub, "spam", None)
+        # self.assertRaises(PropertyDel, delattr, sub, "spam")
+
+    # def test_property_decorator_subclass_doc(self):
+    #     sub = SubClass()
+    #     self.assertEqual(sub.__class__.spam.__doc__, "SubClass.getter")
+    #
+    # def test_property_decorator_baseclass_doc(self):
+    #     base = BaseClass()
+    #     self.assertEqual(base.__class__.spam.__doc__, "BaseClass.getter")
+
+    # def test_property_decorator_doc(self):
+    #     base = PropertyDocBase()
+    #     sub = PropertyDocSub()
+    #     self.assertEqual(base.__class__.spam.__doc__, "spam spam spam")
+    #     self.assertEqual(sub.__class__.spam.__doc__, "spam spam spam")
+
+    # def test_property_getter_doc_override(self):
+    #     newgettersub = PropertySubNewGetter()
+    #     self.assertEqual(newgettersub.spam, 5)
+    #     self.assertEqual(newgettersub.__class__.spam.__doc__, "new docstring")
+    #     newgetter = PropertyNewGetter()
+    #     self.assertEqual(newgetter.spam, 8)
+    #     self.assertEqual(newgetter.__class__.spam.__doc__, "new docstring")
+
+    # def test_property___isabstractmethod__descriptor(self):
+    #     for val in (True, False, [], [1], '', '1'):
+    #         class C(object):
+    #             def foo(self):
+    #                 pass
+    #             foo.__isabstractmethod__ = val
+    #             foo = property(foo)
+    #         self.assertIs(C.foo.__isabstractmethod__, bool(val))
+    #
+    #     # check that the property's __isabstractmethod__ descriptor does the
+    #     # right thing when presented with a value that fails truth testing:
+    #     class NotBool(object):
+    #         def __bool__(self):
+    #             raise ValueError()
+    #         __len__ = __bool__
+    #     with self.assertRaises(ValueError):
+    #         class C(object):
+    #             def foo(self):
+    #                 pass
+    #             foo.__isabstractmethod__ = NotBool()
+    #             foo = property(foo)
+    #         C.foo.__isabstractmethod__
+
+    # def test_property_builtin_doc_writable(self):
+    #     p = property(doc='basic')
+    #     self.assertEqual(p.__doc__, 'basic')
+    #     p.__doc__= 'extended'
+    #     self.assertEqual(p.__doc__, 'extended')
+
+    # def test_property_decorator_doc_writable(self):
+    #     class PropertyWritableDoc(object):
+    #
+    #         @property
+    #         def spam(self):
+    #             """Eggs"""
+    #             return "eggs"
+    #
+    #     sub = PropertyWritableDoc()
+    #     self.assertEqual(sub.__class__.spam.__doc__, 'Eggs')
+    #     sub.__class__.spam.__doc__ = 'Spam'
+    #     self.assertEqual(sub.__class__.spam.__doc__, 'Spam')
+
+# Issue 5890: subclasses of property do not preserve method __doc__ strings
+class PropertySub(property):
+    """This is a subclass of property"""
+
+class PropertySubSlots(property):
+    """This is a subclass of property that defines __slots__"""
+    __slots__ = ()
+
+class Foo(object):
+    def __init__(self): self._spam = 1
+    @PropertySub
+    def spam(self):
+        """spam wrapped in property subclass"""
+        return self._spam
+    @spam.setter
+    def spam(self, value):
+        """this docstring is ignored"""
+        self._spam = value
+
+class FooSub(Foo):
+    @Foo.spam.setter
+    def spam(self, value):
+        """another ignored docstring"""
+        self._spam = 'eggs'
+
+class PropertySubclassTests(unittest.TestCase):
+
+    # def test_slots_docstring_copy_exception(self):
+    #     try:
+    #         class Foo(object):
+    #             @PropertySubSlots
+    #             def spam(self):
+    #                 """Trying to copy this docstring will raise an exception"""
+    #                 return 1
+    #     except AttributeError:
+    #         pass
+    #     else:
+    #         raise Exception("AttributeError not raised")
+    #
+    # def test_docstring_copy(self):
+    #     class Foo(object):
+    #         @PropertySub
+    #         def spam(self):
+    #             """spam wrapped in property subclass"""
+    #             return 1
+    #     self.assertEqual(
+    #         Foo.spam.__doc__,
+    #         "spam wrapped in property subclass")
+
+    def test_property_setter_copies_getter_docstring(self):
+        foo = Foo()
+        self.assertEqual(foo.spam, 1)
+        foo.spam = 2
+        self.assertEqual(foo.spam, 2)
+        # self.assertEqual(
+        #     Foo.spam.__doc__,
+        #     "spam wrapped in property subclass")
+
+        foosub = FooSub()
+        self.assertEqual(foosub.spam, 1)
+        foosub.spam = 7
+        self.assertEqual(foosub.spam, 'eggs')
+        # self.assertEqual(
+        #     FooSub.spam.__doc__,
+        #     "spam wrapped in property subclass")
+
+    # def test_property_new_getter_new_docstring(self):
+    #
+    #     class Foo(object):
+    #         @PropertySub
+    #         def spam(self):
+    #             """a docstring"""
+    #             return 1
+    #         @spam.getter
+    #         def spam(self):
+    #             """a new docstring"""
+    #             return 2
+    #     self.assertEqual(Foo.spam.__doc__, "a new docstring")
+    #     class FooBase(object):
+    #         @PropertySub
+    #         def spam(self):
+    #             """a docstring"""
+    #             return 1
+    #     class Foo2(FooBase):
+    #         @FooBase.spam.getter
+    #         def spam(self):
+    #             """a new docstring"""
+    #             return 2
+    #     self.assertEqual(Foo.spam.__doc__, "a new docstring")
+
+class TestDecorators(unittest.TestCase):
+
+    def test_single(self):
+        class C(object):
+            @staticmethod
+            def foo(): return 42
+        self.assertEqual(C.foo(), 42)
+        self.assertEqual(C().foo(), 42)
+
+    def test_staticmethods(self):
+        # Testing static methods...
+        class C(object):
+            def foo(*a): return a
+            goo = staticmethod(foo)
+        c = C()
+        self.assertEqual(C.goo(1), (1,))
+        self.assertEqual(c.goo(1), (1,))
+        self.assertEqual(c.foo(1), (c, 1,))
+        class D(C):
+            pass
+        d = D()
+        self.assertEqual(D.goo(1), (1,))
+        self.assertEqual(d.goo(1), (1,))
+        self.assertEqual(d.foo(1), (d, 1))
+        self.assertEqual(D.foo(d, 1), (d, 1))
+
+    def test_classmethods(self):
+        # Testing class methods...
+        class C(object):
+            def foo(*a): return a
+            goo = classmethod(foo)
+        c = C()
+        self.assertEqual(C.goo(1), (C, 1))
+        self.assertEqual(c.goo(1), (C, 1))
+        self.assertEqual(c.foo(1), (c, 1))
+        class D(C):
+            pass
+        d = D()
+        self.assertEqual(D.goo(1), (D, 1))
+        self.assertEqual(d.goo(1), (D, 1))
+        self.assertEqual(d.foo(1), (d, 1))
+        self.assertEqual(D.foo(d, 1), (d, 1))
+        # Test for a specific crash (SF bug 528132)
+        def f(cls, arg): return (cls, arg)
+        ff = classmethod(f)
+        self.assertEqual(ff.__get__(0, int)(42), (int, 42))
+        self.assertEqual(ff.__get__(0)(42), (int, 42))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_defaultdict.py
+++ b/test/unit3/test_defaultdict.py
@@ -1,0 +1,164 @@
+"""Unit tests for collections.defaultdict."""
+
+import copy
+import unittest
+
+from collections import defaultdict
+
+def foobar():
+    return list
+
+class TestDefaultDict(unittest.TestCase):
+
+    def test_basic(self):
+        d1 = defaultdict()
+        self.assertEqual(d1.default_factory, None)
+        d1.default_factory = list
+        # d1[12].append(42)
+        # self.assertEqual(d1, {12: [42]})
+        # d1[12].append(24)
+        # self.assertEqual(d1, {12: [42, 24]})
+        # d1[13]
+        # d1[14]
+        # self.assertEqual(d1, {12: [42, 24], 13: [], 14: []})
+        # self.assertTrue(d1[12] is not d1[13] is not d1[14])
+        # d2 = defaultdict(list, foo=1, bar=2)
+        # self.assertEqual(d2.default_factory, list)
+        # self.assertEqual(d2, {"foo": 1, "bar": 2})
+        # self.assertEqual(d2["foo"], 1)
+        # self.assertEqual(d2["bar"], 2)
+        # self.assertEqual(d2[42], [])
+        # self.assertIn("foo", d2)
+        # self.assertIn("foo", d2.keys())
+        # self.assertIn("bar", d2)
+        # self.assertIn("bar", d2.keys())
+        # self.assertIn(42, d2)
+        # self.assertIn(42, d2.keys())
+        # self.assertNotIn(12, d2)
+        # self.assertNotIn(12, d2.keys())
+        # d2.default_factory = None
+        # self.assertEqual(d2.default_factory, None)
+        # try:
+        #     d2[15]
+        # except KeyError as err:
+        #     self.assertEqual(err.args, (15,))
+        # else:
+        #     self.fail("d2[15] didn't raise KeyError")
+        # self.assertRaises(TypeError, defaultdict, 1)
+
+    def test_missing(self):
+        d1 = defaultdict()
+        self.assertRaises(KeyError, d1.__missing__, 42)
+        d1.default_factory = list
+        # self.assertEqual(d1.__missing__(42), [])
+
+    def test_repr(self):
+        d1 = defaultdict()
+        self.assertEqual(d1.default_factory, None)
+        self.assertEqual(repr(d1), "defaultdict(None, {})")
+        # self.assertEqual(eval(repr(d1)), d1)
+        d1[11] = 41
+        self.assertEqual(repr(d1), "defaultdict(None, {11: 41})")
+        d2 = defaultdict(int)
+        self.assertEqual(d2.default_factory, int)
+        d2[12] = 42
+        self.assertEqual(repr(d2), "defaultdict(<class 'int'>, {12: 42})")
+        def foo(): return 43
+        d3 = defaultdict(foo)
+        self.assertTrue(d3.default_factory is foo)
+        d3[13]
+        self.assertEqual(repr(d3), "defaultdict(%s, {13: 43})" % repr(foo))
+
+
+    # def test_copy(self):
+    #     d1 = defaultdict()
+    #     d2 = d1.copy()
+    #     self.assertEqual(type(d2), defaultdict)
+    #     self.assertEqual(d2.default_factory, None)
+    #     self.assertEqual(d2, {})
+    #     d1.default_factory = list
+    #     d3 = d1.copy()
+    #     self.assertEqual(type(d3), defaultdict)
+    #     self.assertEqual(d3.default_factory, list)
+    #     self.assertEqual(d3, {})
+    #     d1[42]
+    #     d4 = d1.copy()
+    #     self.assertEqual(type(d4), defaultdict)
+    #     self.assertEqual(d4.default_factory, list)
+    #     self.assertEqual(d4, {42: []})
+    #     d4[12]
+    #     self.assertEqual(d4, {42: [], 12: []})
+    #
+    #     # Issue 6637: Copy fails for empty default dict
+    #     d = defaultdict()
+    #     d['a'] = 42
+    #     e = d.copy()
+    #     self.assertEqual(e['a'], 42)
+
+    def test_shallow_copy(self):
+        d1 = defaultdict(foobar, {1: 1})
+        d2 = copy.copy(d1)
+        self.assertEqual(d2.default_factory, foobar)
+        self.assertEqual(d2, d1)
+        d1.default_factory = list
+        d2 = copy.copy(d1)
+        self.assertEqual(d2.default_factory, list)
+        self.assertEqual(d2, d1)
+
+    # def test_deep_copy(self):
+    #     d1 = defaultdict(foobar, {1: [1]})
+    #     d2 = copy.deepcopy(d1)
+    #     self.assertEqual(d2.default_factory, foobar)
+    #     self.assertEqual(d2, d1)
+    #     self.assertTrue(d1[1] is not d2[1])
+    #     d1.default_factory = list
+    #     d2 = copy.deepcopy(d1)
+    #     self.assertEqual(d2.default_factory, list)
+    #     self.assertEqual(d2, d1)
+
+    # def test_keyerror_without_factory(self):
+    #     d1 = defaultdict()
+    #     try:
+    #         d1[(1,)]
+    #     except KeyError as err:
+    #         self.assertEqual(err.args[0], (1,))
+    #     else:
+    #         self.fail("expected KeyError")
+    #
+    # def test_recursive_repr(self):
+    #     # Issue2045: stack overflow when default_factory is a bound method
+    #     class sub(defaultdict):
+    #         def __init__(self):
+    #             self.default_factory = self._factory
+    #         def _factory(self):
+    #             return []
+    #     d = sub()
+    #     self.assertRegex(repr(d),
+    #         r"defaultdict\(<bound method .*sub\._factory "
+    #         r"of defaultdict\(\.\.\., \{\}\)>, \{\}\)")
+    #
+    #     # NOTE: printing a subclass of a builtin type does not call its
+    #     # tp_print slot. So this part is essentially the same test as above.
+    #     tfn = tempfile.mktemp()
+    #     try:
+    #         f = open(tfn, "w+")
+    #         try:
+    #             print(d, file=f)
+    #         finally:
+    #             f.close()
+    #     finally:
+    #         os.remove(tfn)
+    #
+    # def test_callable_arg(self):
+    #     self.assertRaises(TypeError, defaultdict, {})
+    #
+    # def test_pickling(self):
+    #     d = defaultdict(int)
+    #     d[1]
+    #     for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+    #         s = pickle.dumps(d, proto)
+    #         o = pickle.loads(s)
+    #         self.assertEqual(d, o)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_dict.py
+++ b/test/unit3/test_dict.py
@@ -17,7 +17,7 @@ class DictTest(unittest.TestCase):
 
     def test_keys(self):
         d = {}
-        self.assertListEqual(list(d.keys()), [])
+        self.assertEqual(list(d.keys()), [])
         # changed from self.assertEqual(d.keys(), [])
         d = {'a': 1, 'b': 2}
         k = d.keys()
@@ -31,20 +31,20 @@ class DictTest(unittest.TestCase):
 
     def test_values(self):
         d = {}
-        self.assertListEqual(list(d.values()), [])
+        self.assertEqual(list(d.values()), [])
         # changed from self.assertEqual(d.values(), [])
         d = {1:2}
-        self.assertListEqual(list(d.values()), [2])
+        self.assertEqual(list(d.values()), [2])
         # changed from self.assertEqual(d.values(), [2])
 
         self.assertRaises(TypeError, d.values, None)
 
     def test_items(self):
         d = {}
-        self.assertListEqual(list(d.items()), [])
+        self.assertEqual(list(d.items()), [])
         # changed from self.assertEqual(d.items(), [])
         d = {1:2}
-        self.assertListEqual(list(d.items()), [(1, 2)])
+        self.assertEqual(list(d.items()), [(1, 2)])
         # changed from self.assertEqual(d.items(), [(1, 2)])
 
         self.assertRaises(TypeError, d.items, None)

--- a/test/unit3/test_dict.py
+++ b/test/unit3/test_dict.py
@@ -1,0 +1,214 @@
+import unittest
+
+'''
+    source: https://bitbucket.org/pypy/pypy/src/d7777f2ccd3f0c1a4720d5e6fc3c6b8da4547ea7/lib-python/2.7/test/test_dict.py?at=default
+'''
+class DictTest(unittest.TestCase):
+    def test_constructor(self):
+        # calling built-in types without argument must return empty
+        self.assertEqual(dict(), {})
+        self.assertIsNot(dict(), {})
+
+    def test_bool(self):
+        self.assertIs(not {}, True)
+        self.assertTrue({1: 2})
+        self.assertIs(bool({}), False)
+        self.assertIs(bool({1: 2}), True)
+
+    def test_keys(self):
+        d = {}
+        self.assertListEqual(list(d.keys()), [])
+        # changed from self.assertEqual(d.keys(), [])
+        d = {'a': 1, 'b': 2}
+        k = d.keys()
+        self.assertEqual(set(k), {'a', 'b'})
+        self.assertIn('a', k)
+        self.assertIn('b', k)
+        # self.assertTrue(d.has_key('a'))
+        # self.assertTrue(d.has_key('b'))
+        # has_key depreciated in Python 3
+        self.assertRaises(TypeError, d.keys, None)
+
+    def test_values(self):
+        d = {}
+        self.assertListEqual(list(d.values()), [])
+        # changed from self.assertEqual(d.values(), [])
+        d = {1:2}
+        self.assertListEqual(list(d.values()), [2])
+        # changed from self.assertEqual(d.values(), [2])
+
+        self.assertRaises(TypeError, d.values, None)
+
+    def test_items(self):
+        d = {}
+        self.assertListEqual(list(d.items()), [])
+        # changed from self.assertEqual(d.items(), [])
+        d = {1:2}
+        self.assertListEqual(list(d.items()), [(1, 2)])
+        # changed from self.assertEqual(d.items(), [(1, 2)])
+
+        self.assertRaises(TypeError, d.items, None)
+
+    # def test_has_key(self):
+    #     d = {}
+    #     self.assertFalse('a' in d)
+    #     # has_key replaced with "in"
+    #     d = {'a': 1, 'b': 2}
+    #     k = d.keys()
+    #     k_list = list(k)
+    #     k_list.sort()
+    #     # changed from k.sort()
+    #     self.assertEqual(k_list, ['a', 'b'])
+    #     # changed comparison from k to k_list
+    #
+    #     self.assertRaises(TypeError, d.has_key)
+    #     # don't know what to do about this
+
+    def test_contains(self):
+        d = {}
+        self.assertNotIn('a', d)
+        self.assertFalse('a' in d)
+        self.assertTrue('a' not in d)
+        d = {'a': 1, 'b': 2}
+        self.assertIn('a', d)
+        self.assertIn('b', d)
+        self.assertNotIn('c', d)
+        '''
+            The direct call of __contains__ on a dict is currently not working
+            in skulpt
+        '''
+        self.assertRaises(TypeError, d.__contains__)
+
+    def test_len(self):
+        d = {}
+        self.assertEqual(len(d), 0)
+        d = {'a': 1, 'b': 2}
+        self.assertEqual(len(d), 2)
+
+    def test_clear(self):
+        d = {1:1, 2:2, 3:3}
+        d.clear()
+        self.assertEqual(d, {})
+
+        self.assertRaises(TypeError, d.clear, None)
+
+    def test_update(self):
+        d = {}
+        d.update({1:100})
+        d.update({2:20})
+        d.update({1:1, 2:2, 3:3})
+        self.assertEqual(d, {1:1, 2:2, 3:3})
+
+        d.update()
+        self.assertEqual(d, {1:1, 2:2, 3:3})
+
+        self.assertRaises(TypeError, d.update, None)
+
+        class SimpleUserDict:
+            def __init__(self):
+                self.d = {1:1, 2:2, 3:3}
+            def keys(self):
+                return self.d.keys()
+            def __getitem__(self, i):
+                return self.d[i]
+        d.clear()
+        d.update(SimpleUserDict())
+        self.assertEqual(d, {1:1, 2:2, 3:3})
+
+        d.clear()
+        class FailingUserDict:
+            def keys(self):
+                raise KeyError
+        self.assertRaises(KeyError, d.update, FailingUserDict())
+
+        # skulpt seems not to support this kind of behavior
+        # especially defining this inner iter
+        # hence test is disabled
+        class FailingUserDict:
+            def keys(self):
+                class BogonIter:
+                    def __init__(self):
+                        self.i = 1
+                    def __iter__(self):
+                        return self
+                    def next(self):
+                        if self.i:
+                            self.i = 0
+                            return 'a'
+                        raise Exception
+                return BogonIter()
+            def __getitem__(self, key):
+                return key
+        self.assertRaises(Exception, d.update, FailingUserDict())
+
+        class FailingUserDict:
+            def keys(self):
+                class BogonIter:
+                    def __init__(self):
+                        self.i = ord('a')
+                    def __iter__(self):
+                        return self
+                    def next(self):
+                        if self.i <= ord('z'):
+                            rtn = chr(self.i)
+                            self.i += 1
+                            return rtn
+                        raise StopIteration
+                return BogonIter()
+            def __getitem__(self, key):
+                raise Exception
+        self.assertRaises(Exception, d.update, FailingUserDict())
+
+        class badseq(object):
+            def __iter__(self):
+                return self
+            def next(self):
+                raise Exception()
+
+        self.assertRaises(Exception, {}.update, badseq())
+
+        self.assertRaises(ValueError, {}.update, [(1, 2, 3)])
+
+    def test_repr(self):
+        d = {}
+        self.assertEqual(repr(d), '{}')
+        d[1] = 2
+        self.assertEqual(repr(d), '{1: 2}')
+        d = {}
+        d[1] = d
+        self.assertEqual(repr(d), '{1: {...}}')
+
+
+        # we cannot subclass Exceptions -.-
+        '''
+        class Exc(Exception): pass
+
+        class BadRepr(object):
+            def __repr__(self):
+                raise Exc()
+
+        d = {1: BadRepr()}
+        #self.assertRaises(Exc, repr, d)
+        '''
+
+    def test_get(self):
+        d = {}
+        self.assertIs(d.get('c'), None)
+        self.assertEqual(d.get('c', 3), 3)
+        d = {'a': 1, 'b': 2}
+        self.assertIs(d.get('c'), None)
+        self.assertEqual(d.get('c', 3), 3)
+        self.assertEqual(d.get('a'), 1)
+        self.assertEqual(d.get('a', 3), 1)
+        self.assertRaises(TypeError, d.get)
+        self.assertRaises(TypeError, d.get, None, None, None)
+
+    def test_attrib(self):
+        d = {}
+        def do_set():
+            d.x = 42
+        self.assertRaises(AttributeError, do_set)
+        self.assertRaises(AttributeError, lambda: d.x)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_dictcomps.py
+++ b/test/unit3/test_dictcomps.py
@@ -1,0 +1,73 @@
+import unittest
+
+# For scope testing.
+g = "Global variable"
+
+
+class DictComprehensionTest(unittest.TestCase):
+
+    def test_basics(self):
+        expected = {0: 10, 1: 11, 2: 12, 3: 13, 4: 14, 5: 15, 6: 16, 7: 17,
+                    8: 18, 9: 19}
+        actual = {k: k + 10 for k in range(10)}
+        self.assertEqual(actual, expected)
+
+        expected = {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9}
+        actual = {k: v for k in range(10) for v in range(10) if k == v}
+        self.assertEqual(actual, expected)
+
+    def test_scope_isolation(self):
+        k = "Local Variable"
+
+        expected = {0: None, 1: None, 2: None, 3: None, 4: None, 5: None,
+                    6: None, 7: None, 8: None, 9: None}
+        actual = {k: None for k in range(10)}
+        self.assertEqual(actual, expected)
+        # self.assertEqual(k, "Local Variable")
+
+        expected = {9: 1, 18: 2, 19: 2, 27: 3, 28: 3, 29: 3, 36: 4, 37: 4,
+                    38: 4, 39: 4, 45: 5, 46: 5, 47: 5, 48: 5, 49: 5, 54: 6,
+                    55: 6, 56: 6, 57: 6, 58: 6, 59: 6, 63: 7, 64: 7, 65: 7,
+                    66: 7, 67: 7, 68: 7, 69: 7, 72: 8, 73: 8, 74: 8, 75: 8,
+                    76: 8, 77: 8, 78: 8, 79: 8, 81: 9, 82: 9, 83: 9, 84: 9,
+                    85: 9, 86: 9, 87: 9, 88: 9, 89: 9}
+        actual = {k: v for v in range(10) for k in range(v * 9, v * 10)}
+        # self.assertEqual(k, "Local Variable")
+        self.assertEqual(actual, expected)
+
+    def test_scope_isolation_from_global(self):
+        expected = {0: None, 1: None, 2: None, 3: None, 4: None, 5: None,
+                    6: None, 7: None, 8: None, 9: None}
+        actual = {g: None for g in range(10)}
+        self.assertEqual(actual, expected)
+        # self.assertEqual(g, "Global variable")
+
+        expected = {9: 1, 18: 2, 19: 2, 27: 3, 28: 3, 29: 3, 36: 4, 37: 4,
+                    38: 4, 39: 4, 45: 5, 46: 5, 47: 5, 48: 5, 49: 5, 54: 6,
+                    55: 6, 56: 6, 57: 6, 58: 6, 59: 6, 63: 7, 64: 7, 65: 7,
+                    66: 7, 67: 7, 68: 7, 69: 7, 72: 8, 73: 8, 74: 8, 75: 8,
+                    76: 8, 77: 8, 78: 8, 79: 8, 81: 9, 82: 9, 83: 9, 84: 9,
+                    85: 9, 86: 9, 87: 9, 88: 9, 89: 9}
+        actual = {g: v for v in range(10) for g in range(v * 9, v * 10)}
+        # self.assertEqual(g, "Global variable")
+        self.assertEqual(actual, expected)
+
+    def test_local_visibility(self):
+        v = "Local variable"
+        expected = {0: 'Local variable', 1: 'Local variable',
+                    2: 'Local variable', 3: 'Local variable',
+                    4: 'Local variable', 5: 'Local variable',
+                    6: 'Local variable', 7: 'Local variable',
+                    8: 'Local variable', 9: 'Local variable'}
+        actual = {k: v for k in range(10)}
+        self.assertEqual(actual, expected)
+        self.assertEqual(v, "Local variable")
+
+    # def test_illegal_assignment(self):
+    #     self.assertRaisesRegex(SyntaxError, "can't assign", lambda: compile("{x: y for y, x in ((1, 2), (3, 4))} = 5", "<test>","exec"))
+    #
+    #     self.assertRaisesRegex(SyntaxError, "can't assign", lambda: compile("{x: y for y, x in ((1, 2), (3, 4))} += 5", "<test>","exec"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_enumerate.py
+++ b/test/unit3/test_enumerate.py
@@ -1,0 +1,238 @@
+import unittest
+import operator
+import sys
+
+class G:
+    'Sequence using __getitem__'
+    def __init__(self, seqn):
+        self.seqn = seqn
+    def __getitem__(self, i):
+        return self.seqn[i]
+
+class I:
+    'Sequence using iterator protocol'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __iter__(self):
+        return self
+    def __next__(self):
+        if self.i >= len(self.seqn): raise StopIteration
+        v = self.seqn[self.i]
+        self.i += 1
+        return v
+
+class Ig:
+    'Sequence using iterator protocol defined with a generator'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __iter__(self):
+        for val in self.seqn:
+            yield val
+
+class X:
+    'Missing __getitem__ and __iter__'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __next__(self):
+        if self.i >= len(self.seqn): raise StopIteration
+        v = self.seqn[self.i]
+        self.i += 1
+        return v
+
+class E:
+    'Test propagation of exceptions'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __iter__(self):
+        return self
+    def __next__(self):
+        3 // 0
+
+class N:
+    'Iterator missing __next__()'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __iter__(self):
+        return self
+
+class EnumerateTestCase(unittest.TestCase):
+
+    enum = enumerate
+    seq, res = 'abc', [(0,'a'), (1,'b'), (2,'c')]
+
+    def test_basicfunction(self):
+        self.assertEqual(type(self.enum(self.seq)), self.enum)
+        e = self.enum(self.seq)
+        self.assertEqual(iter(e), e)
+        self.assertEqual(list(self.enum(self.seq)), self.res)
+        # self.enum.__doc__
+
+    # def test_getitemseqn(self):
+    #     self.assertEqual(list(self.enum(G(self.seq))), self.res)
+    #     e = self.enum(G(''))
+    #     self.assertRaises(StopIteration, next, e)
+
+    # def test_iteratorseqn(self):
+    #     self.assertEqual(list(self.enum(I(self.seq))), self.res)
+    #     e = self.enum(I(''))
+    #     self.assertRaises(StopIteration, next, e)
+
+    # def test_iteratorgenerator(self):
+    #     self.assertEqual(list(self.enum(Ig(self.seq))), self.res)
+    #     e = self.enum(Ig(''))
+    #     self.assertRaises(StopIteration, next, e)
+
+    # def test_noniterable(self):
+    #     self.assertRaises(TypeError, self.enum, X(self.seq))
+
+    # def test_illformediterable(self):
+    #     self.assertRaises(TypeError, self.enum, N(self.seq))
+
+    # def test_exception_propagation(self):
+    #     self.assertRaises(ZeroDivisionError, list, self.enum(E(self.seq)))
+
+    def test_argumentcheck(self):
+        # self.assertRaises(TypeError, self.enum) # no arguments
+        # self.assertRaises(TypeError, self.enum, 1) # wrong type (not iterable)
+        self.assertRaises(TypeError, self.enum, 'abc', 'a') # wrong type
+        # self.assertRaises(TypeError, self.enum, 'abc', 2, 3) # too many arguments
+
+    def test_tuple_reuse(self):
+        # Tests an implementation detail where tuple is reused
+        # whenever nothing else holds a reference to it
+        self.assertEqual(len(set(map(id, list(enumerate(self.seq))))), len(self.seq))
+        # self.assertEqual(len(set(map(id, enumerate(self.seq)))), min(1,len(self.seq)))
+
+class MyEnum(enumerate):
+    pass
+
+class SubclassTestCase(EnumerateTestCase):
+
+    enum = MyEnum
+
+class TestEmpty(EnumerateTestCase):
+
+    seq, res = '', []
+
+class TestBig(EnumerateTestCase):
+
+    seq = range(10,20000,2)
+    res = list(zip(range(20000), seq))
+
+class TestReversed(unittest.TestCase):
+
+    # def test_simple(self):
+    #     class A:
+    #         def __getitem__(self, i):
+    #             if i < 5:
+    #                 return str(i)
+    #             raise StopIteration
+    #         def __len__(self):
+    #             return 5
+    #     for data in 'abc', range(5), tuple(enumerate('abc')), A(), range(1,17,5):
+    #         self.assertEqual(list(data)[::-1], list(reversed(data)))
+    #     self.assertRaises(TypeError, reversed, {})
+    #     # don't allow keyword arguments
+    #     self.assertRaises(TypeError, reversed, [], a=1)
+
+    # def test_range_optimization(self):
+    #     x = range(1)
+    #     self.assertEqual(type(reversed(x)), type(iter(x)))
+
+    # def test_len(self):
+    #     for s in ('hello', tuple('hello'), list('hello'), range(5)):
+    #         self.assertEqual(operator.length_hint(reversed(s)), len(s))
+    #         r = reversed(s)
+    #         list(r)
+    #         self.assertEqual(operator.length_hint(r), 0)
+    #     class SeqWithWeirdLen:
+    #         called = False
+    #         def __len__(self):
+    #             if not self.called:
+    #                 self.called = True
+    #                 return 10
+    #             raise ZeroDivisionError
+    #         def __getitem__(self, index):
+    #             return index
+    #     r = reversed(SeqWithWeirdLen())
+    #     self.assertRaises(ZeroDivisionError, operator.length_hint, r)
+
+
+    # def test_gc(self):
+    #     class Seq:
+    #         def __len__(self):
+    #             return 10
+    #         def __getitem__(self, index):
+    #             return index
+    #     s = Seq()
+    #     r = reversed(s)
+    #     s.r = r
+
+    def test_args(self):
+        self.assertRaises(TypeError, reversed)
+        self.assertRaises(TypeError, reversed, [], 'extra')
+
+    # def test_bug1229429(self):
+    #     # this bug was never in reversed, it was in
+    #     # PyObject_CallMethod, and reversed_new calls that sometimes.
+    #     def f():
+    #         pass
+    #     r = f.__reversed__ = object()
+    #     rc = sys.getrefcount(r)
+    #     for i in range(10):
+    #         try:
+    #             reversed(f)
+    #         except TypeError:
+    #             pass
+    #         else:
+    #             self.fail("non-callable __reversed__ didn't raise!")
+    #     self.assertEqual(rc, sys.getrefcount(r))
+
+    def test_objmethods(self):
+        # Objects must have __len__() and __getitem__() implemented.
+        class NoLen(object):
+            def __getitem__(self, i): return 1
+        nl = NoLen()
+        self.assertRaises(TypeError, reversed, nl)
+
+        class NoGetItem(object):
+            def __len__(self): return 2
+        ngi = NoGetItem()
+        self.assertRaises(TypeError, reversed, ngi)
+
+        class Blocked(object):
+            def __getitem__(self, i): return 1
+            def __len__(self): return 2
+            __reversed__ = None
+        b = Blocked()
+        self.assertRaises(TypeError, reversed, b)
+
+
+# class EnumerateStartTestCase(EnumerateTestCase):
+#
+#     def test_basicfunction(self):
+#         e = self.enum(self.seq)
+#         self.assertEqual(iter(e), e)
+#         self.assertEqual(list(self.enum(self.seq)), self.res)
+#
+#
+# class TestStart(EnumerateStartTestCase):
+#
+#     enum = lambda self, i: enumerate(i, start=11)
+#     seq, res = 'abc', [(11, 'a'), (12, 'b'), (13, 'c')]
+#
+#
+# class TestLongStart(EnumerateStartTestCase):
+#
+#     enum = lambda self, i: enumerate(i, start=sys.maxsize+1)
+#     seq, res = 'abc', [(sys.maxsize+1,'a'), (sys.maxsize+2,'b'),
+#                        (sys.maxsize+3,'c')]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_exit.py
+++ b/test/unit3/test_exit.py
@@ -1,0 +1,45 @@
+__author__ = "leszek"
+
+import unittest
+
+class ExitTest(unittest.TestCase):
+    def test_exit(self):
+        try:
+            exit()
+            self.fail("Should not reach line after exit")
+        except SystemExit as e:
+            return
+        self.fail("Test should have returned")
+
+    def test_exit_not_exception(self):
+        try:
+            try:
+                exit()
+            except Exception as e:
+                self.fail("except Exception should not catch SystemExit")
+            self.fail("Should not reach line after exit")
+        except SystemExit as e:
+            return
+        self.fail("Test should have returned")
+
+    def test_exit_in_func(self):
+        try:
+            def foo():
+                exit()
+            exit()
+            self.fail("Should not reach line after exit")
+        except SystemExit as e:
+            return
+        self.fail("Test should have returned")
+
+    def test_import_exit(self):
+        try:
+            import exiting_module
+            self.fail("Should not reach line after import")
+        except SystemExit as e:
+            return
+        self.fail("Test should have returned")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_float.py
+++ b/test/unit3/test_float.py
@@ -1,0 +1,18 @@
+import sys
+import unittest
+import math
+
+class FloatTestCases(unittest.TestCase):
+    def test_conjugate(self):
+        self.assertEqual(float(3.0).conjugate(), 3.0)
+        self.assertEqual(int(-3.0).conjugate(), -3.0)
+
+    def test_inf(self):
+        self.assertTrue(math.isinf(float('Inf')))
+        self.assertFalse(math.isinf(42))
+        self.assertFalse(math.isinf(42.1))
+        self.assertRaises(TypeError, lambda: math.isinf("42"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_index.py
+++ b/test/unit3/test_index.py
@@ -1,5 +1,4 @@
 import unittest
-from test import support
 import operator
 #from sys import maxint
 #maxsize = test_support.MAX_Py_ssize_t
@@ -69,116 +68,116 @@ class BaseTestCase(unittest.TestCase):
         #self.assertRaises(TypeError, slice(self.n).indices, 0)
 
 
-class SeqTestCase(unittest.TestCase):
-    # This test case isn't run directly. It just defines common tests
-    # to the different sequence types below
-    def setUp(self):
-        self.o = oldstyle()
-        #self.n = newstyle()
-        self.o2 = oldstyle()
-        #self.n2 = newstyle()
-
-    def test_index(self):
-        self.o.ind = -2
-        #self.n.ind = 2
-        #self.assertEqual(self.seq[self.n], self.seq[2])
-        self.assertEqual(self.seq[self.o], self.seq[-2])
-
-    def test_slice(self):
-        self.o.ind = 1
-        self.o2.ind = 3
-        #self.n.ind = 2
-        #self.n2.ind = 4
-        self.assertEqual(self.seq[self.o:self.o2], self.seq[1:3])
-        #self.assertEqual(self.seq[self.n:self.n2], self.seq[2:4])
-
-    def test_slice_bug7532a(self):
-        seqlen = len(self.seq)
-        self.o.ind = int(seqlen * 1.5)
-        #self.n.ind = seqlen + 2
-        self.assertEqual(self.seq[self.o:], self.seq[0:0])
-        self.assertEqual(self.seq[:self.o], self.seq)
-        #self.assertEqual(self.seq[self.n:], self.seq[0:0])
-        #self.assertEqual(self.seq[:self.n], self.seq)
-
-    def test_slice_bug7532b(self):
-        if isinstance(self.seq, ClassicSeq):
-            self.skipTest('test fails for ClassicSeq')
-        # These tests fail for ClassicSeq (see bug #7532)
-        seqlen = len(self.seq)
-        self.o2.ind = -seqlen - 2
-        #self.n2.ind = -int(seqlen * 1.5)
-        self.assertEqual(self.seq[self.o2:], self.seq)
-        self.assertEqual(self.seq[:self.o2], self.seq[0:0])
-        #self.assertEqual(self.seq[self.n2:], self.seq)
-        #self.assertEqual(self.seq[:self.n2], self.seq[0:0])
-
-    def test_repeat(self):
-        self.o.ind = 3
-        #self.n.ind = 2
-        self.assertEqual(self.seq * self.o, self.seq * 3)
-        #self.assertEqual(self.seq * self.n, self.seq * 2)
-        self.assertEqual(self.o * self.seq, self.seq * 3)
-        #self.assertEqual(self.n * self.seq, self.seq * 2)
-
-    def test_wrappers(self):
-        self.o.ind = 4
-        #self.n.ind = 5
-        self.assertEqual(self.seq.__getitem__(self.o), self.seq[4])
-        self.assertEqual(self.seq.__mul__(self.o), self.seq * 4)
-        self.assertEqual(self.seq.__rmul__(self.o), self.seq * 4)
-        #self.assertEqual(self.seq.__getitem__(self.n), self.seq[5])
-        #self.assertEqual(self.seq.__mul__(self.n), self.seq * 5)
-        #self.assertEqual(self.seq.__rmul__(self.n), self.seq * 5)
-
-    def test_subclasses(self):
-        self.assertEqual(self.seq[TrapInt()], self.seq[0])
-        self.assertEqual(self.seq[TrapLong()], self.seq[0])
-
-    def test_error(self):
-        self.o.ind = 'dumb'
-        #self.n.ind = 'bad'
-        indexobj = lambda x, obj: obj.seq[x]
-        self.assertRaises(TypeError, indexobj, self.o, self)
-        #self.assertRaises(TypeError, indexobj, self.n, self)
-        sliceobj = lambda x, obj: obj.seq[x:]
-        self.assertRaises(TypeError, sliceobj, self.o, self)
-        #self.assertRaises(TypeError, sliceobj, self.n, self)
-
-
-class ListTestCase(SeqTestCase):
-    seq = [0,10,20,30,40,50]
-
-    def test_setdelitem(self):
-        self.o.ind = -2
-        #self.n.ind = 2
-        lst = list('ab!cdefghi!j')
-        del lst[self.o]
-        #del lst[self.n]
-        lst[self.o] = 'X'
-        #lst[self.n] = 'Y'
-        #self.assertEqual(lst, list('abYdefghXj'))
-        self.assertEqual(lst, list('ab!cdefghXj'))
-
-        # lst = [5, 6, 7, 8, 9, 10, 11]
-        # lst.__setitem__(self.n, "here")
-        # self.assertEqual(lst, [5, 6, "here", 8, 9, 10, 11])
-        # lst.__delitem__(self.n)
-        # self.assertEqual(lst, [5, 6, 8, 9, 10, 11])
-
-    def test_inplace_repeat(self):
-        self.o.ind = 2
-        #self.n.ind = 3
-        lst = [6, 4]
-        lst *= self.o
-        self.assertEqual(lst, [6, 4, 6, 4])
-        #lst *= self.n
-        #self.assertEqual(lst, [6, 4, 6, 4] * 3)
-
-        #lst = [5, 6, 7, 8, 9, 11]
-        #l2 = lst.__imul__(self.n)
-        #self.assertIs(l2, lst)
-        #self.assertEqual(lst, [5, 6, 7, 8, 9, 11] * 3)
+# class SeqTestCase(unittest.TestCase):
+#     # This test case isn't run directly. It just defines common tests
+#     # to the different sequence types below
+#     def setUp(self):
+#         self.o = oldstyle()
+#         #self.n = newstyle()
+#         self.o2 = oldstyle()
+#         #self.n2 = newstyle()
+#
+#     def test_index(self):
+#         self.o.ind = -2
+#         #self.n.ind = 2
+#         #self.assertEqual(self.seq[self.n], self.seq[2])
+#         self.assertEqual(self.seq[self.o], self.seq[-2])
+#
+#     def test_slice(self):
+#         self.o.ind = 1
+#         self.o2.ind = 3
+#         #self.n.ind = 2
+#         #self.n2.ind = 4
+#         self.assertEqual(self.seq[self.o:self.o2], self.seq[1:3])
+#         #self.assertEqual(self.seq[self.n:self.n2], self.seq[2:4])
+#
+#     def test_slice_bug7532a(self):
+#         seqlen = len(self.seq)
+#         self.o.ind = int(seqlen * 1.5)
+#         #self.n.ind = seqlen + 2
+#         self.assertEqual(self.seq[self.o:], self.seq[0:0])
+#         self.assertEqual(self.seq[:self.o], self.seq)
+#         #self.assertEqual(self.seq[self.n:], self.seq[0:0])
+#         #self.assertEqual(self.seq[:self.n], self.seq)
+#
+#     def test_slice_bug7532b(self):
+#         if isinstance(self.seq, ClassicSeq):
+#             self.skipTest('test fails for ClassicSeq')
+#         # These tests fail for ClassicSeq (see bug #7532)
+#         seqlen = len(self.seq)
+#         self.o2.ind = -seqlen - 2
+#         #self.n2.ind = -int(seqlen * 1.5)
+#         self.assertEqual(self.seq[self.o2:], self.seq)
+#         self.assertEqual(self.seq[:self.o2], self.seq[0:0])
+#         #self.assertEqual(self.seq[self.n2:], self.seq)
+#         #self.assertEqual(self.seq[:self.n2], self.seq[0:0])
+#
+#     def test_repeat(self):
+#         self.o.ind = 3
+#         #self.n.ind = 2
+#         self.assertEqual(self.seq * self.o, self.seq * 3)
+#         #self.assertEqual(self.seq * self.n, self.seq * 2)
+#         self.assertEqual(self.o * self.seq, self.seq * 3)
+#         #self.assertEqual(self.n * self.seq, self.seq * 2)
+#
+#     def test_wrappers(self):
+#         self.o.ind = 4
+#         #self.n.ind = 5
+#         self.assertEqual(self.seq.__getitem__(self.o), self.seq[4])
+#         self.assertEqual(self.seq.__mul__(self.o), self.seq * 4)
+#         self.assertEqual(self.seq.__rmul__(self.o), self.seq * 4)
+#         #self.assertEqual(self.seq.__getitem__(self.n), self.seq[5])
+#         #self.assertEqual(self.seq.__mul__(self.n), self.seq * 5)
+#         #self.assertEqual(self.seq.__rmul__(self.n), self.seq * 5)
+#
+#     def test_subclasses(self):
+#         self.assertEqual(self.seq[TrapInt()], self.seq[0])
+#         self.assertEqual(self.seq[TrapLong()], self.seq[0])
+#
+#     def test_error(self):
+#         self.o.ind = 'dumb'
+#         #self.n.ind = 'bad'
+#         indexobj = lambda x, obj: obj.seq[x]
+#         self.assertRaises(TypeError, indexobj, self.o, self)
+#         #self.assertRaises(TypeError, indexobj, self.n, self)
+#         sliceobj = lambda x, obj: obj.seq[x:]
+#         self.assertRaises(TypeError, sliceobj, self.o, self)
+#         #self.assertRaises(TypeError, sliceobj, self.n, self)
+#
+#
+# class ListTestCase(SeqTestCase):
+#     seq = [0,10,20,30,40,50]
+#
+#     def test_setdelitem(self):
+#         self.o.ind = -2
+#         #self.n.ind = 2
+#         lst = list('ab!cdefghi!j')
+#         del lst[self.o]
+#         #del lst[self.n]
+#         lst[self.o] = 'X'
+#         #lst[self.n] = 'Y'
+#         #self.assertEqual(lst, list('abYdefghXj'))
+#         self.assertEqual(lst, list('ab!cdefghXj'))
+#
+#         # lst = [5, 6, 7, 8, 9, 10, 11]
+#         # lst.__setitem__(self.n, "here")
+#         # self.assertEqual(lst, [5, 6, "here", 8, 9, 10, 11])
+#         # lst.__delitem__(self.n)
+#         # self.assertEqual(lst, [5, 6, 8, 9, 10, 11])
+#
+#     def test_inplace_repeat(self):
+#         self.o.ind = 2
+#         #self.n.ind = 3
+#         lst = [6, 4]
+#         lst *= self.o
+#         self.assertEqual(lst, [6, 4, 6, 4])
+#         #lst *= self.n
+#         #self.assertEqual(lst, [6, 4, 6, 4] * 3)
+#
+#         #lst = [5, 6, 7, 8, 9, 11]
+#         #l2 = lst.__imul__(self.n)
+#         #self.assertIs(l2, lst)
+#         #self.assertEqual(lst, [5, 6, 7, 8, 9, 11] * 3)
 
 
 class _BaseSeq:
@@ -215,11 +214,11 @@ class ClassicSeq(_BaseSeq): pass
 #class NewSeqDeprecated(_GetSliceMixin, NewSeq): pass
 
 
-class TupleTestCase(SeqTestCase):
-    seq = (0,10,20,30,40,50)
-
-class StringTestCase(SeqTestCase):
-    seq = "this is a test"
+# class TupleTestCase(SeqTestCase):
+#     seq = (0,10,20,30,40,50)
+#
+# class StringTestCase(SeqTestCase):
+#     seq = "this is a test"
 
 # class ByteArrayTestCase(SeqTestCase):
 #     seq = bytearray("this is a test")
@@ -304,19 +303,19 @@ class StringTestCase(SeqTestCase):
 #         self.assertRaises(OverflowError, lambda: "a" * self.neg)
 
 
-def test_main():
-    support.run_unittest(
-        BaseTestCase,
-        ListTestCase,
-        TupleTestCase,
-        # ByteArrayTestCase,
-        StringTestCase,
-        # UnicodeTestCase,
-        # ClassicSeqTestCase,
-        # NewSeqTestCase,
-        # XRangeTestCase,
-        # OverflowTestCase,
-    )
+# def test_main():
+#     support.run_unittest(
+#         BaseTestCase,
+#         ListTestCase,
+#         TupleTestCase,
+#         # ByteArrayTestCase,
+#         StringTestCase,
+#         # UnicodeTestCase,
+#         # ClassicSeqTestCase,
+#         # NewSeqTestCase,
+#         # XRangeTestCase,
+#         # OverflowTestCase,
+#     )
     # with test_support.check_py3k_warnings():
     #     test_support.run_unittest(
     #         ClassicSeqDeprecatedTestCase,
@@ -325,4 +324,4 @@ def test_main():
 
 
 if __name__ == "__main__":
-    test_main()
+    unittest.main()

--- a/test/unit3/test_index.py
+++ b/test/unit3/test_index.py
@@ -1,0 +1,328 @@
+import unittest
+from test import support
+import operator
+#from sys import maxint
+#maxsize = test_support.MAX_Py_ssize_t
+#minsize = -maxsize-1
+
+class oldstyle:
+    def __index__(self):
+        return self.ind
+
+# class newstyle(object):
+#     def __index__(self):
+#         return self.ind
+
+class TrapInt(int):
+    def __index__(self):
+        return self
+
+class TrapLong(int):
+    # changed to int
+    def __index__(self):
+        return self
+
+class BaseTestCase(unittest.TestCase):
+    def setUp(self):
+        self.o = oldstyle()
+        #self.n = newstyle()
+
+    def test_basic(self):
+        self.o.ind = -2
+        #self.n.ind = 2
+        self.assertEqual(operator.index(self.o), -2)
+        #self.assertEqual(operator.index(self.n), 2)
+
+    def test_slice(self):
+        self.o.ind = 1
+        #self.n.ind = 2
+        slc = slice(self.o, self.o, self.o)
+        check_slc = slice(1, 1, 1)
+        self.assertEqual(slc.indices(self.o), check_slc.indices(1))
+        #slc = slice(self.n, self.n, self.n)
+        #check_slc = slice(2, 2, 2)
+        #self.assertEqual(slc.indices(self.n), check_slc.indices(2))
+
+    def test_wrappers(self):
+        self.o.ind = 4
+        #self.n.ind = 5
+        #self.assertEqual(6.__index__(), 6)
+        #self.assertEqual(-7L.__index__(), -7)
+        self.assertEqual(self.o.__index__(), 4)
+        #self.assertEqual(self.n.__index__(), 5)
+        #self.assertEqual(True.__index__(), 1)
+        #self.assertEqual(False.__index__(), 0)
+
+    def test_subclasses(self):
+        r = range(10)
+        self.assertEqual(r[TrapInt(5):TrapInt(10)], r[5:10])
+        self.assertEqual(r[TrapLong(5):TrapLong(10)], r[5:10])
+        self.assertEqual(slice(TrapInt()).indices(0), (0,0,1))
+        self.assertEqual(slice(TrapLong(0)).indices(0), (0,0,1))
+
+    def test_error(self):
+        self.o.ind = 'dumb'
+        #self.n.ind = 'bad'
+        self.assertRaises(TypeError, operator.index, self.o)
+        #self.assertRaises(TypeError, operator.index, self.n)
+        self.assertRaises(TypeError, slice(self.o).indices, 0)
+        #self.assertRaises(TypeError, slice(self.n).indices, 0)
+
+
+class SeqTestCase(unittest.TestCase):
+    # This test case isn't run directly. It just defines common tests
+    # to the different sequence types below
+    def setUp(self):
+        self.o = oldstyle()
+        #self.n = newstyle()
+        self.o2 = oldstyle()
+        #self.n2 = newstyle()
+
+    def test_index(self):
+        self.o.ind = -2
+        #self.n.ind = 2
+        #self.assertEqual(self.seq[self.n], self.seq[2])
+        self.assertEqual(self.seq[self.o], self.seq[-2])
+
+    def test_slice(self):
+        self.o.ind = 1
+        self.o2.ind = 3
+        #self.n.ind = 2
+        #self.n2.ind = 4
+        self.assertEqual(self.seq[self.o:self.o2], self.seq[1:3])
+        #self.assertEqual(self.seq[self.n:self.n2], self.seq[2:4])
+
+    def test_slice_bug7532a(self):
+        seqlen = len(self.seq)
+        self.o.ind = int(seqlen * 1.5)
+        #self.n.ind = seqlen + 2
+        self.assertEqual(self.seq[self.o:], self.seq[0:0])
+        self.assertEqual(self.seq[:self.o], self.seq)
+        #self.assertEqual(self.seq[self.n:], self.seq[0:0])
+        #self.assertEqual(self.seq[:self.n], self.seq)
+
+    def test_slice_bug7532b(self):
+        if isinstance(self.seq, ClassicSeq):
+            self.skipTest('test fails for ClassicSeq')
+        # These tests fail for ClassicSeq (see bug #7532)
+        seqlen = len(self.seq)
+        self.o2.ind = -seqlen - 2
+        #self.n2.ind = -int(seqlen * 1.5)
+        self.assertEqual(self.seq[self.o2:], self.seq)
+        self.assertEqual(self.seq[:self.o2], self.seq[0:0])
+        #self.assertEqual(self.seq[self.n2:], self.seq)
+        #self.assertEqual(self.seq[:self.n2], self.seq[0:0])
+
+    def test_repeat(self):
+        self.o.ind = 3
+        #self.n.ind = 2
+        self.assertEqual(self.seq * self.o, self.seq * 3)
+        #self.assertEqual(self.seq * self.n, self.seq * 2)
+        self.assertEqual(self.o * self.seq, self.seq * 3)
+        #self.assertEqual(self.n * self.seq, self.seq * 2)
+
+    def test_wrappers(self):
+        self.o.ind = 4
+        #self.n.ind = 5
+        self.assertEqual(self.seq.__getitem__(self.o), self.seq[4])
+        self.assertEqual(self.seq.__mul__(self.o), self.seq * 4)
+        self.assertEqual(self.seq.__rmul__(self.o), self.seq * 4)
+        #self.assertEqual(self.seq.__getitem__(self.n), self.seq[5])
+        #self.assertEqual(self.seq.__mul__(self.n), self.seq * 5)
+        #self.assertEqual(self.seq.__rmul__(self.n), self.seq * 5)
+
+    def test_subclasses(self):
+        self.assertEqual(self.seq[TrapInt()], self.seq[0])
+        self.assertEqual(self.seq[TrapLong()], self.seq[0])
+
+    def test_error(self):
+        self.o.ind = 'dumb'
+        #self.n.ind = 'bad'
+        indexobj = lambda x, obj: obj.seq[x]
+        self.assertRaises(TypeError, indexobj, self.o, self)
+        #self.assertRaises(TypeError, indexobj, self.n, self)
+        sliceobj = lambda x, obj: obj.seq[x:]
+        self.assertRaises(TypeError, sliceobj, self.o, self)
+        #self.assertRaises(TypeError, sliceobj, self.n, self)
+
+
+class ListTestCase(SeqTestCase):
+    seq = [0,10,20,30,40,50]
+
+    def test_setdelitem(self):
+        self.o.ind = -2
+        #self.n.ind = 2
+        lst = list('ab!cdefghi!j')
+        del lst[self.o]
+        #del lst[self.n]
+        lst[self.o] = 'X'
+        #lst[self.n] = 'Y'
+        #self.assertEqual(lst, list('abYdefghXj'))
+        self.assertEqual(lst, list('ab!cdefghXj'))
+
+        # lst = [5, 6, 7, 8, 9, 10, 11]
+        # lst.__setitem__(self.n, "here")
+        # self.assertEqual(lst, [5, 6, "here", 8, 9, 10, 11])
+        # lst.__delitem__(self.n)
+        # self.assertEqual(lst, [5, 6, 8, 9, 10, 11])
+
+    def test_inplace_repeat(self):
+        self.o.ind = 2
+        #self.n.ind = 3
+        lst = [6, 4]
+        lst *= self.o
+        self.assertEqual(lst, [6, 4, 6, 4])
+        #lst *= self.n
+        #self.assertEqual(lst, [6, 4, 6, 4] * 3)
+
+        #lst = [5, 6, 7, 8, 9, 11]
+        #l2 = lst.__imul__(self.n)
+        #self.assertIs(l2, lst)
+        #self.assertEqual(lst, [5, 6, 7, 8, 9, 11] * 3)
+
+
+class _BaseSeq:
+
+    def __init__(self, iterable):
+        self._list = list(iterable)
+
+    def __repr__(self):
+        return repr(self._list)
+
+    def __eq__(self, other):
+        return self._list == other
+
+    def __len__(self):
+        return len(self._list)
+
+    def __mul__(self, n):
+        return self.__class__(self._list*n)
+    __rmul__ = __mul__
+
+    def __getitem__(self, index):
+        return self._list[index]
+
+
+class _GetSliceMixin:
+
+    def __getslice__(self, i, j):
+        return self._list.__getslice__(i, j)
+
+
+class ClassicSeq(_BaseSeq): pass
+#class NewSeq(_BaseSeq, object): pass
+#class ClassicSeqDeprecated(_GetSliceMixin, ClassicSeq): pass
+#class NewSeqDeprecated(_GetSliceMixin, NewSeq): pass
+
+
+class TupleTestCase(SeqTestCase):
+    seq = (0,10,20,30,40,50)
+
+class StringTestCase(SeqTestCase):
+    seq = "this is a test"
+
+# class ByteArrayTestCase(SeqTestCase):
+#     seq = bytearray("this is a test")
+
+# class UnicodeTestCase(SeqTestCase):
+#     seq = u"this is a test"
+
+# class ClassicSeqTestCase(SeqTestCase):
+#     seq = ClassicSeq((0,10,20,30,40,50))
+
+# class NewSeqTestCase(SeqTestCase):
+#     seq = NewSeq((0,10,20,30,40,50))
+
+# class ClassicSeqDeprecatedTestCase(SeqTestCase):
+#     seq = ClassicSeqDeprecated((0,10,20,30,40,50))
+
+# class NewSeqDeprecatedTestCase(SeqTestCase):
+#     seq = NewSeqDeprecated((0,10,20,30,40,50))
+
+
+# class XRangeTestCase(unittest.TestCase):
+
+#     def test_xrange(self):
+#         n = newstyle()
+#         n.ind = 5
+#         self.assertEqual(xrange(1, 20)[n], 6)
+#         self.assertEqual(xrange(1, 20).__getitem__(n), 6)
+
+# class OverflowTestCase(unittest.TestCase):
+
+#     def setUp(self):
+#         self.pos = 2**100
+#         self.neg = -self.pos
+
+#     def test_large_longs(self):
+#         self.assertEqual(self.pos.__index__(), self.pos)
+#         self.assertEqual(self.neg.__index__(), self.neg)
+
+#     def _getitem_helper(self, base):
+#         class GetItem(base):
+#             def __len__(self):
+#                 return maxint # cannot return long here
+#             def __getitem__(self, key):
+#                 return key
+#         x = GetItem()
+#         self.assertEqual(x[self.pos], self.pos)
+#         self.assertEqual(x[self.neg], self.neg)
+#         self.assertEqual(x[self.neg:self.pos].indices(maxsize),
+#                          (0, maxsize, 1))
+#         self.assertEqual(x[self.neg:self.pos:1].indices(maxsize),
+#                          (0, maxsize, 1))
+
+#     def _getslice_helper_deprecated(self, base):
+#         class GetItem(base):
+#             def __len__(self):
+#                 return maxint # cannot return long here
+#             def __getitem__(self, key):
+#                 return key
+#             def __getslice__(self, i, j):
+#                 return i, j
+#         x = GetItem()
+#         self.assertEqual(x[self.pos], self.pos)
+#         self.assertEqual(x[self.neg], self.neg)
+#         self.assertEqual(x[self.neg:self.pos], (maxint+minsize, maxsize))
+#         self.assertEqual(x[self.neg:self.pos:1].indices(maxsize),
+#                          (0, maxsize, 1))
+
+#     def test_getitem(self):
+#         self._getitem_helper(object)
+#         with test_support.check_py3k_warnings():
+#             self._getslice_helper_deprecated(object)
+
+#     def test_getitem_classic(self):
+#         class Empty: pass
+#         # XXX This test fails (see bug #7532)
+#         #self._getitem_helper(Empty)
+#         with test_support.check_py3k_warnings():
+#             self._getslice_helper_deprecated(Empty)
+
+#     def test_sequence_repeat(self):
+#         self.assertRaises(OverflowError, lambda: "a" * self.pos)
+#         self.assertRaises(OverflowError, lambda: "a" * self.neg)
+
+
+def test_main():
+    support.run_unittest(
+        BaseTestCase,
+        ListTestCase,
+        TupleTestCase,
+        # ByteArrayTestCase,
+        StringTestCase,
+        # UnicodeTestCase,
+        # ClassicSeqTestCase,
+        # NewSeqTestCase,
+        # XRangeTestCase,
+        # OverflowTestCase,
+    )
+    # with test_support.check_py3k_warnings():
+    #     test_support.run_unittest(
+    #         ClassicSeqDeprecatedTestCase,
+    #         NewSeqDeprecatedTestCase,
+    #     )
+
+
+if __name__ == "__main__":
+    test_main()

--- a/test/unit3/test_int.py
+++ b/test/unit3/test_int.py
@@ -1,0 +1,459 @@
+import sys
+
+import unittest
+
+L = [
+        ('0', 0),
+        ('1', 1),
+        ('9', 9),
+        ('10', 10),
+        ('99', 99),
+        ('100', 100),
+        ('314', 314),
+        (' 314', 314),
+        ('314 ', 314),
+        ('  \t\t  314  \t\t  ', 314),
+        (repr(sys.maxsize), sys.maxsize),
+        ('  1x', ValueError),
+        ('  1  ', 1),
+        ('  1\02  ', ValueError),
+        ('', ValueError),
+        (' ', ValueError),
+        ('  \t\t  ', ValueError),
+        ("\u0200", ValueError)
+]
+
+class IntSubclass(int):
+    pass
+
+class IntTestCases(unittest.TestCase):
+
+    def test_basic(self):
+        self.assertEqual(int(314), 314)
+        self.assertEqual(int(3.14), 3)
+        # Check that conversion from float truncates towards zero
+        self.assertEqual(int(-3.14), -3)
+        self.assertEqual(int(3.9), 3)
+        self.assertEqual(int(-3.9), -3)
+        self.assertEqual(int(3.5), 3)
+        self.assertEqual(int(-3.5), -3)
+        self.assertEqual(int("-3"), -3)
+        self.assertEqual(int(" -3 "), -3)
+        # self.assertEqual(int("\N{EM SPACE}-3\N{EN SPACE}"), -3)
+        # Different base:
+        self.assertEqual(int("10",16), 16)
+        # Test conversion from strings and various anomalies
+        for s, v in L:
+            for sign in "", "+", "-":
+                for prefix in "", " ", "\t", "  \t\t  ":
+                    ss = prefix + sign + s
+                    vv = v
+                    if sign == "-" and v is not ValueError:
+                        vv = -v
+                    try:
+                        self.assertEqual(int(ss), vv)
+                    except ValueError:
+                        pass
+
+        s = repr(-1-sys.maxsize)
+        # x = int(s)
+        # self.assertEqual(x+1, -sys.maxsize)
+        # self.assertIsInstance(x, int)
+        # # should return int
+        # self.assertEqual(int(s[1:]), sys.maxsize+1)
+
+        # should return int
+        x = int(1e100)
+        # self.assertIsInstance(x, int)
+        x = int(-1e100)
+        # self.assertIsInstance(x, int)
+
+
+        # SF bug 434186:  0x80000000/2 != 0x80000000>>1.
+        # Worked by accident in Windows release build, but failed in debug build.
+        # Failed in all Linux builds.
+        x = -1-sys.maxsize
+        self.assertEqual(x >> 1, x//2)
+
+        x = int('1' * 600)
+        # self.assertIsInstance(x, int)
+
+
+        self.assertRaises(TypeError, int, 1, 12)
+
+        self.assertEqual(int('0o123', 0), 83)
+        self.assertEqual(int('0x123', 16), 291)
+
+        # Bug 1679: "0x" is not a valid hex literal
+        self.assertRaises(ValueError, int, "0x", 16)
+        self.assertRaises(ValueError, int, "0x", 0)
+
+        self.assertRaises(ValueError, int, "0o", 8)
+        self.assertRaises(ValueError, int, "0o", 0)
+
+        self.assertRaises(ValueError, int, "0b", 2)
+        self.assertRaises(ValueError, int, "0b", 0)
+
+        # SF bug 1334662: int(string, base) wrong answers
+        # Various representations of 2**32 evaluated to 0
+        # rather than 2**32 in previous versions
+
+        self.assertEqual(int('100000000000000000000000000000000', 2), 4294967296)
+        self.assertEqual(int('102002022201221111211', 3), 4294967296)
+        self.assertEqual(int('10000000000000000', 4), 4294967296)
+        self.assertEqual(int('32244002423141', 5), 4294967296)
+        self.assertEqual(int('1550104015504', 6), 4294967296)
+        self.assertEqual(int('211301422354', 7), 4294967296)
+        self.assertEqual(int('40000000000', 8), 4294967296)
+        self.assertEqual(int('12068657454', 9), 4294967296)
+        self.assertEqual(int('4294967296', 10), 4294967296)
+        self.assertEqual(int('1904440554', 11), 4294967296)
+        self.assertEqual(int('9ba461594', 12), 4294967296)
+        self.assertEqual(int('535a79889', 13), 4294967296)
+        self.assertEqual(int('2ca5b7464', 14), 4294967296)
+        self.assertEqual(int('1a20dcd81', 15), 4294967296)
+        self.assertEqual(int('100000000', 16), 4294967296)
+        self.assertEqual(int('a7ffda91', 17), 4294967296)
+        self.assertEqual(int('704he7g4', 18), 4294967296)
+        self.assertEqual(int('4f5aff66', 19), 4294967296)
+        self.assertEqual(int('3723ai4g', 20), 4294967296)
+        self.assertEqual(int('281d55i4', 21), 4294967296)
+        self.assertEqual(int('1fj8b184', 22), 4294967296)
+        self.assertEqual(int('1606k7ic', 23), 4294967296)
+        self.assertEqual(int('mb994ag', 24), 4294967296)
+        self.assertEqual(int('hek2mgl', 25), 4294967296)
+        self.assertEqual(int('dnchbnm', 26), 4294967296)
+        self.assertEqual(int('b28jpdm', 27), 4294967296)
+        self.assertEqual(int('8pfgih4', 28), 4294967296)
+        self.assertEqual(int('76beigg', 29), 4294967296)
+        self.assertEqual(int('5qmcpqg', 30), 4294967296)
+        self.assertEqual(int('4q0jto4', 31), 4294967296)
+        self.assertEqual(int('4000000', 32), 4294967296)
+        self.assertEqual(int('3aokq94', 33), 4294967296)
+        self.assertEqual(int('2qhxjli', 34), 4294967296)
+        self.assertEqual(int('2br45qb', 35), 4294967296)
+        self.assertEqual(int('1z141z4', 36), 4294967296)
+
+        # tests with base 0
+        # this fails on 3.0, but in 2.x the old octal syntax is allowed
+        self.assertEqual(int(' 0o123  ', 0), 83)
+        self.assertEqual(int(' 0o123  ', 0), 83)
+        self.assertEqual(int('000', 0), 0)
+        self.assertEqual(int('0o123', 0), 83)
+        self.assertEqual(int('0x123', 0), 291)
+        self.assertEqual(int('0b100', 0), 4)
+        self.assertEqual(int(' 0O123   ', 0), 83)
+        self.assertEqual(int(' 0X123  ', 0), 291)
+        self.assertEqual(int(' 0B100 ', 0), 4)
+
+        # without base still base 10
+        self.assertEqual(int('0123'), 123)
+        self.assertEqual(int('0123', 10), 123)
+
+        # tests with prefix and base != 0
+        self.assertEqual(int('0x123', 16), 291)
+        self.assertEqual(int('0o123', 8), 83)
+        self.assertEqual(int('0b100', 2), 4)
+        self.assertEqual(int('0X123', 16), 291)
+        self.assertEqual(int('0O123', 8), 83)
+        self.assertEqual(int('0B100', 2), 4)
+
+        # the code has special checks for the first character after the
+        #  type prefix
+        self.assertRaises(ValueError, int, '0b2', 2)
+        self.assertRaises(ValueError, int, '0b02', 2)
+        self.assertRaises(ValueError, int, '0B2', 2)
+        self.assertRaises(ValueError, int, '0B02', 2)
+        self.assertRaises(ValueError, int, '0o8', 8)
+        self.assertRaises(ValueError, int, '0o08', 8)
+        self.assertRaises(ValueError, int, '0O8', 8)
+        self.assertRaises(ValueError, int, '0O08', 8)
+        self.assertRaises(ValueError, int, '0xg', 16)
+        self.assertRaises(ValueError, int, '0x0g', 16)
+        self.assertRaises(ValueError, int, '0Xg', 16)
+        self.assertRaises(ValueError, int, '0X0g', 16)
+
+        # SF bug 1334662: int(string, base) wrong answers
+        # Checks for proper evaluation of 2**32 + 1
+        self.assertEqual(int('100000000000000000000000000000001', 2), 4294967297)
+        self.assertEqual(int('102002022201221111212', 3), 4294967297)
+        self.assertEqual(int('10000000000000001', 4), 4294967297)
+        self.assertEqual(int('32244002423142', 5), 4294967297)
+        self.assertEqual(int('1550104015505', 6), 4294967297)
+        self.assertEqual(int('211301422355', 7), 4294967297)
+        self.assertEqual(int('40000000001', 8), 4294967297)
+        self.assertEqual(int('12068657455', 9), 4294967297)
+        self.assertEqual(int('4294967297', 10), 4294967297)
+        self.assertEqual(int('1904440555', 11), 4294967297)
+        self.assertEqual(int('9ba461595', 12), 4294967297)
+        self.assertEqual(int('535a7988a', 13), 4294967297)
+        self.assertEqual(int('2ca5b7465', 14), 4294967297)
+        self.assertEqual(int('1a20dcd82', 15), 4294967297)
+        self.assertEqual(int('100000001', 16), 4294967297)
+        self.assertEqual(int('a7ffda92', 17), 4294967297)
+        self.assertEqual(int('704he7g5', 18), 4294967297)
+        self.assertEqual(int('4f5aff67', 19), 4294967297)
+        self.assertEqual(int('3723ai4h', 20), 4294967297)
+        self.assertEqual(int('281d55i5', 21), 4294967297)
+        self.assertEqual(int('1fj8b185', 22), 4294967297)
+        self.assertEqual(int('1606k7id', 23), 4294967297)
+        self.assertEqual(int('mb994ah', 24), 4294967297)
+        self.assertEqual(int('hek2mgm', 25), 4294967297)
+        self.assertEqual(int('dnchbnn', 26), 4294967297)
+        self.assertEqual(int('b28jpdn', 27), 4294967297)
+        self.assertEqual(int('8pfgih5', 28), 4294967297)
+        self.assertEqual(int('76beigh', 29), 4294967297)
+        self.assertEqual(int('5qmcpqh', 30), 4294967297)
+        self.assertEqual(int('4q0jto5', 31), 4294967297)
+        self.assertEqual(int('4000001', 32), 4294967297)
+        self.assertEqual(int('3aokq95', 33), 4294967297)
+        self.assertEqual(int('2qhxjlj', 34), 4294967297)
+        self.assertEqual(int('2br45qc', 35), 4294967297)
+        self.assertEqual(int('1z141z5', 36), 4294967297)
+
+    def test_underscores(self):
+        # Additional test cases with bases != 0, only for the constructor:
+        # self.assertEqual(int("1_00", 3), 9)
+        # self.assertEqual(int("0_100"), 100)  # not valid as a literal!
+        self.assertRaises(ValueError, int, "_100")
+        self.assertRaises(ValueError, int, "+_100")
+        self.assertRaises(ValueError, int, "1__00")
+        self.assertRaises(ValueError, int, "100_")
+
+    def test_small_ints(self):
+        # Bug #3236: Return small longs from PyLong_FromString
+        self.assertIs(int('10'), 10)
+        self.assertIs(int('-1'), -1)
+
+    def test_no_args(self):
+        self.assertEqual(int(), 0)
+
+    def test_keyword_args(self):
+        # Test invoking int() using keyword arguments.
+        # self.assertEqual(int(x=1.2), 1)
+        self.assertEqual(int('100', base=2), 4)
+        # self.assertEqual(int(x='100', base=2), 4)
+        # self.assertRaises(TypeError, int, base=10)
+        # self.assertRaises(TypeError, int, base=0)
+
+    def test_int_base_limits(self):
+        """Testing the supported limits of the int() base parameter."""
+        self.assertEqual(int('0', 5), 0)
+        self.assertRaises(ValueError, lambda: int('0', 1))
+        self.assertRaises(ValueError, lambda: int('0', 37))
+        self.assertRaises(ValueError, lambda: int('0', -909))    # An old magic value base from Python 2.
+        self.assertRaises(ValueError, lambda: int('0', base=0-(2**234)))
+        self.assertRaises(ValueError, lambda: int('0', base=2**234))
+        # Bases 2 through 36 are supported.
+        for base in range(2,37):
+            self.assertEqual(int('0', base=base), 0)
+
+    def test_int_base_bad_types(self):
+        """Not integer types are not valid bases; issue16772."""
+        self.assertRaises(TypeError, lambda: int('0', 5.5))
+        self.assertRaises(TypeError, lambda: int('0', 5.0))
+
+    def test_int_base_indexable(self):
+        class MyIndexable(object):
+            def __init__(self, value):
+                self.value = value
+            def __index__(self):
+                return self.value
+
+        # Check out of range bases.
+        for base in 2**100, -2**100, 1, 37:
+            self.assertRaises(ValueError, lambda: int('43', base))
+
+        # Check in-range bases.
+        self.assertEqual(int('101', base=MyIndexable(2)), 5)
+        self.assertEqual(int('101', base=MyIndexable(10)), 101)
+        self.assertEqual(int('101', base=MyIndexable(36)), 1 + 36**2)
+
+    # def test_non_numeric_input_types(self):
+        # Test possible non-numeric types for the argument x, including
+        # subclasses of the explicitly documented accepted types.
+        # class CustomStr(str): pass
+        # class CustomBytes(bytes): pass
+        # class CustomByteArray(bytearray): pass
+        #
+        # factories = [
+        #     bytes,
+        #     bytearray,
+        #     lambda b: CustomStr(b.decode()),
+        #     CustomBytes,
+        #     CustomByteArray,
+        #     memoryview,
+        # ]
+        # try:
+        #     from array import array
+        # except ImportError:
+        #     pass
+        # else:
+        #     factories.append(lambda b: array('B', b))
+
+        # for f in factories:
+        #     with self.subTest(type(x)):
+        #         self.assertEqual(int(x), 100)
+        #         if isinstance(x, (str, bytes, bytearray)):
+        #             self.assertEqual(int(x, 2), 4)
+        #         else:
+        #             msg = "can't convert non-string"
+        #             with self.assertRaisesRegex(TypeError, msg):
+        #                 int(x, 2)
+        #         self.assertRaisesRegex(ValueError, 'invalid literal'):
+        #             int(f(b'A' * 0x10))
+
+    def test_string_float(self):
+        self.assertRaises(ValueError, int, '1.2')
+
+    def test_intconversion(self):
+        # Test __int__()
+        class ClassicMissingMethods:
+            pass
+        self.assertRaises(TypeError, int, ClassicMissingMethods())
+
+        class MissingMethods(object):
+            pass
+        self.assertRaises(TypeError, int, MissingMethods())
+
+        class Foo0:
+            def __int__(self):
+                return 42
+
+        self.assertEqual(int(Foo0()), 42)
+
+        class Classic:
+            pass
+        for base in (object, Classic):
+            class IntOverridesTrunc(base):
+                def __int__(self):
+                    return 42
+                def __trunc__(self):
+                    return -12
+            self.assertEqual(int(IntOverridesTrunc()), 42)
+
+            class JustTrunc(base):
+                def __trunc__(self):
+                    return 42
+            self.assertEqual(int(JustTrunc()), 42)
+
+            class ExceptionalTrunc(base):
+                def __trunc__(self):
+                    1 / 0
+            self.assertRaises(ZeroDivisionError, lambda: int(ExceptionalTrunc()))
+
+            for trunc_result_base in (object, Classic):
+                class Integral(trunc_result_base):
+                    def __int__(self):
+                        return 42
+
+                # class TruncReturnsNonInt(base):
+                #     def __trunc__(self):
+                #         return Integral()
+                # self.assertEqual(int(TruncReturnsNonInt()), 42)
+
+                # class NonIntegral(trunc_result_base):
+                #     def __trunc__(self):
+                #         # Check that we avoid infinite recursion.
+                #         return NonIntegral()
+
+                # class TruncReturnsNonIntegral(base):
+                #     def __trunc__(self):
+                #         return NonIntegral()
+                # try:
+                #     int(TruncReturnsNonIntegral())
+                # except TypeError as e:
+                #     self.assertEqual(str(e),
+                #                       "__trunc__ returned non-Integral"
+                #                       " (type NonIntegral)")
+                # else:
+                #     self.fail("Failed to raise TypeError with %s" %
+                #               ((base, trunc_result_base),))
+                #
+                # # Regression test for bugs.python.org/issue16060.
+                # class BadInt(trunc_result_base):
+                #     def __int__(self):
+                #         return 42.0
+                #
+                # class TruncReturnsBadInt(base):
+                #     def __trunc__(self):
+                #         return BadInt()
+                #
+                # self.assertRaises(TypeError, lambda: int(TruncReturnsBadInt()))
+
+    # def test_int_subclass_with_int(self):
+    #     class MyInt(int):
+    #         def __int__(self):
+    #             return 42
+    #
+    #     class BadInt(int):
+    #         def __int__(self):
+    #             return 42.0
+    #
+    #     my_int = MyInt(7)
+    #     self.assertEqual(my_int, 7)
+    #     self.assertEqual(int(my_int), 42)
+    #
+    #     self.assertRaises(TypeError, int, BadInt())
+
+    def test_int_returns_int_subclass(self):
+        class BadInt:
+            def __int__(self):
+                return True
+
+        # class BadInt2(int):
+        #     def __int__(self):
+        #         return True
+
+        # class TruncReturnsBadInt:
+        #     def __trunc__(self):
+        #         return BadInt()
+
+        class TruncReturnsIntSubclass:
+            def __trunc__(self):
+                return True
+
+        bad_int = BadInt()
+        # self.assertWarns(DeprecationWarning, lambda: int(bad_int))
+        n = int(bad_int)
+        self.assertEqual(n, 1)
+        self.assertIs(type(n), int)
+
+        # bad_int = BadInt2()
+        # self.assertWarns(DeprecationWarning, lambda: int(bad_int))
+        # n = int(bad_int)
+        # self.assertEqual(n, 1)
+        # self.assertIs(type(n), int)
+
+        # bad_int = TruncReturnsBadInt()
+        # self.assertWarns(DeprecationWarning, lambda: int(bad_int))
+        # n = int(bad_int)
+        # self.assertEqual(n, 1)
+        # self.assertIs(type(n), int)
+
+        good_int = TruncReturnsIntSubclass()
+        n = int(good_int)
+        self.assertEqual(n, 1)
+        self.assertIs(type(n), int)
+        n = IntSubclass(good_int)
+        self.assertEqual(n, 1)
+        self.assertIs(type(n), IntSubclass)
+
+        # check('\xbd')
+        # check('123\xbd')
+        # check('  123 456  ')
+        #
+        # check('123\x00')
+        # # SF bug 1545497: embedded NULs were not detected with explicit base
+        # check('123\x00', 10)
+        # check('123\x00 245', 20)
+        # check('123\x00 245', 16)
+        # check('123\x00245', 20)
+        # check('123\x00245', 16)
+        #
+        # # lone surrogate in Unicode string
+        # check('123\ud800')
+        # check('123\ud800', 10)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_int_literal.py
+++ b/test/unit3/test_int_literal.py
@@ -1,0 +1,98 @@
+import sys
+import unittest
+
+class TestHexOctBin(unittest.TestCase):
+    def test_hex_baseline(self):
+        # A few upper/lowercase tests
+        self.assertEqual(0x0, 0X0)
+        self.assertEqual(0x1, 0X1)
+        self.assertEqual(0x123456789abcdef, 0X123456789abcdef)
+        # Baseline tests
+        self.assertEqual(0x0, 0)
+        self.assertEqual(0x10, 16)
+        self.assertEqual(0x7fffffff, 2147483647)
+        self.assertEqual(0x7fffffffffffffff, 9223372036854775807)
+        # Ditto with a minus sign and parentheses
+        self.assertEqual(-(0x0), 0)
+        self.assertEqual(-(0x10), -16)
+        self.assertEqual(-(0x7fffffff), -2147483647)
+        self.assertEqual(-(0x7fffffffffffffff), -9223372036854775807)
+        # Ditto with a minus sign and NO parentheses
+        self.assertEqual(-0x0, 0)
+        self.assertEqual(-0x10, -16)
+        self.assertEqual(-0x7fffffff, -2147483647)
+        self.assertEqual(-0x7fffffffffffffff, -9223372036854775807)
+
+    def test_hex_unsigned(self):
+        # Positive constants
+        self.assertEqual(0x80000000, 2147483648)
+        self.assertEqual(0xffffffff, 4294967295)
+        # Ditto with a minus sign and parentheses
+        self.assertEqual(-(0x80000000), -2147483648)
+        self.assertEqual(-(0xffffffff), -4294967295)
+        # Ditto with a minus sign and NO parentheses
+        # This failed in Python 2.2 through 2.2.2 and in 2.3a1
+        self.assertEqual(-0x80000000, -2147483648)
+        self.assertEqual(-0xffffffff, -4294967295)
+
+        # Positive constants
+        self.assertEqual(0x8000000000000000, 9223372036854775808)
+        self.assertEqual(0xffffffffffffffff, 18446744073709551615)
+        # Ditto with a minus sign and parentheses
+        self.assertEqual(-(0x8000000000000000), -9223372036854775808)
+        self.assertEqual(-(0xffffffffffffffff), -18446744073709551615)
+        # Ditto with a minus sign and NO parentheses
+        # This failed in Python 2.2 through 2.2.2 and in 2.3a1
+        self.assertEqual(-0x8000000000000000, -9223372036854775808)
+        self.assertEqual(-0xffffffffffffffff, -18446744073709551615)
+
+    def test_oct_baseline(self):
+        # A few upper/lowercase tests
+        self.assertEqual(0o0, 0O0)
+        self.assertEqual(0o1, 0O1)
+        self.assertEqual(0o1234567, 0O1234567)
+        # Baseline tests
+        self.assertEqual(0o0, 0)
+        self.assertEqual(0o20, 16)
+        self.assertEqual(0o17777777777, 2147483647)
+        self.assertEqual(0o777777777777777777777, 9223372036854775807)
+        # Ditto with a minus sign and parentheses
+        self.assertEqual(-(0o0), 0)
+        self.assertEqual(-(0o20), -16)
+        self.assertEqual(-(0o17777777777), -2147483647)
+        self.assertEqual(-(0o777777777777777777777), -9223372036854775807)
+        # Ditto with a minus sign and NO parentheses
+        self.assertEqual(-0o0, 0)
+        self.assertEqual(-0o20, -16)
+        self.assertEqual(-0o17777777777, -2147483647)
+        self.assertEqual(-0o777777777777777777777, -9223372036854775807)
+
+    def test_oct_unsigned(self):
+        # Positive constants
+        self.assertEqual(0o20000000000, 2147483648)
+        self.assertEqual(0o37777777777, 4294967295)
+        # Ditto with a minus sign and parentheses
+        self.assertEqual(-(0o20000000000), -2147483648)
+        self.assertEqual(-(0o37777777777), -4294967295)
+        # Ditto with a minus sign and NO parentheses
+        # This failed in Python 2.2 through 2.2.2 and in 2.3a1
+        self.assertEqual(-0o20000000000, -2147483648)
+        self.assertEqual(-0o37777777777, -4294967295)
+
+        # Positive constants
+        self.assertEqual(0o1000000000000000000000, 9223372036854775808)
+        self.assertEqual(0o1777777777777777777777, 18446744073709551615)
+        # Ditto with a minus sign and parentheses
+        self.assertEqual(-(0o1000000000000000000000), -9223372036854775808)
+        self.assertEqual(-(0o1777777777777777777777), -18446744073709551615)
+        # Ditto with a minus sign and NO parentheses
+        # This failed in Python 2.2 through 2.2.2 and in 2.3a1
+        self.assertEqual(-0o1000000000000000000000, -9223372036854775808)
+        self.assertEqual(-0o1777777777777777777777, -18446744073709551615)
+
+    """
+      we do not support binary literals
+    """
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_iter.py
+++ b/test/unit3/test_iter.py
@@ -1,0 +1,663 @@
+# Test iterators.
+
+import sys
+import unittest
+
+# Test result of triple loop (too big to inline)
+TRIPLETS = [(0, 0, 0), (0, 0, 1), (0, 0, 2),
+            (0, 1, 0), (0, 1, 1), (0, 1, 2),
+            (0, 2, 0), (0, 2, 1), (0, 2, 2),
+
+            (1, 0, 0), (1, 0, 1), (1, 0, 2),
+            (1, 1, 0), (1, 1, 1), (1, 1, 2),
+            (1, 2, 0), (1, 2, 1), (1, 2, 2),
+
+            (2, 0, 0), (2, 0, 1), (2, 0, 2),
+            (2, 1, 0), (2, 1, 1), (2, 1, 2),
+            (2, 2, 0), (2, 2, 1), (2, 2, 2)]
+
+# Helper classes
+
+class BasicIterClass:
+    def __init__(self, n):
+        self.n = n
+        self.i = 0
+    def __next__(self):
+        res = self.i
+        if res >= self.n:
+            raise StopIteration
+        self.i = res + 1
+        return res
+    def __iter__(self):
+        return self
+
+class IteratingSequenceClass:
+    def __init__(self, n):
+        self.n = n
+    def __iter__(self):
+        return BasicIterClass(self.n)
+
+class SequenceClass:
+    def __init__(self, n):
+        self.n = n
+    def __getitem__(self, i):
+        if 0 <= i < self.n:
+            return i
+        else:
+            raise IndexError
+
+class UnlimitedSequenceClass:
+    def __getitem__(self, i):
+        return i
+
+class DefaultIterClass:
+    pass
+
+class NoIterClass:
+    def __getitem__(self, i):
+        return i
+    __iter__ = None
+
+# Main test suite
+
+class TestCase(unittest.TestCase):
+
+    # # Helper to check that an iterator returns a given sequence
+    # def check_iterator(self, it, seq):
+    #     res = []
+    #     while 1:
+    #         try:
+    #             val = next(it)
+    #         except StopIteration:
+    #             break
+    #         res.append(val)
+    #     self.assertEqual(res, seq)
+
+    # # Helper to check that a for loop generates a given sequence
+    # def check_for_loop(self, expr, seq):
+    #     res = []
+    #     for val in expr:
+    #         res.append(val)
+    #     self.assertEqual(res, seq)
+
+
+    # # Test basic use of iter() function
+    # def test_iter_basic(self):
+    #     self.check_iterator(iter(range(10)), list(range(10)))
+
+    # Test that iter(iter(x)) is the same as iter(x)
+    def test_iter_idempotency(self):
+        seq = list(range(10))
+        it = iter(seq)
+        it2 = iter(it)
+        self.assertTrue(it is it2)
+
+    # # Test that for loops over iterators work
+    # def test_iter_for_loop(self):
+    #     self.check_for_loop(iter(range(10)), list(range(10)))
+
+    # Test several independent iterators over the same list
+    def test_iter_independence(self):
+        seq = range(3)
+        res = []
+        for i in iter(seq):
+            for j in iter(seq):
+                for k in iter(seq):
+                    res.append((i, j, k))
+        self.assertEqual(res, TRIPLETS)
+
+    # Test triple list comprehension using iterators
+    def test_nested_comprehensions_iter(self):
+        seq = range(3)
+        res = [(i, j, k)
+               for i in iter(seq) for j in iter(seq) for k in iter(seq)]
+        self.assertEqual(res, TRIPLETS)
+
+    # Test triple list comprehension without iterators
+    def test_nested_comprehensions_for(self):
+        seq = range(3)
+        res = [(i, j, k) for i in seq for j in seq for k in seq]
+        self.assertEqual(res, TRIPLETS)
+
+    # # Test a class with __iter__ in a for loop
+    # def test_iter_class_for(self):
+    #     self.check_for_loop(IteratingSequenceClass(10), list(range(10)))
+    #
+    # # Test a class with __iter__ with explicit iter()
+    # def test_iter_class_iter(self):
+    #     self.check_iterator(iter(IteratingSequenceClass(10)), list(range(10)))
+    #
+    # # Test for loop on a sequence class without __iter__
+    # def test_seq_class_for(self):
+    #     self.check_for_loop(SequenceClass(10), list(range(10)))
+    #
+    # # Test iter() on a sequence class without __iter__
+    # def test_seq_class_iter(self):
+    #     self.check_iterator(iter(SequenceClass(10)), list(range(10)))
+
+    def test_mutating_seq_class_exhausted_iter(self):
+        a = SequenceClass(5)
+        exhit = iter(a)
+        empit = iter(a)
+        for x in exhit:  # exhaust the iterator
+            next(empit)  # not exhausted
+        a.n = 7
+        # self.assertEqual(list(exhit), [])
+        self.assertEqual(list(empit), [5, 6])
+        self.assertEqual(list(a), [0, 1, 2, 3, 4, 5, 6])
+
+    # # Test a new_style class with __iter__ but no next() method
+    # def test_new_style_iter_class(self):
+    #     class IterClass(object):
+    #         def __iter__(self):
+    #             return self
+    #     self.assertRaises(TypeError, iter, IterClass())
+
+    # # Test two-argument iter() with callable instance
+    # def test_iter_callable(self):
+    #     class C:
+    #         def __init__(self):
+    #             self.i = 0
+    #         def __call__(self):
+    #             i = self.i
+    #             self.i = i + 1
+    #             if i > 100:
+    #                 raise IndexError # Emergency stop
+    #             return i
+    #     self.check_iterator(iter(C(), 10), list(range(10)), pickle=False)
+    #
+    # # Test two-argument iter() with function
+    # def test_iter_function(self):
+    #     def spam(state=[0]):
+    #         i = state[0]
+    #         state[0] = i+1
+    #         return i
+    #     self.check_iterator(iter(spam, 10), list(range(10)), pickle=False)
+
+    # # Test two-argument iter() with function that raises StopIteration
+    # def test_iter_function_stop(self):
+    #     def spam(state=[0]):
+    #         i = state[0]
+    #         if i == 10:
+    #             raise StopIteration
+    #         state[0] = i+1
+    #         return i
+    #     self.check_iterator(iter(spam, 20), list(range(10)), pickle=False)
+
+    # Test exception propagation through function iterator
+    def test_exception_function(self):
+        def spam(state=[0]):
+            i = state[0]
+            state[0] = i+1
+            if i == 10:
+                raise RuntimeError
+            return i
+        res = []
+        try:
+            for x in iter(spam, 20):
+                res.append(x)
+        except RuntimeError:
+            self.assertEqual(res, list(range(10)))
+        else:
+            self.fail("should have raised RuntimeError")
+
+    # Test exception propagation through sequence iterator
+    def test_exception_sequence(self):
+        class MySequenceClass(SequenceClass):
+            def __getitem__(self, i):
+                if i == 10:
+                    raise RuntimeError
+                return SequenceClass.__getitem__(self, i)
+        res = []
+        try:
+            for x in MySequenceClass(20):
+                res.append(x)
+        except RuntimeError:
+            self.assertEqual(res, list(range(10)))
+        else:
+            self.fail("should have raised RuntimeError")
+
+    # # Test for StopIteration from __getitem__
+    # def test_stop_sequence(self):
+    #     class MySequenceClass(SequenceClass):
+    #         def __getitem__(self, i):
+    #             if i == 10:
+    #                 raise StopIteration
+    #             return SequenceClass.__getitem__(self, i)
+    #     self.check_for_loop(MySequenceClass(20), list(range(10)), pickle=False)
+    #
+    # # Test a big range
+    # def test_iter_big_range(self):
+    #     self.check_for_loop(iter(range(10000)), list(range(10000)))
+    #
+    # # Test an empty list
+    # def test_iter_empty(self):
+    #     self.check_for_loop(iter([]), [])
+    #
+    # # Test a tuple
+    # def test_iter_tuple(self):
+    #     self.check_for_loop(iter((0,1,2,3,4,5,6,7,8,9)), list(range(10)))
+    #
+    # # Test a range
+    # def test_iter_range(self):
+    #     self.check_for_loop(iter(range(10)), list(range(10)))
+    #
+    # # Test a string
+    # def test_iter_string(self):
+    #     self.check_for_loop(iter("abcde"), ["a", "b", "c", "d", "e"])
+    #
+    # # Test a directory
+    # def test_iter_dict(self):
+    #     dict = {}
+    #     for i in range(10):
+    #         dict[i] = None
+    #     self.check_for_loop(dict, list(dict.keys()))
+
+    # Test list()'s use of iterators.
+    def test_builtin_list(self):
+        self.assertEqual(list(SequenceClass(5)), list(range(5)))
+        self.assertEqual(list(SequenceClass(0)), [])
+        self.assertEqual(list(()), [])
+
+        d = {"one": 1, "two": 2, "three": 3}
+        self.assertEqual(list(d), list(d.keys()))
+
+        self.assertRaises(TypeError, list, list)
+        self.assertRaises(TypeError, list, 42)
+
+    # Test tuples()'s use of iterators.
+    def test_builtin_tuple(self):
+        self.assertEqual(tuple(SequenceClass(5)), (0, 1, 2, 3, 4))
+        self.assertEqual(tuple(SequenceClass(0)), ())
+        self.assertEqual(tuple([]), ())
+        self.assertEqual(tuple(()), ())
+        self.assertEqual(tuple("abc"), ("a", "b", "c"))
+
+        d = {"one": 1, "two": 2, "three": 3}
+        self.assertEqual(tuple(d), tuple(d.keys()))
+
+        self.assertRaises(TypeError, tuple, list)
+        self.assertRaises(TypeError, tuple, 42)
+
+    # Test filter()'s use of iterators.
+    def test_builtin_filter(self):
+        self.assertEqual(list(filter(None, SequenceClass(5))),
+                         list(range(1, 5)))
+        self.assertEqual(list(filter(None, SequenceClass(0))), [])
+        self.assertEqual(list(filter(None, ())), [])
+        self.assertEqual(list(filter(None, "abc")), ["a", "b", "c"])
+
+        d = {"one": 1, "two": 2, "three": 3}
+        self.assertEqual(list(filter(None, d)), list(d.keys()))
+
+        self.assertRaises(TypeError, filter, None, list)
+        self.assertRaises(TypeError, filter, None, 42)
+
+        # class Boolean:
+        #     def __init__(self, truth):
+        #         self.truth = truth
+        #     def __bool__(self):
+        #         return self.truth
+        # bTrue = Boolean(True)
+        # bFalse = Boolean(False)
+        #
+        # class Seq:
+        #     def __init__(self, *args):
+        #         self.vals = args
+        #     def __iter__(self):
+        #         class SeqIter:
+        #             def __init__(self, vals):
+        #                 self.vals = vals
+        #                 self.i = 0
+        #             def __iter__(self):
+        #                 return self
+        #             def __next__(self):
+        #                 i = self.i
+        #                 self.i = i + 1
+        #                 if i < len(self.vals):
+        #                     return self.vals[i]
+        #                 else:
+        #                     raise StopIteration
+        #         return SeqIter(self.vals)
+        #
+        # seq = Seq(*([bTrue, bFalse] * 25))
+        # self.assertEqual(list(filter(lambda x: not x, seq)), [bFalse]*25)
+        # self.assertEqual(list(filter(lambda x: not x, iter(seq))), [bFalse]*25)
+
+    # Test max() and min()'s use of iterators.
+    def test_builtin_max_min(self):
+        self.assertEqual(max(SequenceClass(5)), 4)
+        self.assertEqual(min(SequenceClass(5)), 0)
+        self.assertEqual(max(8, -1), 8)
+        self.assertEqual(min(8, -1), -1)
+
+        d = {"one": 1, "two": 2, "three": 3}
+        self.assertEqual(max(d), "two")
+        self.assertEqual(min(d), "one")
+        self.assertEqual(max(d.values()), 3)
+        self.assertEqual(min(iter(d.values())), 1)
+
+    # Test map()'s use of iterators.
+    def test_builtin_map(self):
+        self.assertEqual(list(map(lambda x: x+1, SequenceClass(5))),
+                         list(range(1, 6)))
+
+        d = {"one": 1, "two": 2, "three": 3}
+        self.assertEqual(list(map(lambda k, d=d: (k, d[k]), d)),
+                         list(d.items()))
+        dkeys = list(d.keys())
+        expected = [(i < len(d) and dkeys[i] or None,
+                     i,
+                     i < len(d) and dkeys[i] or None)
+                    for i in range(3)]
+
+    # Test zip()'s use of iterators.
+    def test_builtin_zip(self):
+        self.assertEqual(list(zip()), [])
+        self.assertEqual(list(zip(*[])), [])
+        self.assertEqual(list(zip(*[(1, 2), 'ab'])), [(1, 'a'), (2, 'b')])
+
+        self.assertRaises(TypeError, zip, None)
+        self.assertRaises(TypeError, zip, range(10), 42)
+        self.assertRaises(TypeError, zip, range(10), zip)
+
+        # self.assertEqual(list(zip(IteratingSequenceClass(3))),
+        #                  [(0,), (1,), (2,)])
+        self.assertEqual(list(zip(SequenceClass(3))),
+                         [(0,), (1,), (2,)])
+
+        d = {"one": 1, "two": 2, "three": 3}
+        self.assertEqual(list(d.items()), list(zip(d, d.values())))
+
+        # Generate all ints starting at constructor arg.
+        class IntsFrom:
+            def __init__(self, start):
+                self.i = start
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                i = self.i
+                self.i = i+1
+                return i
+
+        self.assertEqual(list(zip(range(5))), [(i,) for i in range(5)])
+
+        # Classes that lie about their lengths.
+        class NoGuessLen5:
+            def __getitem__(self, i):
+                if i >= 5:
+                    raise IndexError
+                return i
+
+        class Guess3Len5(NoGuessLen5):
+            def __len__(self):
+                return 3
+
+        class Guess30Len5(NoGuessLen5):
+            def __len__(self):
+                return 30
+
+        def lzip(*args):
+            return list(zip(*args))
+
+        self.assertEqual(len(Guess3Len5()), 3)
+        self.assertEqual(len(Guess30Len5()), 30)
+        self.assertEqual(lzip(NoGuessLen5()), lzip(range(5)))
+        self.assertEqual(lzip(Guess3Len5()), lzip(range(5)))
+        self.assertEqual(lzip(Guess30Len5()), lzip(range(5)))
+
+        expected = [(i, i) for i in range(5)]
+        for x in NoGuessLen5(), Guess3Len5(), Guess30Len5():
+            for y in NoGuessLen5(), Guess3Len5(), Guess30Len5():
+                self.assertEqual(lzip(x, y), expected)
+
+    def test_unicode_join_endcase(self):
+
+        # This class inserts a Unicode object into its argument's natural
+        # iteration, in the 3rd position.
+        class OhPhooey:
+            def __init__(self, seq):
+                self.it = iter(seq)
+                self.i = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                i = self.i
+                self.i = i+1
+                if i == 2:
+                    return "fooled you!"
+                return next(self.it)
+
+    # Test iterators with 'x in y' and 'x not in y'.
+    def test_in_and_not_in(self):
+        # for sc5 in IteratingSequenceClass(5), SequenceClass(5):
+        #     for i in range(5):
+        #         self.assertIn(i, sc5)
+        #     for i in "abc", -1, 5, 42.42, (3, 4), [], {1: 1}, 3-12j, sc5:
+        #         self.assertNotIn(i, sc5)
+        #
+        self.assertRaises(TypeError, lambda: 3 in 12)
+        self.assertRaises(TypeError, lambda: 3 not in map)
+
+        d = {"one": 1, "two": 2, "three": 3, 1j: 2j}
+        for k in d:
+            self.assertIn(k, d)
+            self.assertNotIn(k, d.values())
+        for v in d.values():
+            self.assertIn(v, d.values())
+            self.assertNotIn(v, d)
+        for k, v in d.items():
+            self.assertIn((k, v), d.items())
+            self.assertNotIn((v, k), d.items())
+
+
+    # Test iterators with operator.countOf (PySequence_Count).
+    def test_countOf(self):
+        from operator import countOf
+        self.assertEqual(countOf([1,2,2,3,2,5], 2), 3)
+        self.assertEqual(countOf((1,2,2,3,2,5), 2), 3)
+        self.assertEqual(countOf("122325", "2"), 3)
+        self.assertEqual(countOf("122325", "6"), 0)
+
+        self.assertRaises(TypeError, countOf, 42, 1)
+        self.assertRaises(TypeError, countOf, countOf, countOf)
+
+        d = {"one": 3, "two": 3, "three": 3, 1j: 2j}
+        for k in d:
+            self.assertEqual(countOf(d, k), 1)
+        self.assertEqual(countOf(d.values(), 3), 3)
+        self.assertEqual(countOf(d.values(), 2j), 1)
+        self.assertEqual(countOf(d.values(), 1j), 0)
+
+
+    # Test iterators with operator.indexOf (PySequence_Index).
+    def test_indexOf(self):
+        from operator import indexOf
+        self.assertEqual(indexOf([1,2,2,3,2,5], 1), 0)
+        self.assertEqual(indexOf((1,2,2,3,2,5), 2), 1)
+        self.assertEqual(indexOf((1,2,2,3,2,5), 3), 3)
+        self.assertEqual(indexOf((1,2,2,3,2,5), 5), 5)
+        self.assertRaises(ValueError, indexOf, (1,2,2,3,2,5), 0)
+        self.assertRaises(ValueError, indexOf, (1,2,2,3,2,5), 6)
+
+        self.assertEqual(indexOf("122325", "2"), 1)
+        self.assertEqual(indexOf("122325", "5"), 5)
+        self.assertRaises(ValueError, indexOf, "122325", "6")
+
+        self.assertRaises(TypeError, indexOf, 42, 1)
+        self.assertRaises(TypeError, indexOf, indexOf, indexOf)
+
+
+        iclass = IteratingSequenceClass(3)
+        # for i in range(3):
+        #     self.assertEqual(indexOf(iclass, i), i)
+        # self.assertRaises(ValueError, indexOf, iclass, -1)
+
+
+    # Test iterators on RHS of unpacking assignments.
+    def test_unpack_iter(self):
+        a, b = 1, 2
+        self.assertEqual((a, b), (1, 2))
+
+        # a, b, c = IteratingSequenceClass(3)
+        # self.assertEqual((a, b, c), (0, 1, 2))
+        #
+        # try:    # too many values
+        #     a, b = IteratingSequenceClass(3)
+        # except ValueError:
+        #     pass
+        # else:
+        #     self.fail("should have raised ValueError")
+        #
+        # try:    # not enough values
+        #     a, b, c = IteratingSequenceClass(2)
+        # except ValueError:
+        #     pass
+        # else:
+        #     self.fail("should have raised ValueError")
+        #
+        # try:    # not iterable
+        #     a, b, c = len
+        # except TypeError:
+        #     pass
+        # else:
+        #     self.fail("should have raised TypeError")
+
+        a, b, c = {1: 42, 2: 42, 3: 42}.values()
+        self.assertEqual((a, b, c), (42, 42, 42))
+
+
+        # (a, b), (c,) = IteratingSequenceClass(2), {42: 24}
+        # self.assertEqual((a, b, c), (0, 1, 42))
+
+
+    def test_ref_counting_behavior(self):
+        class C(object):
+            count = 0
+            def __new__(cls):
+                cls.count += 1
+                return object.__new__(cls)
+            def __del__(self):
+                cls = self.__class__
+                assert cls.count > 0
+                cls.count -= 1
+        # x = C()
+        # self.assertEqual(C.count, 1)
+        # del x
+        # self.assertEqual(C.count, 0)
+        # l = [C(), C(), C()]
+        # self.assertEqual(C.count, 3)
+        # try:
+        #     a, b = iter(l)
+        # except ValueError:
+        #     pass
+        # del l
+        # self.assertEqual(C.count, 0)
+
+
+    # Make sure StopIteration is a "sink state".
+    # This tests various things that weren't sink states in Python 2.2.1,
+    # plus various things that always were fine.
+
+    def test_sinkstate_list(self):
+        # This used to fail
+        a = list(range(5))
+        b = iter(a)
+        self.assertEqual(list(b), list(range(5)))
+        a.extend(range(5, 10))
+        self.assertEqual(list(b), [])
+
+    def test_sinkstate_tuple(self):
+        a = (0, 1, 2, 3, 4)
+        b = iter(a)
+        self.assertEqual(list(b), list(range(5)))
+        self.assertEqual(list(b), [])
+
+    def test_sinkstate_string(self):
+        a = "abcde"
+        b = iter(a)
+        self.assertEqual(list(b), ['a', 'b', 'c', 'd', 'e'])
+        self.assertEqual(list(b), [])
+
+    def test_sinkstate_sequence(self):
+        # This used to fail
+        a = SequenceClass(5)
+        b = iter(a)
+        self.assertEqual(list(b), list(range(5)))
+        a.n = 10
+        # self.assertEqual(list(b), [])
+
+    def test_sinkstate_callable(self):
+        # This used to fail
+        def spam(state=[0]):
+            i = state[0]
+            state[0] = i+1
+            if i == 10:
+                raise AssertionError("shouldn't have gotten this far")
+            return i
+        b = iter(spam, 5)
+        self.assertEqual(list(b), list(range(5)))
+        self.assertEqual(list(b), [])
+
+    def test_sinkstate_dict(self):
+        # XXX For a more thorough test, see towards the end of:
+        # http://mail.python.org/pipermail/python-dev/2002-July/026512.html
+        a = {1:1, 2:2, 0:0, 4:4, 3:3}
+        for b in iter(a), a.keys(), a.items(), a.values():
+            b = iter(a)
+            self.assertEqual(len(list(b)), 5)
+            self.assertEqual(list(b), [])
+
+    def test_sinkstate_yield(self):
+        def gen():
+            for i in range(5):
+                yield i
+        b = gen()
+        self.assertEqual(list(b), list(range(5)))
+        self.assertEqual(list(b), [])
+
+    def test_sinkstate_range(self):
+        a = range(5)
+        b = iter(a)
+        self.assertEqual(list(b), list(range(5)))
+        self.assertEqual(list(b), [])
+
+    def test_sinkstate_enumerate(self):
+        a = range(5)
+        e = enumerate(a)
+        b = iter(e)
+        self.assertEqual(list(b), list(zip(range(5), range(5))))
+        self.assertEqual(list(b), [])
+
+    def test_extending_list_with_iterator_does_not_segfault(self):
+        # The code to extend a list with an iterator has a fair
+        # amount of nontrivial logic in terms of guessing how
+        # much memory to allocate in advance, "stealing" refs,
+        # and then shrinking at the end.  This is a basic smoke
+        # test for that scenario.
+        def gen():
+            for i in range(500):
+                yield i
+        lst = [0] * 500
+        for i in range(240):
+            lst.pop(0)
+        lst.extend(gen())
+        self.assertEqual(len(lst), 760)
+
+    def test_iter_neg_setstate(self):
+        it = iter(UnlimitedSequenceClass())
+        # it.__setstate__(-42)
+        self.assertEqual(next(it), 0)
+        self.assertEqual(next(it), 1)
+
+    def test_error_iter(self):
+        for typ in (DefaultIterClass, NoIterClass):
+            self.assertRaises(TypeError, iter, typ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_list.py
+++ b/test/unit3/test_list.py
@@ -44,14 +44,14 @@ class IterInheritsTestCase(unittest.TestCase):
                     self.current += 1
                     return self.current - 1
 
-        l = list(Counter(1,12))
-        self.assertTrue(5 in l)
+        # l = list(Counter(1,12))
+        # self.assertTrue(5 in l)
 
-        class Foo(Counter):
-            pass
-
-        l = list(Foo(100,120))
-        self.assertTrue(105 in l)
+        # class Foo(Counter):
+        #     pass
+        #
+        # l = list(Foo(100,120))
+        # self.assertTrue(105 in l)
 
     def test_str(self):
         l = list("this is a sequence")

--- a/test/unit3/test_list.py
+++ b/test/unit3/test_list.py
@@ -1,0 +1,276 @@
+"""Test compiler changes for unary ops (+, -, ~) introduced in Python 2.2"""
+
+import unittest
+
+
+class IterInheritsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.type2test = list
+
+    def test_generator(self):
+        def counter(low, high):
+            current = low
+            while current <= high:
+                yield current
+                current += 1
+
+        l = list(counter(1,12))
+        t = 4 in l
+        self.assertTrue(t)
+
+    def test_getitem(self):
+        class Counter:
+           def __getitem__(self,idx):
+              if idx < 13:
+                 return idx
+              else:
+                 raise StopIteration
+        l = list(Counter())
+        self.assertTrue(5 in l)
+
+    def test_dunderiter(self):
+        class Counter:
+            def __init__(self, low, high):
+                self.current = low
+                self.high = high
+
+            def __iter__(self):
+                return self
+
+            def __next__(self): # Python 3: def __next__(self)
+                if self.current > self.high:
+                    raise StopIteration
+                else:
+                    self.current += 1
+                    return self.current - 1
+
+        l = list(Counter(1,12))
+        self.assertTrue(5 in l)
+
+        class Foo(Counter):
+            pass
+
+        l = list(Foo(100,120))
+        self.assertTrue(105 in l)
+
+    def test_str(self):
+        l = list("this is a sequence")
+        self.assertTrue("q" in l)
+
+
+    def test_reversed(self):
+        a = list(range(20))
+        r = sorted(a,reverse=True)
+        self.assertEqual(list(r), list(range(19, -1, -1)))
+
+    def test_explicit_not_reversed(self):
+        a = list(range(20))
+        r = sorted(a,reverse=False)
+        self.assertEqual(r, a)
+
+    def test_delitem(self):
+        self.type2test = list
+        a = self.type2test([0, 1])
+        del a[1]
+        self.assertEqual(a, [0])
+        del a[0]
+        self.assertEqual(a, [])
+
+        a = self.type2test([0, 1])
+        del a[-2]
+        self.assertEqual(a, [1])
+        del a[-1]
+        self.assertEqual(a, [])
+
+        # todo: why __delitem__ not found?
+        # a = self.type2test([0, 1])
+        # self.assertRaises(IndexError, a.__delitem__, -3)
+        # self.assertRaises(IndexError, a.__delitem__, 2)
+        #
+        # a = self.type2test([])
+        # self.assertRaises(IndexError, a.__delitem__, 0)
+        #
+        # self.assertRaises(TypeError, a.__delitem__)
+
+    def test_set_subscript(self):
+        self.type2test = list
+        a = self.type2test(range(20))
+        # todo: again __setitem__ not found
+        # self.assertRaises(ValueError, a.__setitem__, slice(0, 10, 0), [1,2,3])
+        # self.assertRaises(TypeError, a.__setitem__, slice(0, 10), 1)
+        # self.assertRaises(ValueError, a.__setitem__, slice(0, 10, 2), [1,2])
+        # self.assertRaises(TypeError, a.__getitem__, 'x', 1)
+        a[slice(2,10,3)] = [1,2,3]
+        self.assertEqual(a, self.type2test([0, 1, 1, 3, 4, 2, 6, 7, 3,
+                                            9, 10, 11, 12, 13, 14, 15,
+                                            16, 17, 18, 19]))
+
+    def test_append(self):
+        self.type2test = list
+        a = self.type2test([])
+        a.append(0)
+        a.append(1)
+        a.append(2)
+        self.assertEqual(a, self.type2test([0, 1, 2]))
+
+        self.assertRaises(TypeError, a.append)
+
+    def test_extend(self):
+        self.type2test = list
+        a1 = self.type2test([0])
+        a2 = self.type2test((0, 1))
+        a = a1[:]
+        a.extend(a2)
+        self.assertEqual(a, a1 + a2)
+
+        a.extend(self.type2test([]))
+        self.assertEqual(a, a1 + a2)
+
+        a.extend(a)
+        self.assertEqual(a, self.type2test([0, 0, 1, 0, 0, 1]))
+
+        a = self.type2test("spam")
+        a.extend("eggs")
+        self.assertEqual(a, list("spameggs"))
+
+        self.assertRaises(TypeError, a.extend, None)
+
+    def test_insert(self):
+        a = self.type2test([0, 1, 2])
+        a.insert(0, -2)
+        a.insert(1, -1)
+        a.insert(2, 0)
+        self.assertEqual(a, [-2, -1, 0, 0, 1, 2])
+
+        b = a[:]
+        b.insert(-2, "foo")
+        b.insert(-200, "left")
+        b.insert(200, "right")
+        self.assertEqual(b, self.type2test(["left",-2,-1,0,0,"foo",1,2,"right"]))
+
+        self.assertRaises(TypeError, a.insert)
+
+    def test_pop(self):
+        a = self.type2test([-1, 0, 1])
+        a.pop()
+        self.assertEqual(a, [-1, 0])
+        a.pop(0)
+        self.assertEqual(a, [0])
+        self.assertRaises(IndexError, a.pop, 5)
+        a.pop(0)
+        self.assertEqual(a, [])
+        self.assertRaises(IndexError, a.pop)
+        self.assertRaises(TypeError, a.pop, 42, 42)
+        a = self.type2test([0, 10, 20, 30, 40])
+
+    def test_remove(self):
+        a = self.type2test([0, 0, 1])
+        a.remove(1)
+        self.assertEqual(a, [0, 0])
+        a.remove(0)
+        self.assertEqual(a, [0])
+        a.remove(0)
+        self.assertEqual(a, [])
+
+        self.assertRaises(ValueError, a.remove, 0)
+
+        self.assertRaises(TypeError, a.remove)
+
+    def test_count(self):
+        a = self.type2test([0, 1, 2])*3
+        self.assertEqual(a.count(0), 3)
+        self.assertEqual(a.count(1), 3)
+        self.assertEqual(a.count(3), 0)
+
+        self.assertRaises(TypeError, a.count)
+
+        # class BadExc(Exception):
+        #     pass
+        #
+        # class BadCmp:
+        #     def __eq__(self, other):
+        #         if other == 2:
+        #             raise BadExc()
+        #         return False
+        #
+        # self.assertRaises(BadExc, a.count, BadCmp())
+
+    def test_index(self):
+        u = self.type2test([0, 1])
+        self.assertEqual(u.index(0), 0)
+        self.assertEqual(u.index(1), 1)
+        self.assertRaises(ValueError, u.index, 2)
+
+        u = self.type2test([-2, -1, 0, 0, 1, 2])
+        self.assertEqual(u.count(0), 2)
+        self.assertEqual(u.index(0), 2)
+        self.assertEqual(u.index(0, 2), 2)
+        self.assertEqual(u.index(-2, -10), 0)
+        self.assertEqual(u.index(0, 3), 3)
+        self.assertEqual(u.index(0, 3, 4), 3)
+        self.assertRaises(ValueError, u.index, 2, 0, -10)
+
+        self.assertRaises(TypeError, u.index)
+
+        # class BadExc(Exception):
+        #     pass
+        #
+        # class BadCmp:
+        #     def __eq__(self, other):
+        #         if other == 2:
+        #             raise BadExc()
+        #         return False
+        #
+        # a = self.type2test([0, 1, 2, 3])
+        # self.assertRaises(BadExc, a.index, BadCmp())
+
+    def test_slice(self):
+        u = self.type2test("spam")
+        u[:2] = "h"
+        self.assertEqual(u, list("ham"))
+
+    def test_extendedslicing(self):
+        #  subscript
+        a = self.type2test([0,1,2,3,4])
+
+        #  deletion
+        del a[::2]
+        self.assertEqual(a, self.type2test([1,3]))
+        a = self.type2test(range(5))
+        del a[1::2]
+        self.assertEqual(a, self.type2test([0,2,4]))
+        a = self.type2test(range(5))
+        del a[1::-2]
+        self.assertEqual(a, self.type2test([0,2,3,4]))
+        a = self.type2test(range(10))
+        del a[::1000]
+        self.assertEqual(a, self.type2test([1, 2, 3, 4, 5, 6, 7, 8, 9]))
+        #  assignment
+        a = self.type2test(range(10))
+        a[::2] = [-1]*5
+        self.assertEqual(a, self.type2test([-1, 1, -1, 3, -1, 5, -1, 7, -1, 9]))
+        a = self.type2test(range(10))
+        a[::-4] = [10]*3
+        self.assertEqual(a, self.type2test([0, 10, 2, 3, 4, 10, 6, 7, 8 ,10]))
+        # todo:  this odd test fails
+        # a = self.type2test(range(4))
+        # a[::-1] = a
+        # self.assertEqual(a, self.type2test([3, 2, 1, 0]))
+        a = self.type2test(range(10))
+        b = a[:]
+        c = a[:]
+        a[2:3] = self.type2test(["two", "elements"])
+        b[slice(2,3)] = self.type2test(["two", "elements"])
+        c[2:3:] = self.type2test(["two", "elements"])
+        self.assertEqual(a, b)
+        self.assertEqual(a, c)
+        a = self.type2test(range(10))
+        a[::2] = tuple(range(5))
+        self.assertEqual(a, self.type2test([0, 1, 1, 3, 2, 5, 3, 7, 4, 9]))
+        # test issue7788
+        a = self.type2test(range(10))
+        del a[9::1<<333]
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/unit3/test_list_sort.py
+++ b/test/unit3/test_list_sort.py
@@ -13,16 +13,16 @@ class ListSort(unittest.TestCase):
         x.sort(reverse=False)
         self.assertEqual(x, [1,2,3])
 
-    def test_revserNoneShouldThrowError(self):
-        x = [1,2,3]
-        try:
-            x.sort(reverse=None)
-        except TypeError as e:
-            self.assertEqual(str(e), "an integer is required (got type NoneType)")
-            # changed from self.assertEqual(str(e), "TypeError: an integer is required on line 19")
-            return
-
-        self.fail("Test should have thrown exception")
+    # def test_revserNoneShouldThrowError(self):
+    #     x = [1,2,3]
+    #     try:
+    #         x.sort(reverse=None)
+    #     except TypeError as e:
+    #         self.assertEqual(str(e), "an integer is required (got type NoneType)")
+    #         # changed from self.assertEqual(str(e), "TypeError: an integer is required on line 19")
+    #         return
+    #
+    #     self.fail("Test should have thrown exception")
 
     def test_reverseShouldAllowInts(self):
         x = [1,2,3]

--- a/test/unit3/test_list_sort.py
+++ b/test/unit3/test_list_sort.py
@@ -1,0 +1,35 @@
+__author__ = 'albertjan'
+
+# unit test files should be named test_<your name here>.py
+# this ensures they will automatically be included in the
+# ./skulpt.py test or ./skulpt.py dist testing procedures
+#
+
+import unittest
+
+class ListSort(unittest.TestCase):
+    def test_sortReverseFalseShouldWork(self):
+        x = [1,2,3]
+        x.sort(reverse=False)
+        self.assertEqual(x, [1,2,3])
+
+    def test_revserNoneShouldThrowError(self):
+        x = [1,2,3]
+        try:
+            x.sort(reverse=None)
+        except TypeError as e:
+            self.assertEqual(str(e), "an integer is required (got type NoneType)")
+            # changed from self.assertEqual(str(e), "TypeError: an integer is required on line 19")
+            return
+
+        self.fail("Test should have thrown exception")
+
+    def test_reverseShouldAllowInts(self):
+        x = [1,2,3]
+        x.sort(reverse=-6)
+        self.assertEqual(x, [3,2,1])
+        x.sort(reverse=0)
+        self.assertEqual(x, [1,2,3])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_math.py
+++ b/test/unit3/test_math.py
@@ -1,0 +1,1038 @@
+# Python test set -- math module
+# XXXX Should not do tests around zero only
+
+import unittest
+import math
+import sys
+
+eps = 1E-05
+NAN = float('nan')
+INF = float('inf')
+NINF = float('-inf')
+
+# detect evidence of double-rounding: fsum is not always correctly
+# rounded on machines that suffer from double rounding.
+x, y = 1e16, 2.9999 # use temporary values to defeat peephole optimizer
+HAVE_DOUBLE_ROUNDING = (x + y == 1e16 + 4)
+
+
+
+# def to_ulps(x):
+#     """Convert a non-NaN float x to an integer, in such a way that
+#     adjacent floats are converted to adjacent integers.  Then
+#     abs(ulps(x) - ulps(y)) gives the difference in ulps between two
+#     floats.
+#
+#     The results from this function will only make sense on platforms
+#     where native doubles are represented in IEEE 754 binary64 format.
+#
+#     Note: 0.0 and -0.0 are converted to 0 and -1, respectively.
+#     """
+#     n = struct.unpack('<q', struct.pack('<d', x))[0]
+#     if n < 0:
+#         n = ~(n+2**63)
+#     return n
+
+
+def ulp(x):
+    """Return the value of the least significant bit of a
+    float x, such that the first float bigger than x is x+ulp(x).
+    Then, given an expected result x and a tolerance of n ulps,
+    the result y should be such that abs(y-x) <= n * ulp(x).
+    The results from this function will only make sense on platforms
+    where native doubles are represented in IEEE 754 binary64 format.
+    """
+    x = abs(float(x))
+    if math.isnan(x) or math.isinf(x):
+        return x
+
+    # # Find next float up from x.
+    # n = struct.unpack('<q', struct.pack('<d', x))[0]
+    # x_next = struct.unpack('<d', struct.pack('<q', n + 1))[0]
+    # if math.isinf(x_next):
+    #     # Corner case: x was the largest finite float. Then it's
+    #     # not an exact power of two, so we can take the difference
+    #     # between x and the previous float.
+    #     x_prev = struct.unpack('<d', struct.pack('<q', n - 1))[0]
+    #     return x - x_prev
+    # else:
+    #     return x_next - x
+
+# Here's a pure Python version of the math.factorial algorithm, for
+# documentation and comparison purposes.
+#
+# Formula:
+#
+#   factorial(n) = factorial_odd_part(n) << (n - count_set_bits(n))
+#
+# where
+#
+#   factorial_odd_part(n) = product_{i >= 0} product_{0 < j <= n >> i; j odd} j
+#
+# The outer product above is an infinite product, but once i >= n.bit_length,
+# (n >> i) < 1 and the corresponding term of the product is empty.  So only the
+# finitely many terms for 0 <= i < n.bit_length() contribute anything.
+#
+# We iterate downwards from i == n.bit_length() - 1 to i == 0.  The inner
+# product in the formula above starts at 1 for i == n.bit_length(); for each i
+# < n.bit_length() we get the inner product for i from that for i + 1 by
+# multiplying by all j in {n >> i+1 < j <= n >> i; j odd}.  In Python terms,
+# this set is range((n >> i+1) + 1 | 1, (n >> i) + 1 | 1, 2).
+
+def count_set_bits(n):
+    """Number of '1' bits in binary expansion of a nonnnegative integer."""
+    return 1 + count_set_bits(n & n - 1) if n else 0
+
+def partial_product(start, stop):
+    """Product of integers in range(start, stop, 2), computed recursively.
+    start and stop should both be odd, with start <= stop.
+
+    """
+    numfactors = (stop - start) >> 1
+    if not numfactors:
+        return 1
+    elif numfactors == 1:
+        return start
+    else:
+        mid = (start + numfactors) | 1
+        return partial_product(start, mid) * partial_product(mid, stop)
+
+def ulp_abs_check(expected, got, ulp_tol, abs_tol):
+    """Given finite floats `expected` and `got`, check that they're
+    approximately equal to within the given number of ulps or the
+    given absolute tolerance, whichever is bigger.
+
+    Returns None on success and an error message on failure.
+    """
+    # ulp_error = abs(to_ulps(expected) - to_ulps(got))
+    abs_error = abs(expected - got)
+
+    # Succeed if either abs_error <= abs_tol or ulp_error <= ulp_tol.
+    # if abs_error <= abs_tol or ulp_error <= ulp_tol:
+    #     return None
+    # else:
+    #     fmt = ("error = {:.3g} ({:d} ulps); "
+    #            "permitted error = {:.3g} or {:d} ulps")
+    #     return fmt.format(abs_error, ulp_error, abs_tol, ulp_tol)
+
+def result_check(expected, got, ulp_tol=5, abs_tol=0.0):
+    # Common logic of MathTests.(ftest, test_testcases, test_mtestcases)
+    """Compare arguments expected and got, as floats, if either
+    is a float, using a tolerance expressed in multiples of
+    ulp(expected) or absolutely (if given and greater).
+
+    As a convenience, when neither argument is a float, and for
+    non-finite floats, exact equality is demanded. Also, nan==nan
+    as far as this function is concerned.
+
+    Returns None on success and an error message on failure.
+    """
+
+    # Check exactly equal (applies also to strings representing exceptions)
+    if got == expected:
+        return None
+
+    failure = "not equal"
+
+    # Turn mixed float and int comparison (e.g. floor()) to all-float
+    if isinstance(expected, float) and isinstance(got, int):
+        got = float(got)
+    elif isinstance(got, float) and isinstance(expected, int):
+        expected = float(expected)
+
+    if isinstance(expected, float) and isinstance(got, float):
+        if math.isnan(expected) and math.isnan(got):
+            # Pass, since both nan
+            failure = None
+        elif math.isinf(expected) or math.isinf(got):
+            # We already know they're not equal, drop through to failure
+            pass
+        else:
+            # Both are finite floats (now). Are they close enough?
+            failure = ulp_abs_check(expected, got, ulp_tol, abs_tol)
+
+    # arguments are not equal, and if numeric, are too far apart
+    if failure is not None:
+        fail_fmt = "expected {!r}, got {!r}"
+        fail_msg = fail_fmt.format(expected, got)
+        fail_msg += ' ({})'.format(failure)
+        return fail_msg
+    else:
+        return None
+
+# Class providing an __index__ method.
+class MyIndexable(object):
+    def __init__(self, value):
+        self.value = value
+
+    def __index__(self):
+        return self.value
+
+class MathTests(unittest.TestCase):
+
+    def ftest(self, name, got, expected, ulp_tol=5, abs_tol=0.0):
+        """Compare arguments expected and got, as floats, if either
+        is a float, using a tolerance expressed in multiples of
+        ulp(expected) or absolutely, whichever is greater.
+
+        As a convenience, when neither argument is a float, and for
+        non-finite floats, exact equality is demanded. Also, nan==nan
+        in this function.
+        """
+        failure = result_check(expected, got, ulp_tol, abs_tol)
+        if failure is not None:
+            self.fail("{}: {}".format(name, failure))
+
+    def testConstants(self):
+        # Ref: Abramowitz & Stegun (Dover, 1965)
+        self.ftest('pi', math.pi, 3.141592653589793238462643)
+        self.ftest('e', math.e, 2.718281828459045235360287)
+        # self.assertEqual(math.tau, 2*math.pi)
+
+    def testAcos(self):
+        self.assertRaises(TypeError, math.acos)
+        self.ftest('acos(-1)', math.acos(-1), math.pi)
+        self.ftest('acos(0)', math.acos(0), math.pi/2)
+        self.ftest('acos(1)', math.acos(1), 0)
+        # self.assertRaises(ValueError, math.acos, INF)
+        # self.assertRaises(ValueError, math.acos, NINF)
+        # self.assertRaises(ValueError, math.acos, 1 + eps)
+        # self.assertRaises(ValueError, math.acos, -1 - eps)
+        self.assertTrue(math.isnan(math.acos(NAN)))
+
+    def testAcosh(self):
+        self.assertRaises(TypeError, math.acosh)
+        self.ftest('acosh(1)', math.acosh(1), 0)
+        # self.ftest('acosh(2)', math.acosh(2), 1.3169578969248168)
+        # self.assertRaises(ValueError, math.acosh, 0)
+        # self.assertRaises(ValueError, math.acosh, -1)
+        self.assertEqual(math.acosh(INF), INF)
+        # self.assertRaises(ValueError, math.acosh, NINF)
+        self.assertTrue(math.isnan(math.acosh(NAN)))
+
+    def testAsin(self):
+        self.assertRaises(TypeError, math.asin)
+        self.ftest('asin(-1)', math.asin(-1), -math.pi/2)
+        self.ftest('asin(0)', math.asin(0), 0)
+        self.ftest('asin(1)', math.asin(1), math.pi/2)
+        # self.assertRaises(ValueError, math.asin, INF)
+        # self.assertRaises(ValueError, math.asin, NINF)
+        # self.assertRaises(ValueError, math.asin, 1 + eps)
+        # self.assertRaises(ValueError, math.asin, -1 - eps)
+        self.assertTrue(math.isnan(math.asin(NAN)))
+
+    def testAsinh(self):
+        self.assertRaises(TypeError, math.asinh)
+        self.ftest('asinh(0)', math.asinh(0), 0)
+        self.ftest('asinh(1)', math.asinh(1), 0.88137358701954305)
+        self.ftest('asinh(-1)', math.asinh(-1), -0.88137358701954305)
+        self.assertEqual(math.asinh(INF), INF)
+        # self.assertEqual(math.asinh(NINF), NINF)
+        self.assertTrue(math.isnan(math.asinh(NAN)))
+
+    def testAtan(self):
+        self.assertRaises(TypeError, math.atan)
+        self.ftest('atan(-1)', math.atan(-1), -math.pi/4)
+        self.ftest('atan(0)', math.atan(0), 0)
+        self.ftest('atan(1)', math.atan(1), math.pi/4)
+        self.ftest('atan(inf)', math.atan(INF), math.pi/2)
+        self.ftest('atan(-inf)', math.atan(NINF), -math.pi/2)
+        self.assertTrue(math.isnan(math.atan(NAN)))
+
+    def testAtanh(self):
+        self.assertRaises(TypeError, math.atan)
+        self.ftest('atanh(0)', math.atanh(0), 0)
+        self.ftest('atanh(0.5)', math.atanh(0.5), 0.54930614433405489)
+        self.ftest('atanh(-0.5)', math.atanh(-0.5), -0.54930614433405489)
+        # self.assertRaises(ValueError, math.atanh, 1)
+        # self.assertRaises(ValueError, math.atanh, -1)
+        # self.assertRaises(ValueError, math.atanh, INF)
+        # self.assertRaises(ValueError, math.atanh, NINF)
+        self.assertTrue(math.isnan(math.atanh(NAN)))
+
+    def testAtan2(self):
+        self.assertRaises(TypeError, math.atan2)
+        self.ftest('atan2(-1, 0)', math.atan2(-1, 0), -math.pi/2)
+        self.ftest('atan2(-1, 1)', math.atan2(-1, 1), -math.pi/4)
+        self.ftest('atan2(0, 1)', math.atan2(0, 1), 0)
+        self.ftest('atan2(1, 1)', math.atan2(1, 1), math.pi/4)
+        self.ftest('atan2(1, 0)', math.atan2(1, 0), math.pi/2)
+
+        # math.atan2(0, x)
+        self.ftest('atan2(0., -inf)', math.atan2(0., NINF), math.pi)
+        self.ftest('atan2(0., -2.3)', math.atan2(0., -2.3), math.pi)
+        self.ftest('atan2(0., -0.)', math.atan2(0., -0.), math.pi)
+        self.assertEqual(math.atan2(0., 0.), 0.)
+        self.assertEqual(math.atan2(0., 2.3), 0.)
+        self.assertEqual(math.atan2(0., INF), 0.)
+        self.assertTrue(math.isnan(math.atan2(0., NAN)))
+        # math.atan2(-0, x)
+        self.ftest('atan2(-0., -inf)', math.atan2(-0., NINF), -math.pi)
+        self.ftest('atan2(-0., -2.3)', math.atan2(-0., -2.3), -math.pi)
+        self.ftest('atan2(-0., -0.)', math.atan2(-0., -0.), -math.pi)
+        self.assertEqual(math.atan2(-0., 0.), -0.)
+        self.assertEqual(math.atan2(-0., 2.3), -0.)
+        self.assertEqual(math.atan2(-0., INF), -0.)
+        self.assertTrue(math.isnan(math.atan2(-0., NAN)))
+        # math.atan2(INF, x)
+        self.ftest('atan2(inf, -inf)', math.atan2(INF, NINF), math.pi*3/4)
+        self.ftest('atan2(inf, -2.3)', math.atan2(INF, -2.3), math.pi/2)
+        self.ftest('atan2(inf, -0.)', math.atan2(INF, -0.0), math.pi/2)
+        self.ftest('atan2(inf, 0.)', math.atan2(INF, 0.0), math.pi/2)
+        self.ftest('atan2(inf, 2.3)', math.atan2(INF, 2.3), math.pi/2)
+        self.ftest('atan2(inf, inf)', math.atan2(INF, INF), math.pi/4)
+        self.assertTrue(math.isnan(math.atan2(INF, NAN)))
+        # math.atan2(NINF, x)
+        self.ftest('atan2(-inf, -inf)', math.atan2(NINF, NINF), -math.pi*3/4)
+        self.ftest('atan2(-inf, -2.3)', math.atan2(NINF, -2.3), -math.pi/2)
+        self.ftest('atan2(-inf, -0.)', math.atan2(NINF, -0.0), -math.pi/2)
+        self.ftest('atan2(-inf, 0.)', math.atan2(NINF, 0.0), -math.pi/2)
+        self.ftest('atan2(-inf, 2.3)', math.atan2(NINF, 2.3), -math.pi/2)
+        self.ftest('atan2(-inf, inf)', math.atan2(NINF, INF), -math.pi/4)
+        self.assertTrue(math.isnan(math.atan2(NINF, NAN)))
+        # math.atan2(+finite, x)
+        self.ftest('atan2(2.3, -inf)', math.atan2(2.3, NINF), math.pi)
+        self.ftest('atan2(2.3, -0.)', math.atan2(2.3, -0.), math.pi/2)
+        self.ftest('atan2(2.3, 0.)', math.atan2(2.3, 0.), math.pi/2)
+        self.assertEqual(math.atan2(2.3, INF), 0.)
+        self.assertTrue(math.isnan(math.atan2(2.3, NAN)))
+        # math.atan2(-finite, x)
+        self.ftest('atan2(-2.3, -inf)', math.atan2(-2.3, NINF), -math.pi)
+        self.ftest('atan2(-2.3, -0.)', math.atan2(-2.3, -0.), -math.pi/2)
+        self.ftest('atan2(-2.3, 0.)', math.atan2(-2.3, 0.), -math.pi/2)
+        self.assertEqual(math.atan2(-2.3, INF), -0.)
+        self.assertTrue(math.isnan(math.atan2(-2.3, NAN)))
+        # math.atan2(NAN, x)
+        self.assertTrue(math.isnan(math.atan2(NAN, NINF)))
+        self.assertTrue(math.isnan(math.atan2(NAN, -2.3)))
+        self.assertTrue(math.isnan(math.atan2(NAN, -0.)))
+        self.assertTrue(math.isnan(math.atan2(NAN, 0.)))
+        self.assertTrue(math.isnan(math.atan2(NAN, 2.3)))
+        self.assertTrue(math.isnan(math.atan2(NAN, INF)))
+        self.assertTrue(math.isnan(math.atan2(NAN, NAN)))
+
+    def testCeil(self):
+        self.assertRaises(TypeError, math.ceil)
+        self.assertEqual(int, type(math.ceil(0.5)))
+        self.ftest('ceil(0.5)', math.ceil(0.5), 1)
+        self.ftest('ceil(1.0)', math.ceil(1.0), 1)
+        self.ftest('ceil(1.5)', math.ceil(1.5), 2)
+        self.ftest('ceil(-0.5)', math.ceil(-0.5), 0)
+        self.ftest('ceil(-1.0)', math.ceil(-1.0), -1)
+        self.ftest('ceil(-1.5)', math.ceil(-1.5), -1)
+
+        class TestCeil:
+            def __ceil__(self):
+                return 42
+        class TestNoCeil:
+            pass
+        # self.ftest('ceil(TestCeil())', math.ceil(TestCeil()), 42)
+        self.assertRaises(TypeError, math.ceil, TestNoCeil())
+
+        t = TestNoCeil()
+        t.__ceil__ = lambda *args: args
+        self.assertRaises(TypeError, math.ceil, t)
+        self.assertRaises(TypeError, math.ceil, t, 0)
+
+    def testCopysign(self):
+        # self.assertEqual(math.copysign(1, 42), 1.0)
+        # self.assertEqual(math.copysign(0., 42), 0.0)
+        # self.assertEqual(math.copysign(1., -42), -1.0)
+        # self.assertEqual(math.copysign(3, 0.), 3.0)
+        # self.assertEqual(math.copysign(4., -0.), -4.0)
+
+        self.assertRaises(TypeError, math.copysign)
+        # copysign should let us distinguish signs of zeros
+        # self.assertEqual(math.copysign(1., 0.), 1.)
+        # self.assertEqual(math.copysign(1., -0.), -1.)
+        # self.assertEqual(math.copysign(INF, 0.), INF)
+        # self.assertEqual(math.copysign(INF, -0.), NINF)
+        # self.assertEqual(math.copysign(NINF, 0.), INF)
+        # self.assertEqual(math.copysign(NINF, -0.), NINF)
+        # and of infinities
+        # self.assertEqual(math.copysign(1., INF), 1.)
+        # self.assertEqual(math.copysign(1., NINF), -1.)
+        self.assertEqual(math.copysign(INF, INF), INF)
+        self.assertEqual(math.copysign(INF, NINF), NINF)
+        # self.assertEqual(math.copysign(NINF, INF), INF)
+        self.assertEqual(math.copysign(NINF, NINF), NINF)
+        # self.assertTrue(math.isnan(math.copysign(NAN, 1.)))
+        # self.assertTrue(math.isnan(math.copysign(NAN, INF)))
+        # self.assertTrue(math.isnan(math.copysign(NAN, NINF)))
+        self.assertTrue(math.isnan(math.copysign(NAN, NAN)))
+        # copysign(INF, NAN) may be INF or it may be NINF, since
+        # we don't know whether the sign bit of NAN is set on any
+        # given platform.
+        self.assertTrue(math.isinf(math.copysign(INF, NAN)))
+        # similarly, copysign(2., NAN) could be 2. or -2.
+        # self.assertEqual(abs(math.copysign(2., NAN)), 2.)
+
+    def testCos(self):
+        self.assertRaises(TypeError, math.cos)
+        self.ftest('cos(-pi/2)', math.cos(-math.pi/2), 0, abs_tol=ulp(1))
+        self.ftest('cos(0)', math.cos(0), 1)
+        self.ftest('cos(pi/2)', math.cos(math.pi/2), 0, abs_tol=ulp(1))
+        self.ftest('cos(pi)', math.cos(math.pi), -1)
+        try:
+            self.assertTrue(math.isnan(math.cos(INF)))
+            self.assertTrue(math.isnan(math.cos(NINF)))
+        except ValueError:
+            self.assertRaises(ValueError, math.cos, INF)
+            self.assertRaises(ValueError, math.cos, NINF)
+        self.assertTrue(math.isnan(math.cos(NAN)))
+
+    def testCosh(self):
+        self.assertRaises(TypeError, math.cosh)
+        self.ftest('cosh(0)', math.cosh(0), 1)
+        self.ftest('cosh(2)-2*cosh(1)**2', math.cosh(2)-2*math.cosh(1)**2, -1) # Thanks to Lambert
+        self.assertEqual(math.cosh(INF), INF)
+        self.assertEqual(math.cosh(NINF), INF)
+        self.assertTrue(math.isnan(math.cosh(NAN)))
+
+    def testDegrees(self):
+        self.assertRaises(TypeError, math.degrees)
+        self.ftest('degrees(pi)', math.degrees(math.pi), 180.0)
+        self.ftest('degrees(pi/2)', math.degrees(math.pi/2), 90.0)
+        self.ftest('degrees(-pi/4)', math.degrees(-math.pi/4), -45.0)
+        self.ftest('degrees(0)', math.degrees(0), 0)
+
+    def testExp(self):
+        self.assertRaises(TypeError, math.exp)
+        self.ftest('exp(-1)', math.exp(-1), 1/math.e)
+        self.ftest('exp(0)', math.exp(0), 1)
+        self.ftest('exp(1)', math.exp(1), math.e)
+        self.assertEqual(math.exp(INF), INF)
+        self.assertEqual(math.exp(NINF), 0.)
+        self.assertTrue(math.isnan(math.exp(NAN)))
+        # self.assertRaises(OverflowError, math.exp, 1000000)
+
+    def testFabs(self):
+        self.assertRaises(TypeError, math.fabs)
+        self.ftest('fabs(-1)', math.fabs(-1), 1)
+        self.ftest('fabs(0)', math.fabs(0), 0)
+        self.ftest('fabs(1)', math.fabs(1), 1)
+
+
+    def testFloor(self):
+        self.assertRaises(TypeError, math.floor)
+        self.assertEqual(int, type(math.floor(0.5)))
+        self.ftest('floor(0.5)', math.floor(0.5), 0)
+        self.ftest('floor(1.0)', math.floor(1.0), 1)
+        self.ftest('floor(1.5)', math.floor(1.5), 1)
+        self.ftest('floor(-0.5)', math.floor(-0.5), -1)
+        self.ftest('floor(-1.0)', math.floor(-1.0), -1)
+        self.ftest('floor(-1.5)', math.floor(-1.5), -2)
+        # pow() relies on floor() to check for integers
+        # This fails on some platforms - so check it here
+        self.ftest('floor(1.23e167)', math.floor(1.23e167), 1.23e167)
+        self.ftest('floor(-1.23e167)', math.floor(-1.23e167), -1.23e167)
+        #self.assertEqual(math.ceil(INF), INF)
+        #self.assertEqual(math.ceil(NINF), NINF)
+        #self.assertTrue(math.isnan(math.floor(NAN)))
+
+        class TestFloor:
+            def __floor__(self):
+                return 42
+        class TestNoFloor:
+            pass
+        # self.ftest('floor(TestFloor())', math.floor(TestFloor()), 42)
+        self.assertRaises(TypeError, math.floor, TestNoFloor())
+
+        t = TestNoFloor()
+        t.__floor__ = lambda *args: args
+        self.assertRaises(TypeError, math.floor, t)
+        self.assertRaises(TypeError, math.floor, t, 0)
+
+    # def testFmod(self):
+    #     self.assertRaises(TypeError, math.fmod)
+    #     self.ftest('fmod(10, 1)', math.fmod(10, 1), 0.0)
+    #     self.ftest('fmod(10, 0.5)', math.fmod(10, 0.5), 0.0)
+    #     self.ftest('fmod(10, 1.5)', math.fmod(10, 1.5), 1.0)
+    #     self.ftest('fmod(-10, 1)', math.fmod(-10, 1), -0.0)
+    #     self.ftest('fmod(-10, 0.5)', math.fmod(-10, 0.5), -0.0)
+    #     self.ftest('fmod(-10, 1.5)', math.fmod(-10, 1.5), -1.0)
+    #     self.assertTrue(math.isnan(math.fmod(NAN, 1.)))
+    #     self.assertTrue(math.isnan(math.fmod(1., NAN)))
+    #     self.assertTrue(math.isnan(math.fmod(NAN, NAN)))
+    #     self.assertRaises(ValueError, math.fmod, 1., 0.)
+    #     self.assertRaises(ValueError, math.fmod, INF, 1.)
+    #     self.assertRaises(ValueError, math.fmod, NINF, 1.)
+    #     self.assertRaises(ValueError, math.fmod, INF, 0.)
+    #     self.assertEqual(math.fmod(3.0, INF), 3.0)
+    #     self.assertEqual(math.fmod(-3.0, INF), -3.0)
+    #     self.assertEqual(math.fmod(3.0, NINF), 3.0)
+    #     self.assertEqual(math.fmod(-3.0, NINF), -3.0)
+    #     self.assertEqual(math.fmod(0.0, 3.0), 0.0)
+    #     self.assertEqual(math.fmod(0.0, NINF), 0.0)
+
+    # def testFrexp(self):
+    #     self.assertRaises(TypeError, math.frexp)
+    #
+    #     def testfrexp(name, result, expected):
+    #         (mant, exp), (emant, eexp) = result, expected
+    #         if abs(mant-emant) > eps or exp != eexp:
+    #             self.fail('%s returned %r, expected %r'%\
+    #                       (name, result, expected))
+    #
+    #     testfrexp('frexp(-1)', math.frexp(-1), (-0.5, 1))
+    #     testfrexp('frexp(0)', math.frexp(0), (0, 0))
+    #     testfrexp('frexp(1)', math.frexp(1), (0.5, 1))
+    #     testfrexp('frexp(2)', math.frexp(2), (0.5, 2))
+    #
+    #     self.assertEqual(math.frexp(INF)[0], INF)
+    #     self.assertEqual(math.frexp(NINF)[0], NINF)
+    #     self.assertTrue(math.isnan(math.frexp(NAN)[0]))
+
+    # def testFsum(self):
+    #     # math.fsum relies on exact rounding for correct operation.
+    #     # There's a known problem with IA32 floating-point that causes
+    #     # inexact rounding in some situations, and will cause the
+    #     # math.fsum tests below to fail; see issue #2937.  On non IEEE
+    #     # 754 platforms, and on IEEE 754 platforms that exhibit the
+    #     # problem described in issue #2937, we simply skip the whole
+    #     # test.
+    #
+    #     # Python version of math.fsum, for comparison.  Uses a
+    #     # different algorithm based on frexp, ldexp and integer
+    #     # arithmetic.
+    #     from sys import float_info
+    #     mant_dig = float_info.mant_dig
+    #     etiny = float_info.min_exp - mant_dig
+
+        # def msum(iterable):
+        #     """Full precision summation.  Compute sum(iterable) without any
+        #     intermediate accumulation of error.  Based on the 'lsum' function
+        #     at http://code.activestate.com/recipes/393090/
+        #
+        #     """
+        #     tmant, texp = 0, 0
+        #     for x in iterable:
+        #         mant, exp = math.frexp(x)
+        #         mant, exp = int(math.ldexp(mant, mant_dig)), exp - mant_dig
+        #         if texp > exp:
+        #             tmant <<= texp-exp
+        #             texp = exp
+        #         else:
+        #             mant <<= exp-texp
+        #         tmant += mant
+        #     # Round tmant * 2**texp to a float.  The original recipe
+        #     # used float(str(tmant)) * 2.0**texp for this, but that's
+        #     # a little unsafe because str -> float conversion can't be
+        #     # relied upon to do correct rounding on all platforms.
+        #     tail = max(len(bin(abs(tmant)))-2 - mant_dig, etiny - texp)
+        #     if tail > 0:
+        #         h = 1 << (tail-1)
+        #         tmant = tmant // (2*h) + bool(tmant & h and tmant & 3*h-1)
+        #         texp += tail
+        #     return math.ldexp(tmant, texp)
+
+        test_values = [
+            ([], 0.0),
+            ([0.0], 0.0),
+            ([1e100, 1.0, -1e100, 1e-100, 1e50, -1.0, -1e50], 1e-100),
+            ([2.0**53, -0.5, -2.0**-54], 2.0**53-1.0),
+            ([2.0**53, 1.0, 2.0**-100], 2.0**53+2.0),
+            ([2.0**53+10.0, 1.0, 2.0**-100], 2.0**53+12.0),
+            ([2.0**53-4.0, 0.5, 2.0**-54], 2.0**53-3.0),
+            ([1./n for n in range(1, 1001)]),
+            ([(-1.)**n/n for n in range(1, 1001)]),
+            ([1.7**(i+1)-1.7**i for i in range(1000)] + [-1.7**1000], -1.0),
+            ([1e16, 1., 1e-16], 10000000000000002.0),
+            ([1e16-2., 1.-2.**-53, -(1e16-2.), -(1.-2.**-53)], 0.0),
+            # exercise code for resizing partials array
+            ([2.**n - 2.**(n+50) + 2.**(n+52) for n in range(-1074, 972, 2)] +
+             [-2.**1022])
+            ]
+
+        # from random import random, gauss, shuffle
+        # for j in range(1000):
+        #     vals = [7, 1e100, -7, -1e100, -9e-20, 8e-20] * 10
+        #     s = 0
+        #     for i in range(200):
+        #         v = gauss(0, random()) ** 7 - s
+        #         s += v
+        #         vals.append(v)
+        #     shuffle(vals)
+        #
+        #     s = msum(vals)
+        #     self.assertEqual(msum(vals), math.fsum(vals))
+
+    # def testGcd(self):
+    #     gcd = math.gcd
+    #     self.assertEqual(gcd(0, 0), 0)
+    #     self.assertEqual(gcd(1, 0), 1)
+    #     self.assertEqual(gcd(-1, 0), 1)
+    #     self.assertEqual(gcd(0, 1), 1)
+    #     self.assertEqual(gcd(0, -1), 1)
+    #     self.assertEqual(gcd(7, 1), 1)
+    #     self.assertEqual(gcd(7, -1), 1)
+    #     self.assertEqual(gcd(-23, 15), 1)
+    #     self.assertEqual(gcd(120, 84), 12)
+    #     self.assertEqual(gcd(84, -120), 12)
+    #     self.assertEqual(gcd(1216342683557601535506311712,
+    #                          436522681849110124616458784), 32)
+    #     c = 652560
+    #     x = 434610456570399902378880679233098819019853229470286994367836600566
+    #     y = 1064502245825115327754847244914921553977
+    #     a = x * c
+    #     b = y * c
+    #     self.assertEqual(gcd(a, b), c)
+    #     self.assertEqual(gcd(b, a), c)
+    #     self.assertEqual(gcd(-a, b), c)
+    #     self.assertEqual(gcd(b, -a), c)
+    #     self.assertEqual(gcd(a, -b), c)
+    #     self.assertEqual(gcd(-b, a), c)
+    #     self.assertEqual(gcd(-a, -b), c)
+    #     self.assertEqual(gcd(-b, -a), c)
+    #     c = 576559230871654959816130551884856912003141446781646602790216406874
+    #     a = x * c
+    #     b = y * c
+    #     self.assertEqual(gcd(a, b), c)
+    #     self.assertEqual(gcd(b, a), c)
+    #     self.assertEqual(gcd(-a, b), c)
+    #     self.assertEqual(gcd(b, -a), c)
+    #     self.assertEqual(gcd(a, -b), c)
+    #     self.assertEqual(gcd(-b, a), c)
+    #     self.assertEqual(gcd(-a, -b), c)
+    #     self.assertEqual(gcd(-b, -a), c)
+    #
+    #     self.assertRaises(TypeError, gcd, 120.0, 84)
+    #     self.assertRaises(TypeError, gcd, 120, 84.0)
+    #     self.assertEqual(gcd(MyIndexable(120), MyIndexable(84)), 12)
+
+    def testHypot(self):
+        self.assertRaises(TypeError, math.hypot)
+        self.ftest('hypot(0,0)', math.hypot(0,0), 0)
+        self.ftest('hypot(3,4)', math.hypot(3,4), 5)
+        # self.assertEqual(math.hypot(NAN, INF), INF)
+        # self.assertEqual(math.hypot(INF, NAN), INF)
+        # self.assertEqual(math.hypot(NAN, NINF), INF)
+        # self.assertEqual(math.hypot(NINF, NAN), INF)
+        self.assertTrue(math.isnan(math.hypot(1.0, NAN)))
+        self.assertTrue(math.isnan(math.hypot(NAN, -2.0)))
+
+    # def testLdexp(self):
+    #     self.assertRaises(TypeError, math.ldexp)
+    #     self.ftest('ldexp(0,1)', math.ldexp(0,1), 0)
+    #     self.ftest('ldexp(1,1)', math.ldexp(1,1), 2)
+    #     self.ftest('ldexp(1,-1)', math.ldexp(1,-1), 0.5)
+    #     self.ftest('ldexp(-1,1)', math.ldexp(-1,1), -2)
+    #     self.assertRaises(OverflowError, math.ldexp, 1., 1000000)
+    #     self.assertRaises(OverflowError, math.ldexp, -1., 1000000)
+    #     self.assertEqual(math.ldexp(1., -1000000), 0.)
+    #     self.assertEqual(math.ldexp(-1., -1000000), -0.)
+    #     self.assertEqual(math.ldexp(INF, 30), INF)
+    #     self.assertEqual(math.ldexp(NINF, -213), NINF)
+    #     self.assertTrue(math.isnan(math.ldexp(NAN, 0)))
+    #
+    #     # large second argument
+    #     for n in [10**5, 10**10, 10**20, 10**40]:
+    #         self.assertEqual(math.ldexp(INF, -n), INF)
+    #         self.assertEqual(math.ldexp(NINF, -n), NINF)
+    #         self.assertEqual(math.ldexp(1., -n), 0.)
+    #         self.assertEqual(math.ldexp(-1., -n), -0.)
+    #         self.assertEqual(math.ldexp(0., -n), 0.)
+    #         self.assertEqual(math.ldexp(-0., -n), -0.)
+    #         self.assertTrue(math.isnan(math.ldexp(NAN, -n)))
+    #
+    #         self.assertRaises(OverflowError, math.ldexp, 1., n)
+    #         self.assertRaises(OverflowError, math.ldexp, -1., n)
+    #         self.assertEqual(math.ldexp(0., n), 0.)
+    #         self.assertEqual(math.ldexp(-0., n), -0.)
+    #         self.assertEqual(math.ldexp(INF, n), INF)
+    #         self.assertEqual(math.ldexp(NINF, n), NINF)
+    #         self.assertTrue(math.isnan(math.ldexp(NAN, n)))
+
+    def testLog(self):
+        self.assertRaises(TypeError, math.log)
+        self.ftest('log(1/e)', math.log(1/math.e), -1)
+        self.ftest('log(1)', math.log(1), 0)
+        self.ftest('log(e)', math.log(math.e), 1)
+        self.ftest('log(32,2)', math.log(32,2), 5)
+        self.ftest('log(10**40, 10)', math.log(10**40, 10), 40)
+        self.ftest('log(10**40, 10**20)', math.log(10**40, 10**20), 2)
+        # self.ftest('log(10**1000)', math.log(10**1000),
+        #            2302.5850929940457)
+        # self.assertRaises(ValueError, math.log, -1.5)
+        # self.assertRaises(ValueError, math.log, -10**1000)
+        # self.assertRaises(ValueError, math.log, NINF)
+        self.assertEqual(math.log(INF), INF)
+        self.assertTrue(math.isnan(math.log(NAN)))
+
+    # def testLog1p(self):
+    #     self.assertRaises(TypeError, math.log1p)
+    #     for n in [2, 2**90, 2**300]:
+    #         self.assertAlmostEqual(math.log1p(n), math.log1p(float(n)))
+    #     self.assertRaises(ValueError, math.log1p, -1)
+    #     self.assertEqual(math.log1p(INF), INF)
+
+    # def testLog2(self):
+    #     self.assertRaises(TypeError, math.log2)
+    #
+    #     # Check some integer values
+    #     self.assertEqual(math.log2(1), 0.0)
+    #     self.assertEqual(math.log2(2), 1.0)
+    #     self.assertEqual(math.log2(4), 2.0)
+    #
+    #     # Large integer values
+    #     self.assertEqual(math.log2(2**1023), 1023.0)
+    #     self.assertEqual(math.log2(2**1024), 1024.0)
+    #     self.assertEqual(math.log2(2**2000), 2000.0)
+    #
+    #     self.assertRaises(ValueError, math.log2, -1.5)
+    #     self.assertRaises(ValueError, math.log2, NINF)
+    #     self.assertTrue(math.isnan(math.log2(NAN)))
+
+    # log2() is not accurate enough on Mac OS X Tiger (10.4)
+    # def testLog2Exact(self):
+    #     # Check that we get exact equality for log2 of powers of 2.
+    #     actual = [math.log2(math.ldexp(1.0, n)) for n in range(-1074, 1024)]
+    #     expected = [float(n) for n in range(-1074, 1024)]
+    #     self.assertEqual(actual, expected)
+
+    def testLog10(self):
+        self.assertRaises(TypeError, math.log10)
+        self.ftest('log10(0.1)', math.log10(0.1), -1)
+        self.ftest('log10(1)', math.log10(1), 0)
+        self.ftest('log10(10)', math.log10(10), 1)
+        # self.ftest('log10(10**1000)', math.log10(10**1000), 1000.0)
+        # self.assertRaises(ValueError, math.log10, -1.5)
+        # self.assertRaises(ValueError, math.log10, -10**1000)
+        # self.assertRaises(ValueError, math.log10, NINF)
+        self.assertEqual(math.log(INF), INF)
+        self.assertTrue(math.isnan(math.log10(NAN)))
+
+    # def testModf(self):
+    #     self.assertRaises(TypeError, math.modf)
+    #
+    #     def testmodf(name, result, expected):
+    #         (v1, v2), (e1, e2) = result, expected
+    #         if abs(v1-e1) > eps or abs(v2-e2):
+    #             self.fail('%s returned %r, expected %r'%\
+    #                       (name, result, expected))
+    #
+    #     testmodf('modf(1.5)', math.modf(1.5), (0.5, 1.0))
+    #     testmodf('modf(-1.5)', math.modf(-1.5), (-0.5, -1.0))
+    #
+    #     self.assertEqual(math.modf(INF), (0.0, INF))
+    #     self.assertEqual(math.modf(NINF), (-0.0, NINF))
+    #
+    #     modf_nan = math.modf(NAN)
+    #     self.assertTrue(math.isnan(modf_nan[0]))
+    #     self.assertTrue(math.isnan(modf_nan[1]))
+
+    def testPow(self):
+        self.assertRaises(TypeError, math.pow)
+        self.ftest('pow(0,1)', math.pow(0,1), 0)
+        self.ftest('pow(1,0)', math.pow(1,0), 1)
+        self.ftest('pow(2,1)', math.pow(2,1), 2)
+        self.ftest('pow(2,-1)', math.pow(2,-1), 0.5)
+        self.assertEqual(math.pow(INF, 1), INF)
+        self.assertEqual(math.pow(NINF, 1), NINF)
+        # self.assertEqual((math.pow(1, INF)), 1.)
+        # self.assertEqual((math.pow(1, NINF)), 1.)
+        self.assertTrue(math.isnan(math.pow(NAN, 1)))
+        self.assertTrue(math.isnan(math.pow(2, NAN)))
+        self.assertTrue(math.isnan(math.pow(0, NAN)))
+        # self.assertEqual(math.pow(1, NAN), 1)
+
+        # pow(0., x)
+        self.assertEqual(math.pow(0., INF), 0.)
+        self.assertEqual(math.pow(0., 3.), 0.)
+        self.assertEqual(math.pow(0., 2.3), 0.)
+        self.assertEqual(math.pow(0., 2.), 0.)
+        self.assertEqual(math.pow(0., 0.), 1.)
+        self.assertEqual(math.pow(0., -0.), 1.)
+        # self.assertRaises(ValueError, math.pow, 0., -2.)
+        # self.assertRaises(ValueError, math.pow, 0., -2.3)
+        # self.assertRaises(ValueError, math.pow, 0., -3.)
+        # self.assertRaises(ValueError, math.pow, 0., NINF)
+        self.assertTrue(math.isnan(math.pow(0., NAN)))
+
+        # pow(INF, x)
+        self.assertEqual(math.pow(INF, INF), INF)
+        self.assertEqual(math.pow(INF, 3.), INF)
+        self.assertEqual(math.pow(INF, 2.3), INF)
+        self.assertEqual(math.pow(INF, 2.), INF)
+        self.assertEqual(math.pow(INF, 0.), 1.)
+        self.assertEqual(math.pow(INF, -0.), 1.)
+        self.assertEqual(math.pow(INF, -2.), 0.)
+        self.assertEqual(math.pow(INF, -2.3), 0.)
+        self.assertEqual(math.pow(INF, -3.), 0.)
+        self.assertEqual(math.pow(INF, NINF), 0.)
+        self.assertTrue(math.isnan(math.pow(INF, NAN)))
+
+        # pow(-0., x)
+        self.assertEqual(math.pow(-0., INF), 0.)
+        self.assertEqual(math.pow(-0., 3.), -0.)
+        self.assertEqual(math.pow(-0., 2.3), 0.)
+        self.assertEqual(math.pow(-0., 2.), 0.)
+        self.assertEqual(math.pow(-0., 0.), 1.)
+        self.assertEqual(math.pow(-0., -0.), 1.)
+        # self.assertRaises(ValueError, math.pow, -0., -2.)
+        # self.assertRaises(ValueError, math.pow, -0., -2.3)
+        # self.assertRaises(ValueError, math.pow, -0., -3.)
+        # self.assertRaises(ValueError, math.pow, -0., NINF)
+        self.assertTrue(math.isnan(math.pow(-0., NAN)))
+
+        # pow(NINF, x)
+        self.assertEqual(math.pow(NINF, INF), INF)
+        self.assertEqual(math.pow(NINF, 3.), NINF)
+        self.assertEqual(math.pow(NINF, 2.3), INF)
+        self.assertEqual(math.pow(NINF, 2.), INF)
+        self.assertEqual(math.pow(NINF, 0.), 1.)
+        self.assertEqual(math.pow(NINF, -0.), 1.)
+        self.assertEqual(math.pow(NINF, -2.), 0.)
+        self.assertEqual(math.pow(NINF, -2.3), 0.)
+        self.assertEqual(math.pow(NINF, -3.), -0.)
+        self.assertEqual(math.pow(NINF, NINF), 0.)
+        self.assertTrue(math.isnan(math.pow(NINF, NAN)))
+
+        # pow(-1, x)
+        # self.assertEqual(math.pow(-1., INF), 1.)
+        self.assertEqual(math.pow(-1., 3.), -1.)
+        # self.assertRaises(ValueError, math.pow, -1., 2.3)
+        self.assertEqual(math.pow(-1., 2.), 1.)
+        self.assertEqual(math.pow(-1., 0.), 1.)
+        self.assertEqual(math.pow(-1., -0.), 1.)
+        self.assertEqual(math.pow(-1., -2.), 1.)
+        # self.assertRaises(ValueError, math.pow, -1., -2.3)
+        self.assertEqual(math.pow(-1., -3.), -1.)
+        # self.assertEqual(math.pow(-1., NINF), 1.)
+        self.assertTrue(math.isnan(math.pow(-1., NAN)))
+
+        # pow(1, x)
+        # self.assertEqual(math.pow(1., INF), 1.)
+        self.assertEqual(math.pow(1., 3.), 1.)
+        self.assertEqual(math.pow(1., 2.3), 1.)
+        self.assertEqual(math.pow(1., 2.), 1.)
+        self.assertEqual(math.pow(1., 0.), 1.)
+        self.assertEqual(math.pow(1., -0.), 1.)
+        self.assertEqual(math.pow(1., -2.), 1.)
+        self.assertEqual(math.pow(1., -2.3), 1.)
+        self.assertEqual(math.pow(1., -3.), 1.)
+        # self.assertEqual(math.pow(1., NINF), 1.)
+        # self.assertEqual(math.pow(1., NAN), 1.)
+
+        # pow(x, 0) should be 1 for any x
+        self.assertEqual(math.pow(2.3, 0.), 1.)
+        self.assertEqual(math.pow(-2.3, 0.), 1.)
+        self.assertEqual(math.pow(NAN, 0.), 1.)
+        self.assertEqual(math.pow(2.3, -0.), 1.)
+        self.assertEqual(math.pow(-2.3, -0.), 1.)
+        self.assertEqual(math.pow(NAN, -0.), 1.)
+
+        # pow(x, y) is invalid if x is negative and y is not integral
+        # self.assertRaises(ValueError, math.pow, -1., 2.3)
+        # self.assertRaises(ValueError, math.pow, -15., -3.1)
+
+        # pow(x, NINF)
+        self.assertEqual(math.pow(1.9, NINF), 0.)
+        self.assertEqual(math.pow(1.1, NINF), 0.)
+        self.assertEqual(math.pow(0.9, NINF), INF)
+        self.assertEqual(math.pow(0.1, NINF), INF)
+        self.assertEqual(math.pow(-0.1, NINF), INF)
+        self.assertEqual(math.pow(-0.9, NINF), INF)
+        self.assertEqual(math.pow(-1.1, NINF), 0.)
+        self.assertEqual(math.pow(-1.9, NINF), 0.)
+
+        # pow(x, INF)
+        self.assertEqual(math.pow(1.9, INF), INF)
+        self.assertEqual(math.pow(1.1, INF), INF)
+        self.assertEqual(math.pow(0.9, INF), 0.)
+        self.assertEqual(math.pow(0.1, INF), 0.)
+        self.assertEqual(math.pow(-0.1, INF), 0.)
+        self.assertEqual(math.pow(-0.9, INF), 0.)
+        self.assertEqual(math.pow(-1.1, INF), INF)
+        self.assertEqual(math.pow(-1.9, INF), INF)
+
+        # pow(x, y) should work for x negative, y an integer
+        self.ftest('(-2.)**3.', math.pow(-2.0, 3.0), -8.0)
+        self.ftest('(-2.)**2.', math.pow(-2.0, 2.0), 4.0)
+        self.ftest('(-2.)**1.', math.pow(-2.0, 1.0), -2.0)
+        self.ftest('(-2.)**0.', math.pow(-2.0, 0.0), 1.0)
+        self.ftest('(-2.)**-0.', math.pow(-2.0, -0.0), 1.0)
+        self.ftest('(-2.)**-1.', math.pow(-2.0, -1.0), -0.5)
+        self.ftest('(-2.)**-2.', math.pow(-2.0, -2.0), 0.25)
+        self.ftest('(-2.)**-3.', math.pow(-2.0, -3.0), -0.125)
+        # self.assertRaises(ValueError, math.pow, -2.0, -0.5)
+        # self.assertRaises(ValueError, math.pow, -2.0, 0.5)
+
+        # the following tests have been commented out since they don't
+        # really belong here:  the implementation of ** for floats is
+        # independent of the implementation of math.pow
+        #self.assertEqual(1**NAN, 1)
+        #self.assertEqual(1**INF, 1)
+        #self.assertEqual(1**NINF, 1)
+        #self.assertEqual(1**0, 1)
+        #self.assertEqual(1.**NAN, 1)
+        #self.assertEqual(1.**INF, 1)
+        #self.assertEqual(1.**NINF, 1)
+        #self.assertEqual(1.**0, 1)
+
+    def testRadians(self):
+        self.assertRaises(TypeError, math.radians)
+        self.ftest('radians(180)', math.radians(180), math.pi)
+        self.ftest('radians(90)', math.radians(90), math.pi/2)
+        self.ftest('radians(-45)', math.radians(-45), -math.pi/4)
+        self.ftest('radians(0)', math.radians(0), 0)
+
+    def testSin(self):
+        self.assertRaises(TypeError, math.sin)
+        self.ftest('sin(0)', math.sin(0), 0)
+        self.ftest('sin(pi/2)', math.sin(math.pi/2), 1)
+        self.ftest('sin(-pi/2)', math.sin(-math.pi/2), -1)
+        try:
+            self.assertTrue(math.isnan(math.sin(INF)))
+            self.assertTrue(math.isnan(math.sin(NINF)))
+        except ValueError:
+            self.assertRaises(ValueError, math.sin, INF)
+            self.assertRaises(ValueError, math.sin, NINF)
+        self.assertTrue(math.isnan(math.sin(NAN)))
+
+    def testSinh(self):
+        self.assertRaises(TypeError, math.sinh)
+        self.ftest('sinh(0)', math.sinh(0), 0)
+        self.ftest('sinh(1)**2-cosh(1)**2', math.sinh(1)**2-math.cosh(1)**2, -1)
+        self.ftest('sinh(1)+sinh(-1)', math.sinh(1)+math.sinh(-1), 0)
+        self.assertEqual(math.sinh(INF), INF)
+        self.assertEqual(math.sinh(NINF), NINF)
+        self.assertTrue(math.isnan(math.sinh(NAN)))
+
+    def testSqrt(self):
+        self.assertRaises(TypeError, math.sqrt)
+        self.ftest('sqrt(0)', math.sqrt(0), 0)
+        self.ftest('sqrt(1)', math.sqrt(1), 1)
+        self.ftest('sqrt(4)', math.sqrt(4), 2)
+        self.assertEqual(math.sqrt(INF), INF)
+        # self.assertRaises(ValueError, math.sqrt, -1)
+        # self.assertRaises(ValueError, math.sqrt, NINF)
+        self.assertTrue(math.isnan(math.sqrt(NAN)))
+
+    def testTan(self):
+        self.assertRaises(TypeError, math.tan)
+        self.ftest('tan(0)', math.tan(0), 0)
+        self.ftest('tan(pi/4)', math.tan(math.pi/4), 1)
+        self.ftest('tan(-pi/4)', math.tan(-math.pi/4), -1)
+        try:
+            self.assertTrue(math.isnan(math.tan(INF)))
+            self.assertTrue(math.isnan(math.tan(NINF)))
+        except:
+            self.assertRaises(ValueError, math.tan, INF)
+            self.assertRaises(ValueError, math.tan, NINF)
+        self.assertTrue(math.isnan(math.tan(NAN)))
+
+    def testTanh(self):
+        self.assertRaises(TypeError, math.tanh)
+        self.ftest('tanh(0)', math.tanh(0), 0)
+        self.ftest('tanh(1)+tanh(-1)', math.tanh(1)+math.tanh(-1), 0,
+                   abs_tol=ulp(1))
+        # self.ftest('tanh(inf)', math.tanh(INF), 1)
+        # self.ftest('tanh(-inf)', math.tanh(NINF), -1)
+        self.assertTrue(math.isnan(math.tanh(NAN)))
+
+    def testTanhSign(self):
+        # check that tanh(-0.) == -0. on IEEE 754 systems
+        self.assertEqual(math.tanh(-0.), -0.)
+        self.assertEqual(math.copysign(1., math.tanh(-0.)),
+                         math.copysign(1., -0.))
+
+    def test_trunc(self):
+        self.assertEqual(math.trunc(1), 1)
+        self.assertEqual(math.trunc(-1), -1)
+        self.assertEqual(type(math.trunc(1)), int)
+        self.assertEqual(type(math.trunc(1.5)), int)
+        self.assertEqual(math.trunc(1.5), 1)
+        self.assertEqual(math.trunc(-1.5), -1)
+        self.assertEqual(math.trunc(1.999999), 1)
+        self.assertEqual(math.trunc(-1.999999), -1)
+        self.assertEqual(math.trunc(-0.999999), -0)
+        self.assertEqual(math.trunc(-100.999), -100)
+
+        class TestTrunc(object):
+            def __trunc__(self):
+                return 23
+
+        class TestNoTrunc(object):
+            pass
+
+        # self.assertEqual(math.trunc(TestTrunc()), 23)
+
+        self.assertRaises(TypeError, math.trunc)
+        self.assertRaises(TypeError, math.trunc, 1, 2)
+        self.assertRaises(TypeError, math.trunc, TestNoTrunc())
+
+    # def testIsfinite(self):
+    #     self.assertTrue(math.isfinite(0.0))
+    #     self.assertTrue(math.isfinite(-0.0))
+    #     self.assertTrue(math.isfinite(1.0))
+    #     self.assertTrue(math.isfinite(-1.0))
+    #     self.assertFalse(math.isfinite(float("nan")))
+    #     self.assertFalse(math.isfinite(float("inf")))
+    #     self.assertFalse(math.isfinite(float("-inf")))
+
+    def testIsnan(self):
+        self.assertTrue(math.isnan(float("nan")))
+        self.assertTrue(math.isnan(float("-nan")))
+        self.assertTrue(math.isnan(float("inf") * 0.))
+        self.assertFalse(math.isnan(float("inf")))
+        self.assertFalse(math.isnan(0.))
+        self.assertFalse(math.isnan(1.))
+
+    def testIsinf(self):
+        self.assertTrue(math.isinf(float("inf")))
+        self.assertTrue(math.isinf(float("-inf")))
+        self.assertTrue(math.isinf(1E400))
+        self.assertTrue(math.isinf(-1E400))
+        # self.assertFalse(math.isinf(float("nan")))
+        self.assertFalse(math.isinf(0.))
+        self.assertFalse(math.isinf(1.))
+
+    # def test_nan_constant(self):
+    #     self.assertTrue(math.isnan(math.nan))
+
+    # def test_inf_constant(self):
+    #     self.assertTrue(math.isinf(math.inf))
+    #     self.assertGreater(math.inf, 0.0)
+    #     self.assertEqual(math.inf, float("inf"))
+    #     self.assertEqual(-math.inf, float("-inf"))
+
+    # RED_FLAG 16-Oct-2000 Tim
+    # While 2.0 is more consistent about exceptions than previous releases, it
+    # still fails this part of the test on some platforms.  For now, we only
+    # *run* test_exceptions() in verbose mode, so that this isn't normally
+    # tested.
+    def test_exceptions(self):
+        try:
+            x = math.exp(-1000000000)
+        except:
+            # mathmodule.c is failing to weed out underflows from libm, or
+            # we've got an fp format with huge dynamic range
+            self.fail("underflowing exp() should not have raised "
+                        "an exception")
+        if x != 0:
+            self.fail("underflowing exp() should have returned 0")
+
+        # If this fails, probably using a strict IEEE-754 conforming libm, and x
+        # is +Inf afterwards.  But Python wants overflows detected by default.
+        # try:
+        #     x = math.exp(1000000000)
+        # except OverflowError:
+        #     pass
+        # else:
+        #     self.fail("overflowing exp() didn't trigger OverflowError")
+
+        # If this fails, it could be a puzzle.  One odd possibility is that
+        # mathmodule.c's macros are getting confused while comparing
+        # Inf (HUGE_VAL) to a NaN, and artificially setting errno to ERANGE
+        # as a result (and so raising OverflowError instead).
+        # try:
+        #     x = math.sqrt(-1.0)
+        # except ValueError:
+        #     pass
+        # else:
+        #     self.fail("sqrt(-1) didn't raise ValueError")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_ordereddict.py
+++ b/test/unit3/test_ordereddict.py
@@ -1,0 +1,292 @@
+import unittest
+from collections import OrderedDict
+from random import shuffle
+
+class TestOrderedDict(unittest.TestCase):
+
+    def test_init(self):
+        #with self.assertRaises(TypeError):
+        #    OrderedDict([('a', 1), ('b', 2)], None)                                 # too many args
+        pairs = [('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5)]
+        self.assertEqual(sorted(OrderedDict(dict(pairs)).items()), pairs)           # dict input
+        #self.assertEqual(sorted(OrderedDict(**dict(pairs)).items()), pairs)         # kwds input
+        self.assertEqual(list(OrderedDict(pairs).items()), pairs)                   # pairs input
+        #self.assertEqual(list(OrderedDict([('a', 1), ('b', 2), ('c', 9), ('d', 4)],
+        #                                  c=3, e=5).items()), pairs)                # mixed input
+
+        # make sure no positional args conflict with possible kwdargs
+        #self.assertEqual(list(OrderedDict(self=42).items()), [('self', 42)])
+        #self.assertEqual(list(OrderedDict(other=42).items()), [('other', 42)])
+        #self.assertRaises(TypeError, OrderedDict, 42)
+        #self.assertRaises(TypeError, OrderedDict, (), ())
+        #self.assertRaises(TypeError, OrderedDict.__init__)
+
+        # Make sure that direct calls to __init__ do not clear previous contents
+        #d = OrderedDict([('a', 1), ('b', 2), ('c', 3), ('d', 44), ('e', 55)])
+        #d.__init__([('e', 5), ('f', 6)], g=7, d=4)
+        #self.assertEqual(list(d.items()),
+        #    [('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5), ('f', 6), ('g', 7)])
+
+    # def test_update(self):
+    #     #with self.assertRaises(TypeError):
+    #     #    OrderedDict().update([('a', 1), ('b', 2)], None)                        # too many args
+    #     pairs = [('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5)]
+    #     od = OrderedDict()
+    #     od.update(dict(pairs))
+    #     self.assertEqual(sorted(od.items()), pairs)                                 # dict input
+    #     od = OrderedDict()
+    #     od.update(**dict(pairs))
+    #     self.assertEqual(sorted(od.items()), pairs)                                 # kwds input
+    #     od = OrderedDict()
+    #     od.update(pairs)
+    #     self.assertEqual(list(od.items()), pairs)                                   # pairs input
+    #     od = OrderedDict()
+    #     od.update([('a', 1), ('b', 2), ('c', 9), ('d', 4)], c=3, e=5)
+    #     self.assertEqual(list(od.items()), pairs)                                   # mixed input
+
+    #     # Issue 9137: Named argument called 'other' or 'self'
+    #     # shouldn't be treated specially.
+    #     od = OrderedDict()
+    #     od.update(self=23)
+    #     self.assertEqual(list(od.items()), [('self', 23)])
+    #     od = OrderedDict()
+    #     od.update(other={})
+    #     self.assertEqual(list(od.items()), [('other', {})])
+    #     od = OrderedDict()
+    #     od.update(red=5, blue=6, other=7, self=8)
+    #     self.assertEqual(sorted(list(od.items())),
+    #                      [('blue', 6), ('other', 7), ('red', 5), ('self', 8)])
+
+    #     # Make sure that direct calls to update do not clear previous contents
+    #     # add that updates items are not moved to the end
+    #     d = OrderedDict([('a', 1), ('b', 2), ('c', 3), ('d', 44), ('e', 55)])
+    #     d.update([('e', 5), ('f', 6)], g=7, d=4)
+    #     self.assertEqual(list(d.items()),
+    #         [('a', 1), ('b', 2), ('c', 3), ('d', 4), ('e', 5), ('f', 6), ('g', 7)])
+
+    #     self.assertRaises(TypeError, OrderedDict().update, 42)
+    #     self.assertRaises(TypeError, OrderedDict().update, (), ())
+    #     self.assertRaises(TypeError, OrderedDict.update)
+
+    # def test_abc(self):
+    #     self.assertIsInstance(OrderedDict(), MutableMapping)
+    #     self.assertTrue(issubclass(OrderedDict, MutableMapping))
+
+    def test_clear(self):
+        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+        shuffle(pairs)
+        od = OrderedDict(pairs)
+        self.assertEqual(len(od), len(pairs))
+        od.clear()
+        self.assertEqual(len(od), 0)
+
+    def test_delitem(self):
+        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+        od = OrderedDict(pairs)
+        del od['a']
+        self.assertNotIn('a', od)
+        #with self.assertRaises(KeyError):
+        #    del od['a']
+        self.assertEqual(list(od.items()), pairs[:2] + pairs[3:])
+
+    def test_setitem(self):
+        od = OrderedDict([('d', 1), ('b', 2), ('c', 3), ('a', 4), ('e', 5)])
+        od['c'] = 10           # existing element
+        od['f'] = 20           # new element
+        self.assertEqual(list(od.items()),
+                         [('d', 1), ('b', 2), ('c', 10), ('a', 4), ('e', 5), ('f', 20)])
+
+    def test_iterators(self):
+        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+        shuffle(pairs)
+        od = OrderedDict(pairs)
+        self.assertEqual(list(od), [t[0] for t in pairs])
+        self.assertEqual(list(od.keys()), [t[0] for t in pairs])
+        self.assertEqual(list(od.values()), [t[1] for t in pairs])
+        self.assertEqual(list(od.items()), pairs)
+        # self.assertEqual(list(reversed(od)),
+        #                  [t[0] for t in reversed(pairs)])
+        # self.assertEqual(list(reversed(od.keys())),
+        #                  [t[0] for t in reversed(pairs)])
+        # self.assertEqual(list(reversed(od.values())),
+        #                  [t[1] for t in reversed(pairs)])
+        # self.assertEqual(list(reversed(od.items())), list(reversed(pairs)))
+
+    # def test_detect_deletion_during_iteration(self):
+    #     od = OrderedDict.fromkeys('abc')
+    #     it = iter(od)
+    #     key = next(it)
+    #     del od[key]
+    #     with self.assertRaises(Exception):
+    #         # Note, the exact exception raised is not guaranteed
+    #         # The only guarantee that the next() will not succeed
+    #         next(it)
+
+    def test_popitem(self):
+        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+        shuffle(pairs)
+        od = OrderedDict(pairs)
+        while pairs:
+            self.assertEqual(od.popitem(), pairs.pop())
+        #with self.assertRaises(KeyError):
+        #    od.popitem()
+        self.assertEqual(len(od), 0)
+
+    def test_pop(self):
+        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+        shuffle(pairs)
+        od = OrderedDict(pairs)
+        shuffle(pairs)
+        while pairs:
+            k, v = pairs.pop()
+            self.assertEqual(od.pop(k), v)
+        #with self.assertRaises(KeyError):
+        #    od.pop('xyz')
+        self.assertEqual(len(od), 0)
+        self.assertEqual(od.pop(k, 12345), 12345)
+
+        # make sure pop still works when __missing__ is defined
+        # class Missing(OrderedDict):
+        #     def __missing__(self, key):
+        #         return 0
+        # m = Missing(a=1)
+        # self.assertEqual(m.pop('b', 5), 5)
+        # self.assertEqual(m.pop('a', 6), 1)
+        # self.assertEqual(m.pop('a', 6), 6)
+        #with self.assertRaises(KeyError):
+        #    m.pop('a')
+
+    def test_equality(self):
+        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+        shuffle(pairs)
+        od1 = OrderedDict(pairs)
+        od2 = OrderedDict(pairs)
+        self.assertEqual(od1, od2)          # same order implies equality
+        pairs = pairs[2:] + pairs[:2]
+        od2 = OrderedDict(pairs)
+        self.assertNotEqual(od1, od2)       # different order implies inequality
+        # comparison to regular dict is not order sensitive
+        self.assertEqual(od1, dict(od2))
+        self.assertEqual(dict(od2), od1)
+        # different length implied inequality
+        self.assertNotEqual(od1, OrderedDict(pairs[:-1]))
+
+    # def test_copying(self):
+    #     # Check that ordered dicts are copyable, deepcopyable, picklable,
+    #     # and have a repr/eval round-trip
+    #     pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+    #     od = OrderedDict(pairs)
+    #     def check(dup):
+    #         msg = "\ncopy: %s\nod: %s" % (dup, od)
+    #         self.assertIsNot(dup, od, msg)
+    #         self.assertEqual(dup, od)
+    #     check(od.copy())
+    #     check(copy.copy(od))
+    #     check(copy.deepcopy(od))
+    #     for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+    #         with self.subTest(proto=proto):
+    #             check(pickle.loads(pickle.dumps(od, proto)))
+    #     check(eval(repr(od)))
+    #     update_test = OrderedDict()
+    #     update_test.update(od)
+    #     check(update_test)
+    #     check(OrderedDict(od))
+
+    # def test_yaml_linkage(self):
+    #     # Verify that __reduce__ is setup in a way that supports PyYAML's dump() feature.
+    #     # In yaml, lists are native but tuples are not.
+    #     pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+    #     od = OrderedDict(pairs)
+    #     # yaml.dump(od) -->
+    #     # '!!python/object/apply:__main__.OrderedDict\n- - [a, 1]\n  - [b, 2]\n'
+    #     self.assertTrue(all(type(pair)==list for pair in od.__reduce__()[1]))
+
+    # def test_reduce_not_too_fat(self):
+    #     # do not save instance dictionary if not needed
+    #     pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+    #     od = OrderedDict(pairs)
+    #     self.assertIsNone(od.__reduce__()[2])
+    #     od.x = 10
+    #     self.assertIsNotNone(od.__reduce__()[2])
+
+    # def test_pickle_recursive(self):
+    #     od = OrderedDict()
+    #     od[1] = od
+    #     for proto in range(-1, pickle.HIGHEST_PROTOCOL + 1):
+    #         dup = pickle.loads(pickle.dumps(od, proto))
+    #         self.assertIsNot(dup, od)
+    #         self.assertEqual(list(dup.keys()), [1])
+    #         self.assertIs(dup[1], dup)
+
+    def test_repr(self):
+        od = OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])
+        self.assertEqual(repr(od),
+            "OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])")
+        #self.assertEqual(eval(repr(od)), od)
+        self.assertEqual(repr(OrderedDict()), "OrderedDict()")
+
+    # def test_repr_recursive(self):
+    #     # See issue #9826
+    #     od = OrderedDict.fromkeys('abc')
+    #     od['x'] = od
+    #     self.assertEqual(repr(od),
+    #         "OrderedDict([('a', None), ('b', None), ('c', None), ('x', ...)])")
+
+    def test_setdefault(self):
+        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+        shuffle(pairs)
+        od = OrderedDict(pairs)
+        pair_order = list(od.items())
+        self.assertEqual(od.setdefault('a', 10), 3)
+        # make sure order didn't change
+        self.assertEqual(list(od.items()), pair_order)
+        self.assertEqual(od.setdefault('x', 10), 10)
+        # make sure 'x' is added to the end
+        self.assertEqual(list(od.items())[-1], ('x', 10))
+
+        # make sure setdefault still works when __missing__ is defined
+        # class Missing(OrderedDict):
+        #     def __missing__(self, key):
+        #         return 0
+        # self.assertEqual(Missing().setdefault(5, 9), 9)
+
+    def test_reinsert(self):
+        # Given insert a, insert b, delete a, re-insert a,
+        # verify that a is now later than b.
+        od = OrderedDict()
+        od['a'] = 1
+        od['b'] = 2
+        del od['a']
+        od['a'] = 1
+        self.assertEqual(list(od.items()), [('b', 2), ('a', 1)])
+
+    # def test_move_to_end(self):
+    #     od = OrderedDict.fromkeys('abcde')
+    #     self.assertEqual(list(od), list('abcde'))
+    #     od.move_to_end('c')
+    #     self.assertEqual(list(od), list('abdec'))
+    #     od.move_to_end('c', 0)
+    #     self.assertEqual(list(od), list('cabde'))
+    #     od.move_to_end('c', 0)
+    #     self.assertEqual(list(od), list('cabde'))
+    #     od.move_to_end('e')
+    #     self.assertEqual(list(od), list('cabde'))
+    #     with self.assertRaises(KeyError):
+    #         od.move_to_end('x')
+
+    # def test_sizeof(self):
+    #     # Wimpy test: Just verify the reported size is larger than a regular dict
+    #     d = dict(a=1)
+    #     od = OrderedDict(**d)
+    #     self.assertGreater(sys.getsizeof(od), sys.getsizeof(d))
+
+    # def test_override_update(self):
+    #     # Verify that subclasses can override update() without breaking __init__()
+    #     class MyOD(OrderedDict):
+    #         def update(self, *args, **kwds):
+    #             raise Exception()
+    #     items = [('a', 1), ('c', 3), ('b', 2)]
+    #     self.assertEqual(list(MyOD(items).items()), items)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_pow.py
+++ b/test/unit3/test_pow.py
@@ -1,0 +1,123 @@
+import unittest
+
+class PowTest(unittest.TestCase):
+
+    def powtest(self, type):
+        if type != float:
+            for i in range(-1000, 1000):
+                self.assertEqual(pow(type(i), 0), 1)
+                self.assertEqual(pow(type(i), 1), type(i))
+                self.assertEqual(pow(type(0), 1), type(0))
+                self.assertEqual(pow(type(1), 1), type(1))
+
+            for i in range(-100, 100):
+                self.assertEqual(pow(type(i), 3), i*i*i)
+
+            pow2 = 1
+            for i in range(0, 31):
+                self.assertEqual(pow(2, i), pow2)
+                if i != 30 : pow2 = pow2*2
+
+            for othertype in (int,):
+                for i in list(range(-10, 0)) + list(range(1, 10)):
+                    ii = type(i)
+                    for j in range(1, 11):
+                        jj = -othertype(j)
+                        pow(ii, jj)
+
+        for othertype in int, float:
+            for i in range(1, 100):
+                zero = type(0)
+                exp = -othertype(i/10.0)
+                if exp == 0:
+                    continue
+                self.assertRaises(ZeroDivisionError, pow, zero, exp)
+
+        il, ih = -20, 20
+        jl, jh = -5,   5
+        kl, kh = -10, 10
+        asseq = self.assertEqual
+        if type == float:
+            il = 1
+            asseq = self.assertAlmostEqual
+        elif type == int:
+            jl = 0
+        elif type == int:
+            jl, jh = 0, 15
+        for i in range(il, ih+1):
+            for j in range(jl, jh+1):
+                for k in range(kl, kh+1):
+                    if k != 0:
+                        if type == float or j < 0:
+                            self.assertRaises(TypeError, pow, type(i), j, k)
+                            continue
+                        asseq(
+                            pow(type(i),j,k),
+                            pow(type(i),j)% type(k)
+                        )
+
+    # def test_powint(self):
+    #     self.powtest(int)
+
+    # def test_powfloat(self):
+    #     self.powtest(float)
+
+    def test_other(self):
+        # Other tests-- not very systematic
+        self.assertEqual(pow(3,3) % 8, pow(3,3,8))
+        self.assertEqual(pow(3,3) % -8, pow(3,3,-8))
+        self.assertEqual(pow(3,2) % -2, pow(3,2,-2))
+        self.assertEqual(pow(-3,3) % 8, pow(-3,3,8))
+        self.assertEqual(pow(-3,3) % -8, pow(-3,3,-8))
+        self.assertEqual(pow(5,2) % -8, pow(5,2,-8))
+
+        self.assertEqual(pow(3,3) % 8, pow(3,3,8))
+        self.assertEqual(pow(3,3) % -8, pow(3,3,-8))
+        self.assertEqual(pow(3,2) % -2, pow(3,2,-2))
+        self.assertEqual(pow(-3,3) % 8, pow(-3,3,8))
+        self.assertEqual(pow(-3,3) % -8, pow(-3,3,-8))
+        self.assertEqual(pow(5,2) % -8, pow(5,2,-8))
+
+        for i in range(-10, 11):
+            for j in range(0, 6):
+                for k in range(-7, 11):
+                    if j >= 0 and k != 0:
+                        self.assertEqual(
+                            pow(i,j) % k,
+                            pow(i,j,k)
+                        )
+                    if j >= 0 and k != 0:
+                        self.assertEqual(
+                            pow(int(i),j) % k,
+                            pow(int(i),j,k)
+                        )
+
+    def test_bug643260(self):
+        class TestRpow:
+            def __rpow__(self, other):
+                return None
+        None ** TestRpow() # Won't fail when __rpow__ invoked.  SF bug #643260.
+
+    def test_bug705231(self):
+        # -1.0 raised to an integer should never blow up.  It did if the
+        # platform pow() was buggy, and Python didn't worm around it.
+        eq = self.assertEqual
+        a = -1.0
+        # The next two tests can still fail if the platform floor()
+        # function doesn't treat all large inputs as integers
+        # test_math should also fail if that is happening
+        # eq(pow(a, 1.23e167), 1.0)
+        # eq(pow(a, -1.23e167), 1.0)
+        # for b in range(-10, 11):
+        #     eq(pow(a, float(b)), b & 1 and -1.0 or 1.0)
+        for n in range(0, 100):
+            fiveto = float(5 ** n)
+            # For small n, fiveto will be odd.  Eventually we run out of
+            # mantissa bits, though, and thereafer fiveto will be even.
+            expected = fiveto % 2.0 and -1.0 or 1.0
+            # eq(pow(a, fiveto), expected)
+            # eq(pow(a, -fiveto), expected)
+        eq(expected, 1.0)   # else we didn't push fiveto to evenness
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_random.py
+++ b/test/unit3/test_random.py
@@ -1,0 +1,113 @@
+import random 
+import unittest
+from math import exp, sqrt
+
+class Test_Distributions(unittest.TestCase):
+    def test_seeding(self):
+        # Python's seeding is different so we can't hard code
+        random.seed(1)
+        a = random.uniform(1,5)
+        random.seed(1)
+        b = random.uniform(1,5)
+        self.assertEqual(a, b)
+
+    def _excluded_test_avg_std(self):
+        # Use integration to test distribution average and standard deviation.
+        # Only works for distributions which do not consume variates in pairs
+        #g = random.Random()
+        N = 5000
+        x = [i/float(N) for i in xrange(1,N)]
+        for variate, args, mu, sigmasqrd in [
+                (random.uniform, (1.0,10.0), (10.0+1.0)/2, (10.0-1.0)**2/12),
+                (random.gauss, (-5.0,2.0), -5.0, 2.0**2),
+                (random.normalvariate, (2.0,0.8), 2.0, 0.8**2),
+                (random.lognormvariate, (-1.0,0.5), exp(-1.0 + 0.5**2)/2.0, (exp(0.5**2) - 1) * exp(-2.0 + 0.5**2)),
+                (random.expovariate, (0.4,), 1.0/0.4, 1.0/0.4**2),
+                (random.triangular, (0.0, 1.0, 1.0/3.0), 4.0/9.0, 7.0/9.0/18.0) #,
+#                 (g.expovariate, (1.5,), 1/1.5, 1/1.5**2),
+#                 (g.paretovariate, (5.0,), 5.0/(5.0-1),
+#                                   5.0/((5.0-1)**2*(5.0-2))),
+#                 (g.weibullvariate, (1.0, 3.0), gamma(1+1/3.0),
+#                                   gamma(1+2/3.0)-gamma(1+1/3.0)**2) 
+                                                    ]:
+            #g.random = x[:].pop
+            y = []
+            for i in xrange(len(x)):
+                try:
+                    y.append(variate(*args))
+                except IndexError:
+                    pass
+            s1 = s2 = 0
+            for e in y:
+                s1 += e
+                s2 += (e - mu) ** 2
+            N = len(y)
+            # Reduced precision from two to zero decimal places
+            self.assertAlmostEqual(s1/N, mu, 0)
+            self.assertAlmostEqual(s2/(N-1), sigmasqrd, 0)
+
+    def test_sample_frequency(self):
+        N = 1000
+        population = [-2, -1, 0, 1, 2]
+        hist = {}
+        for i in range(N):
+            # changed from for i in xrange(N):
+            sampled = random.sample(population, 2)
+            key = ','.join(str(x) for x in sampled)
+            hist[key] = hist.get(key, 0) + 1
+
+        # There are m * (m-1) ways to pick an ordered pair. The
+        # observed number of occurrences of a pair follows a
+        # Binomial(N, 1/(m*(m-1))) distribution.
+        m = len(population)
+        p = 1.0 / (m*(m-1))
+        mean = N*p
+        stddev = sqrt(N*p*(1-p))
+        low = mean - 4*stddev
+        high = mean + 4*stddev
+
+        for a in population:
+            for b in population:
+                if a != b:
+                    key = '%s,%s' % (a, b)
+                    observed = hist.get(key, 0)
+                    self.assertLess(low, observed, 'Sample %s' % key)
+                    self.assertGreater(high, observed, 'Sample %s' % key)
+
+    def test_sample_tuple(self):
+        population = (1, 2, 3, 4)
+        sampled = random.sample(population, 3)
+        self.assertEqual(len(sampled), 3)
+        for x in sampled:
+            self.assertIn(x, population)
+
+    def test_sample_set(self):
+        population = set(range(20))
+        sampled = random.sample(population, 10)
+        self.assertEqual(len(sampled), 10)
+        for x in sampled:
+            self.assertIn(x, population)
+
+    def test_sample_dict(self):
+        population = {"one": 1, "two": 2, "three": 3}
+        sampled = random.sample(list(population), 2)
+        # changed from sampled = random.sample(population, 2)
+        self.assertEqual(len(sampled), 2)
+        for x in sampled:
+            self.assertIn(x, population.keys())
+
+    def test_sample_empty(self):
+        sampled = random.sample([], 0)
+        self.assertEqual(sampled, [])
+
+    def test_sample_all(self):
+        population = "ABCDEF"
+        sampled = random.sample(population, len(population))
+        self.assertEqual(set(sampled), set(population))
+
+    def test_sample_one_too_many(self):
+        self.assertRaises(ValueError, random.sample, range(4), 5)
+
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/test/unit3/test_range.py
+++ b/test/unit3/test_range.py
@@ -1,0 +1,513 @@
+# Python test set -- built-in functions
+
+import unittest
+import sys
+
+# pure Python implementations (3 args only), for comparison
+def pyrange(start, stop, step):
+    if (start - stop) // step < 0:
+        # replace stop with next element in the sequence of integers
+        # that are congruent to start modulo step.
+        stop += (start - stop) % step
+        while start != stop:
+            yield start
+            start += step
+
+def pyrange_reversed(start, stop, step):
+    stop += (start - stop) % step
+    return pyrange(stop - step, start - step, -step)
+
+#
+class RangeTest(unittest.TestCase):
+    # def assert_iterators_equal(self, xs, ys, test_id, limit=None):
+    #     # check that an iterator xs matches the expected results ys,
+    #     # up to a given limit.
+    #     if limit is not None:
+    #         xs = itertools.islice(xs, limit)
+    #         ys = itertools.islice(ys, limit)
+    #     sentinel = object()
+    #     pairs = itertools.zip_longest(xs, ys, fillvalue=sentinel)
+    #     for i, (x, y) in enumerate(pairs):
+    #         if x == y:
+    #             continue
+    #         elif x == sentinel:
+    #             self.fail('{}: iterator ended unexpectedly '
+    #                       'at position {}; expected {}'.format(test_id, i, y))
+    #         elif y == sentinel:
+    #             self.fail('{}: unexpected excess element {} at '
+    #                       'position {}'.format(test_id, x, i))
+    #         else:
+    #             self.fail('{}: wrong element at position {};'
+    #                       'expected {}, got {}'.format(test_id, i, y, x))
+
+    def test_range(self):
+        self.assertEqual(list(range(3)), [0, 1, 2])
+        self.assertEqual(list(range(1, 5)), [1, 2, 3, 4])
+        self.assertEqual(list(range(0)), [])
+        self.assertEqual(list(range(-3)), [])
+        self.assertEqual(list(range(1, 10, 3)), [1, 4, 7])
+        self.assertEqual(list(range(5, -5, -3)), [5, 2, -1, -4])
+
+        a = 10
+        b = 100
+        c = 50
+
+        self.assertEqual(list(range(a, a+2)), [a, a+1])
+        self.assertEqual(list(range(a+2, a, -1)), [a+2, a+1])
+        self.assertEqual(list(range(a+4, a, -2)), [a+4, a+2])
+
+        seq = list(range(a, b, c))
+        self.assertIn(a, seq)
+        self.assertNotIn(b, seq)
+        self.assertEqual(len(seq), 2)
+
+        seq = list(range(b, a, -c))
+        self.assertIn(b, seq)
+        self.assertNotIn(a, seq)
+        self.assertEqual(len(seq), 2)
+
+        seq = list(range(-a, -b, -c))
+        self.assertIn(-a, seq)
+        self.assertNotIn(-b, seq)
+        self.assertEqual(len(seq), 2)
+
+        self.assertRaises(TypeError, range)
+        self.assertRaises(TypeError, range, 1, 2, 3, 4)
+        self.assertRaises(ValueError, range, 1, 2, 0)
+
+        self.assertRaises(TypeError, range, 0.0, 2, 1)
+        self.assertRaises(TypeError, range, 1, 2.0, 1)
+        self.assertRaises(TypeError, range, 1, 2, 1.0)
+        self.assertRaises(TypeError, range, 1e100, 1e101, 1e101)
+
+        self.assertRaises(TypeError, range, 0, "spam")
+        self.assertRaises(TypeError, range, 0, 42, "spam")
+
+        self.assertEqual(len(range(0, sys.maxsize, sys.maxsize-1)), 2)
+
+    def test_large_operands(self):
+        # x = range(10**20, 10**20+10, 3)
+        # self.assertEqual(len(x), 4)
+        # self.assertEqual(len(list(x)), 4)
+
+        x = range(10**20+10, 10**20, 3)
+        self.assertEqual(len(x), 0)
+        self.assertEqual(len(list(x)), 0)
+
+        x = range(10**20, 10**20+10, -3)
+        self.assertEqual(len(x), 0)
+        self.assertEqual(len(list(x)), 0)
+
+        # x = range(10**20+10, 10**20, -3)
+        # self.assertEqual(len(x), 4)
+        # self.assertEqual(len(list(x)), 4)
+
+        # Now test range() with longs
+        self.assertEqual(list(range(-2**100)), [])
+        self.assertEqual(list(range(0, -2**100)), [])
+        self.assertEqual(list(range(0, 2**100, -1)), [])
+        self.assertEqual(list(range(0, 2**100, -1)), [])
+
+        a = int(10 * sys.maxsize)
+        b = int(100 * sys.maxsize)
+        c = int(50 * sys.maxsize)
+
+        # self.assertEqual(list(range(a, a+2)), [a, a+1])
+        # self.assertEqual(list(range(a+2, a, -1)), [a+2, a+1])
+        # self.assertEqual(list(range(a+4, a, -2)), [a+4, a+2])
+
+        # seq = list(range(a, b, c))
+        # self.assertIn(a, seq)
+        # self.assertNotIn(b, seq)
+        # self.assertEqual(len(seq), 2)
+        # self.assertEqual(seq[0], a)
+        # self.assertEqual(seq[-1], a+c)
+
+        # seq = list(range(b, a, -c))
+        # self.assertIn(b, seq)
+        # self.assertNotIn(a, seq)
+        # self.assertEqual(len(seq), 2)
+        # self.assertEqual(seq[0], b)
+        # self.assertEqual(seq[-1], b-c)
+
+        seq = list(range(-a, -b, -c))
+        # self.assertIn(-a, seq)
+        self.assertNotIn(-b, seq)
+        # self.assertEqual(len(seq), 2)
+        # self.assertEqual(seq[0], -a)
+        # self.assertEqual(seq[-1], -a-c)
+
+    def test_large_range(self):
+        # Check long ranges (len > sys.maxsize)
+        # len() is expected to fail due to limitations of the __len__ protocol
+        def _range_len(x):
+            try:
+                length = len(x)
+            except OverflowError:
+                step = x[1] - x[0]
+                length = 1 + ((x[-1] - x[0]) // step)
+            return length
+
+        # a = 0
+        # b = sys.maxsize**10
+        # c = 2*sys.maxsize
+        # expected_len = 1 + (b - a) // c
+        # x = range(a, b, c)
+        # self.assertIn(a, x)
+        # self.assertNotIn(b, x)
+        # self.assertRaises(OverflowError, len, x)
+        # self.assertEqual(_range_len(x), expected_len)
+        # self.assertEqual(x[0], a)
+        # idx = sys.maxsize+1
+        # self.assertEqual(x[idx], a+(idx*c))
+        # self.assertEqual(x[idx:idx+1][0], a+(idx*c))
+        # self.assertRaises(IndexError, lambda: x[-expected_len-1])
+        # self.assertRaises(IndexError, lambda: x[expected_len])
+
+        # a = sys.maxsize**10
+        # b = 0
+        # c = -2*sys.maxsize
+        # expected_len = 1 + (b - a) // c
+        # x = range(a, b, c)
+        # self.assertIn(a, x)
+        # self.assertNotIn(b, x)
+        # self.assertRaises(OverflowError, len, x)
+        # self.assertEqual(_range_len(x), expected_len)
+        # self.assertEqual(x[0], a)
+        # idx = sys.maxsize+1
+        # self.assertEqual(x[idx], a+(idx*c))
+        # self.assertEqual(x[idx:idx+1][0], a+(idx*c))
+        # self.assertRaises(IndexError, lambda: x[-expected_len-1])
+        # self.assertRaises(IndexError, lambda: x[expected_len])
+
+    def test_invalid_invocation(self):
+        self.assertRaises(TypeError, range)
+        self.assertRaises(TypeError, range, 1, 2, 3, 4)
+        self.assertRaises(ValueError, range, 1, 2, 0)
+        a = int(10 * sys.maxsize)
+        self.assertRaises(ValueError, range, a, a + 1, int(0))
+        self.assertRaises(TypeError, range, 1., 1., 1.)
+        self.assertRaises(TypeError, range, 1e100, 1e101, 1e101)
+        self.assertRaises(TypeError, range, 0, "spam")
+        self.assertRaises(TypeError, range, 0, 42, "spam")
+        # Exercise various combinations of bad arguments, to check
+        # refcounting logic
+        self.assertRaises(TypeError, range, 0.0)
+        self.assertRaises(TypeError, range, 0, 0.0)
+        self.assertRaises(TypeError, range, 0.0, 0)
+        self.assertRaises(TypeError, range, 0.0, 0.0)
+        self.assertRaises(TypeError, range, 0, 0, 1.0)
+        self.assertRaises(TypeError, range, 0, 0.0, 1)
+        self.assertRaises(TypeError, range, 0, 0.0, 1.0)
+        self.assertRaises(TypeError, range, 0.0, 0, 1)
+        self.assertRaises(TypeError, range, 0.0, 0, 1.0)
+        self.assertRaises(TypeError, range, 0.0, 0.0, 1)
+        self.assertRaises(TypeError, range, 0.0, 0.0, 1.0)
+
+    def test_index(self):
+        u = range(2)
+        self.assertEqual(u.index(0), 0)
+        self.assertEqual(u.index(1), 1)
+        self.assertRaises(ValueError, u.index, 2)
+
+        u = range(-2, 3)
+        self.assertEqual(u.count(0), 1)
+        self.assertEqual(u.index(0), 2)
+        self.assertRaises(TypeError, u.index)
+
+        class BadExc(Exception):
+            pass
+
+        # class BadCmp:
+        #     def __eq__(self, other):
+        #         if other == 2:
+        #             raise BadExc()
+        #         return False
+
+        # a = range(4)
+        # self.assertRaises(BadExc, a.index, BadCmp())
+
+        a = range(-2, 3)
+        self.assertEqual(a.index(0), 2)
+        self.assertEqual(range(1, 10, 3).index(4), 1)
+        self.assertEqual(range(1, -10, -3).index(-5), 2)
+
+        # self.assertEqual(range(10**20).index(1), 1)
+        # self.assertEqual(range(10**20).index(10**20 - 1), 10**20 - 1)
+
+        # self.assertRaises(ValueError, range(1, 2**100, 2).index, 2**87)
+        # self.assertEqual(range(1, 2**100, 2).index(2**87+1), 2**86)
+
+        class AlwaysEqual(object):
+            def __eq__(self, other):
+                return True
+        always_equal = AlwaysEqual()
+        self.assertEqual(range(10).index(always_equal), 0)
+
+    def test_user_index_method(self):
+        bignum = 2*sys.maxsize
+        smallnum = 42
+
+        # User-defined class with an __index__ method
+        class I:
+            def __init__(self, n):
+                self.n = int(n)
+            def __index__(self):
+                return self.n
+        # self.assertEqual(list(range(I(bignum), I(bignum + 1))), [bignum])
+        # self.assertEqual(list(range(I(smallnum), I(smallnum + 1))), [smallnum])
+
+        # User-defined class with a failing __index__ method
+        class IX:
+            def __index__(self):
+                raise RuntimeError
+        # self.assertRaises(RuntimeError, range, IX())
+
+        # User-defined class with an invalid __index__ method
+        class IN:
+            def __index__(self):
+                return "not a number"
+
+        self.assertRaises(TypeError, range, IN())
+
+        # Test use of user-defined classes in slice indices.
+        self.assertEqual(range(10)[:I(5)], range(5))
+
+        self.assertRaises(RuntimeError, lambda: range(0, 10)[:IX()])
+        self.assertRaises(TypeError, lambda: range(0, 10)[:IN()])
+
+        class AlwaysEqual(object):
+            def __eq__(self, other):
+                return True
+        always_equal = AlwaysEqual()
+        self.assertEqual(range(10).count(always_equal), 10)
+
+        # self.assertEqual(len(range(sys.maxsize, sys.maxsize+10)), 10)
+
+    # def test_repr(self):
+    #     self.assertEqual(repr(range(1)), 'range(0, 1)')
+    #     self.assertEqual(repr(range(1, 2)), 'range(1, 2)')
+    #     self.assertEqual(repr(range(1, 2, 3)), 'range(1, 2, 3)')
+
+    def test_odd_bug(self):
+        # This used to raise a "SystemError: NULL result without error"
+        # because the range validation step was eating the exception
+        # before NULL was returned.
+        self.assertRaises(TypeError, lambda: range([], 1, -1))
+
+    def test_types(self):
+        # Non-integer objects *equal* to any of the range's items are supposed
+        # to be contained in the range.
+        self.assertIn(1.0, range(3))
+        self.assertIn(True, range(3))
+        self.assertIn(1+0j, range(3))
+
+        class C1:
+            def __eq__(self, other): return True
+        self.assertIn(C1(), range(3))
+
+        # Objects are never coerced into other types for comparison.
+        class C2:
+            def __int__(self): return 1
+            def __index__(self): return 1
+        self.assertNotIn(C2(), range(3))
+        # ..except if explicitly told so.
+        self.assertIn(int(C2()), range(3))
+
+        # Check that the range.__contains__ optimization is only
+        # used for ints, not for instances of subclasses of int.
+        class C3(int):
+            def __eq__(self, other): return True
+        # self.assertIn(C3(11), range(10))
+        # self.assertIn(C3(11), list(range(10)))
+
+    def test_strided_limits(self):
+        r = range(0, 101, 2)
+        self.assertIn(0, r)
+        self.assertNotIn(1, r)
+        self.assertIn(2, r)
+        self.assertNotIn(99, r)
+        self.assertIn(100, r)
+        self.assertNotIn(101, r)
+
+        r = range(0, -20, -1)
+        self.assertIn(0, r)
+        self.assertIn(-1, r)
+        self.assertIn(-19, r)
+        self.assertNotIn(-20, r)
+
+        r = range(0, -20, -2)
+        self.assertIn(-18, r)
+        self.assertNotIn(-19, r)
+        self.assertNotIn(-20, r)
+
+    def test_empty(self):
+        r = range(0)
+        self.assertNotIn(0, r)
+        self.assertNotIn(1, r)
+
+        r = range(0, -10)
+        self.assertNotIn(0, r)
+        self.assertNotIn(-1, r)
+        self.assertNotIn(1, r)
+
+    # def test_range_iterators(self):
+    #     # exercise 'fast' iterators, that use a rangeiterobject internally.
+    #     # see issue 7298
+    #     limits = [base + jiggle
+    #               for M in (2**32, 2**64)
+    #               for base in (-M, -M//2, 0, M//2, M)
+    #               for jiggle in (-2, -1, 0, 1, 2)]
+    #     test_ranges = [(start, end, step)
+    #                    for start in limits
+    #                    for end in limits
+    #                    for step in (-2**63, -2**31, -2, -1, 1, 2)]
+    #
+    #     for start, end, step in test_ranges:
+    #         iter1 = range(start, end, step)
+    #         iter2 = pyrange(start, end, step)
+    #         test_id = "range({}, {}, {})".format(start, end, step)
+    #         # check first 100 entries
+    #         self.assert_iterators_equal(iter1, iter2, test_id, limit=100)
+    #
+    #         iter1 = reversed(range(start, end, step))
+    #         iter2 = pyrange_reversed(start, end, step)
+    #         test_id = "reversed(range({}, {}, {}))".format(start, end, step)
+    #         self.assert_iterators_equal(iter1, iter2, test_id, limit=100)
+
+    # def test_slice(self):
+    #     def check(start, stop, step=None):
+    #         i = slice(start, stop, step)
+    #         self.assertEqual(list(r[i]), list(r)[i])
+    #         self.assertEqual(len(r[i]), len(list(r)[i]))
+    #     for r in [range(10),
+    #               range(0),
+    #               range(1, 9, 3),
+    #               range(8, 0, -3),
+    #               range(sys.maxsize+1, sys.maxsize+10),
+    #               ]:
+    #         check(0, 2)
+    #         check(0, 20)
+    #         check(1, 2)
+    #         check(20, 30)
+    #         check(-30, -20)
+    #         check(-1, 100, 2)
+    #         check(0, -1)
+    #         check(-1, -3, -1)
+
+    def test_contains(self):
+        r = range(10)
+        self.assertIn(0, r)
+        self.assertIn(1, r)
+        self.assertIn(5.0, r)
+        self.assertNotIn(5.1, r)
+        self.assertNotIn(-1, r)
+        self.assertNotIn(10, r)
+        self.assertNotIn("", r)
+        r = range(9, -1, -1)
+        self.assertIn(0, r)
+        self.assertIn(1, r)
+        self.assertIn(5.0, r)
+        self.assertNotIn(5.1, r)
+        self.assertNotIn(-1, r)
+        self.assertNotIn(10, r)
+        self.assertNotIn("", r)
+        r = range(0, 10, 2)
+        self.assertIn(0, r)
+        self.assertNotIn(1, r)
+        self.assertNotIn(5.0, r)
+        self.assertNotIn(5.1, r)
+        self.assertNotIn(-1, r)
+        self.assertNotIn(10, r)
+        self.assertNotIn("", r)
+        r = range(9, -1, -2)
+        self.assertNotIn(0, r)
+        self.assertIn(1, r)
+        self.assertIn(5.0, r)
+        self.assertNotIn(5.1, r)
+        self.assertNotIn(-1, r)
+        self.assertNotIn(10, r)
+        self.assertNotIn("", r)
+
+    # def test_reverse_iteration(self):
+    #     for r in [range(10),
+    #               range(0),
+    #               range(1, 9, 3),
+    #               range(8, 0, -3),
+    #               range(sys.maxsize+1, sys.maxsize+10),
+    #               ]:
+    #         self.assertEqual(list(reversed(r)), list(r)[::-1])
+
+    # def test_issue11845(self):
+    #     r = range(*slice(1, 18, 2).indices(20))
+    #     values = {None, 0, 1, -1, 2, -2, 5, -5, 19, -19,
+    #               20, -20, 21, -21, 30, -30, 99, -99}
+    #     for i in values:
+    #         for j in values:
+    #             for k in values - {0}:
+    #                 r[i:j:k]
+
+    def test_comparison(self):
+        test_ranges = [range(0), range(0, -1), range(1, 1, 3),
+                       range(1), range(5, 6), range(5, 6, 2),
+                       range(5, 7, 2), range(2), range(0, 4, 2),
+                       range(0, 5, 2), range(0, 6, 2)]
+        test_tuples = list(map(tuple, test_ranges))
+
+        # Check that equality of ranges matches equality of the corresponding
+        # tuples for each pair from the test lists above.
+        ranges_eq = [a == b for a in test_ranges for b in test_ranges]
+        tuples_eq = [a == b for a in test_tuples for b in test_tuples]
+        self.assertEqual(ranges_eq, tuples_eq)
+
+        # Check that != correctly gives the logical negation of ==
+        ranges_ne = [a != b for a in test_ranges for b in test_ranges]
+        self.assertEqual(ranges_ne, [not x for x in ranges_eq])
+
+        # # Equal ranges should have equal hashes.
+        # for a in test_ranges:
+        #     for b in test_ranges:
+        #         if a == b:
+        #             self.assertEqual(hash(a), hash(b))
+
+        # Ranges are unequal to other types (even sequence types)
+        self.assertIs(range(0) == (), False)
+        self.assertIs(() == range(0), False)
+        # self.assertIs(range(2) == [0, 1], False)
+
+        # # Huge integers aren't a problem.
+        # self.assertEqual(range(2**200, 2**201 - 2**99, 2**100),
+        #                  range(2**200, 2**201, 2**100))
+        # self.assertEqual(hash(range(2**200, 2**201 - 2**99, 2**100)),
+        #                  hash(range(2**200, 2**201, 2**100)))
+        # self.assertNotEqual(range(2**200, 2**201, 2**100),
+        #                     range(2**200, 2**201 + 1, 2**100))
+
+        # # Order comparisons are not implemented for ranges.
+        # self.assertRaises(TypeError, lambda: range(0) < range(0))
+        # self.assertRaises(TypeError, lambda: range(0) > range(0))
+        # self.assertRaises(TypeError, lambda: range(0) <= range(0))
+        # self.assertRaises(TypeError, lambda: range(0) >= range(0))
+
+
+    # def test_attributes(self):
+    #     # test the start, stop and step attributes of range objects
+    #     self.assert_attrs(range(0), 0, 0, 1)
+    #     self.assert_attrs(range(10), 0, 10, 1)
+    #     self.assert_attrs(range(-10), 0, -10, 1)
+    #     self.assert_attrs(range(0, 10, 1), 0, 10, 1)
+    #     self.assert_attrs(range(0, 10, 3), 0, 10, 3)
+    #     self.assert_attrs(range(10, 0, -1), 10, 0, -1)
+    #     self.assert_attrs(range(10, 0, -3), 10, 0, -3)
+    #
+    # def assert_attrs(self, rangeobj, start, stop, step):
+    #     self.assertEqual(rangeobj.start, start)
+    #     self.assertEqual(rangeobj.stop, stop)
+    #     self.assertEqual(rangeobj.step, step)
+    #
+    #     self.assertRaises(AttributeError, rangeobj, start, 0)
+    #     self.assertRaises(AttributeError, rangeobj, stop, 10)
+    #     self.assertRaises(AttributeError, rangeobj, step, 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_scope.py
+++ b/test/unit3/test_scope.py
@@ -1,0 +1,444 @@
+import unittest
+
+
+class ScopeTests(unittest.TestCase):
+
+    def testSimpleNesting(self):
+
+        def make_adder(x):
+            def adder(y):
+                return x + y
+            return adder
+
+        inc = make_adder(1)
+        plus10 = make_adder(10)
+
+        self.assertEqual(inc(1), 2)
+        self.assertEqual(plus10(-2), 8)
+
+    # def testExtraNesting(self):
+    #
+    #     def make_adder2(x):
+    #         def extra(): # check freevars passing through non-use scopes
+    #             def adder(y):
+    #                 return x + y
+    #             return adder
+    #         return extra()
+    #
+    #     inc = make_adder2(1)
+    #     plus10 = make_adder2(10)
+    #
+    #     self.assertEqual(inc(1), 2)
+    #     self.assertEqual(plus10(-2), 8)
+
+    def testSimpleAndRebinding(self):
+
+        def make_adder3(x):
+            def adder(y):
+                return x + y
+            x = x + 1 # check tracking of assignment to x in defining scope
+            return adder
+
+        inc = make_adder3(0)
+        plus10 = make_adder3(9)
+
+        self.assertEqual(inc(1), 2)
+        self.assertEqual(plus10(-2), 8)
+
+    # def testNestingGlobalNoFree(self):
+    #
+    #     def make_adder4(): # XXX add exta level of indirection
+    #         def nest():
+    #             def nest():
+    #                 def adder(y):
+    #                     return global_x + y # check that plain old globals work
+    #                 return adder
+    #             return nest()
+    #         return nest()
+    #
+    #     global_x = 1
+    #     adder = make_adder4()
+    #     self.assertEqual(adder(1), 2)
+    #
+    #     global_x = 10
+    #     self.assertEqual(adder(-2), 8)
+
+    # def testNestingThroughClass(self):
+    #
+    #     def make_adder5(x):
+    #         class Adder:
+    #             def __call__(self, y):
+    #                 return x + y
+    #         return Adder()
+    #
+    #     inc = make_adder5(1)
+    #     plus10 = make_adder5(10)
+    #
+    #     self.assertEqual(inc(1), 2)
+    #     self.assertEqual(plus10(-2), 8)
+
+    def testNestingPlusFreeRefToGlobal(self):
+
+        def make_adder6(x):
+            global global_nest_x
+            def adder(y):
+                return global_nest_x + y
+            global_nest_x = x
+            return adder
+
+        inc = make_adder6(1)
+        plus10 = make_adder6(10)
+
+        self.assertEqual(inc(1), 11) # there's only one global
+        self.assertEqual(plus10(-2), 8)
+
+    def testNearestEnclosingScope(self):
+
+        def f(x):
+            def g(y):
+                x = 42 # check that this masks binding in f()
+                def h(z):
+                    return x + z
+                return h
+            return g(2)
+
+        test_func = f(10)
+        self.assertEqual(test_func(5), 47)
+
+    # def testMixedFreevarsAndCellvars(self):
+    #
+    #     def identity(x):
+    #         return x
+    #
+    #     def f(x, y, z):
+    #         def g(a, b, c):
+    #             a = a + x # 3
+    #             def h():
+    #                 # z * (4 + 9)
+    #                 # 3 * 13
+    #                 return identity(z * (b + y))
+    #             y = c + z # 9
+    #             return h
+    #         return g
+    #
+    #     g = f(1, 2, 3)
+    #     h = g(2, 4, 6)
+    #     self.assertEqual(h(), 39)
+
+    # def testFreeVarInMethod(self):
+    #
+    #     def test():
+    #         method_and_var = "var"
+    #         class Test:
+    #             def method_and_var(self):
+    #                 return "method"
+    #             def test(self):
+    #                 return method_and_var
+    #             def actual_global(self):
+    #                 return str("global")
+    #             def str(self):
+    #                 return str(self)
+    #         return Test()
+    #
+    #     t = test()
+    #     self.assertEqual(t.test(), "var")
+    #     self.assertEqual(t.method_and_var(), "method")
+    #     self.assertEqual(t.actual_global(), "global")
+    #
+    #     method_and_var = "var"
+    #     class Test:
+    #         # this class is not nested, so the rules are different
+    #         def method_and_var(self):
+    #             return "method"
+    #         def test(self):
+    #             return method_and_var
+    #         def actual_global(self):
+    #             return str("global")
+    #         def str(self):
+    #             return str(self)
+    #
+    #     t = Test()
+    #     self.assertEqual(t.test(), "var")
+    #     self.assertEqual(t.method_and_var(), "method")
+    #     self.assertEqual(t.actual_global(), "global")
+
+    def testRecursion(self):
+
+        def f(x):
+            def fact(n):
+                if n == 0:
+                    return 1
+                else:
+                    return n * fact(n - 1)
+            if x >= 0:
+                return fact(x)
+            else:
+                raise ValueError("x must be >= 0")
+
+        self.assertEqual(f(6), 720)
+
+    def testLambdas(self):
+
+        f1 = lambda x: lambda y: x + y
+        inc = f1(1)
+        plus10 = f1(10)
+        self.assertEqual(inc(1), 2)
+        self.assertEqual(plus10(5), 15)
+
+        # f2 = lambda x: (lambda : lambda y: x + y)()
+        # inc = f2(1)
+        # plus10 = f2(10)
+        # self.assertEqual(inc(1), 2)
+        # self.assertEqual(plus10(5), 15)
+        #
+        # f3 = lambda x: lambda y: global_x + y
+        # global_x = 1
+        # inc = f3(None)
+        # self.assertEqual(inc(2), 3)
+        #
+        # f8 = lambda x, y, z: lambda a, b, c: lambda : z * (b + y)
+        # g = f8(1, 2, 3)
+        # h = g(2, 4, 6)
+        # self.assertEqual(h(), 18)
+
+    # def testUnboundLocal(self):
+    #
+    #     def errorInOuter():
+    #         print(y)
+    #         def inner():
+    #             return y
+    #         y = 1
+    #
+    #     def errorInInner():
+    #         def inner():
+    #             return y
+    #         inner()
+    #         y = 1
+    #
+    #     # self.assertRaises(UnboundLocalError, errorInOuter)
+    #     self.assertRaises(NameError, errorInInner)
+
+    # def testLeaks(self):
+    #
+    #     class Foo:
+    #         count = 0
+    #
+    #         def __init__(self):
+    #             Foo.count += 1
+    #
+    #         def __del__(self):
+    #             Foo.count -= 1
+    #
+    #     def f1():
+    #         x = Foo()
+    #         def f2():
+    #             return x
+    #         f2()
+    #
+    #     for i in range(100):
+    #         f1()
+    #
+    #     self.assertEqual(Foo.count, 0)
+
+
+    # def testLocalsFunction(self):
+    #
+    #     def f(x):
+    #         def g(y):
+    #             def h(z):
+    #                 return y + z
+    #             w = x + y
+    #             y += 3
+    #             # return locals()
+    #         return g
+    #
+    #     d = f(2)(4)
+    #     # self.assertIn('h', d)
+    #     del d['h']
+    #     # self.assertEqual(d, {'x': 2, 'y': 7, 'w': 6})
+
+    # def testLocalsClass(self):
+        # This test verifies that calling locals() does not pollute
+        # the local namespace of the class with free variables.  Old
+        # versions of Python had a bug, where a free variable being
+        # passed through a class namespace would be inserted into
+        # locals() by locals() or exec or a trace function.
+        #
+        # The real bug lies in frame code that copies variables
+        # between fast locals and the locals dict, e.g. when executing
+        # a trace function.
+
+        # def f(x):
+        #     class C:
+        #         x = 12
+        #         def m(self):
+        #             return x
+        #         locals()
+        #     return C
+        #
+        # self.assertEqual(f(1).x, 12)
+        #
+        # def f(x):
+        #     class C:
+        #         y = x
+        #         def m(self):
+        #             return x
+        #         z = list(locals())
+        #     return C
+        #
+        # varnames = f(1).z
+        # self.assertNotIn("x", varnames)
+        # self.assertIn("y", varnames)
+
+    # def testLocalsClass_WithTrace(self):
+    #     # Issue23728: after the trace function returns, the locals()
+    #     # dictionary is used to update all variables, this used to
+    #     # include free variables. But in class statements, free
+    #     # variables are not inserted...
+    #     import sys
+    #     self.addCleanup(sys.settrace, sys.gettrace())
+    #     sys.settrace(lambda a,b,c:None)
+    #     x = 12
+    #
+    #     class C:
+    #         def f(self):
+    #             return x
+    #
+    #     self.assertEqual(x, 12) # Used to raise UnboundLocalError
+
+    # def testBoundAndFree(self):
+    #     # var is bound and free in class
+    #
+    #     def f(x):
+    #         class C:
+    #             def m(self):
+    #                 return x
+    #             a = x
+    #         return C
+    #
+    #     inst = f(3)()
+    #     self.assertEqual(inst.a, inst.m())
+
+    # def testEvalExecFreeVars(self):
+    #
+    #     def f(x):
+    #         return lambda: x + 1
+    #
+    #     g = f(3)
+    #     self.assertRaises(TypeError, eval, g.__code__)
+    #
+    #     try:
+    #         exec(g.__code__, {})
+    #     except TypeError:
+    #         pass
+    #     else:
+    #         self.fail("exec should have failed, because code contained free vars")
+
+    # def testListCompLocalVars(self):
+    #
+    #     try:
+    #         print(bad)
+    #     except NameError:
+    #         pass
+    #     else:
+    #         print("bad should not be defined")
+    #
+    #     def x():
+    #         [bad for s in 'a b' for bad in s.split()]
+    #
+    #     x()
+    #     try:
+    #         print(bad)
+    #     except NameError:
+    #         pass
+
+    # def testEvalFreeVars(self):
+    #
+    #     def f(x):
+    #         def g():
+    #             x
+    #             eval("x + 1")
+    #         return g
+    #
+    #     f(4)()
+
+    # def testFreeingCell(self):
+    #     # Test what happens when a finalizer accesses
+    #     # the cell where the object was stored.
+    #     class Special:
+    #         def __del__(self):
+    #             nestedcell_get()
+    #
+    #     inc, dec = f(0)
+    #     self.assertEqual(inc(), 1)
+    #     self.assertEqual(inc(), 2)
+    #     self.assertEqual(dec(), 1)
+    #     self.assertEqual(dec(), 0)
+
+    # def testGlobalInParallelNestedFunctions(self):
+    #     # A symbol table bug leaked the global statement from one
+    #     # function to other nested functions in the same block.
+    #     # This test verifies that a global statement in the first
+    #     # function does not affect the second function.
+    #     local_ns = {}
+    #     global_ns = {}
+    #     exec("""if 1:
+    #         def f():
+    #             y = 1
+    #             def g():
+    #                 global y
+    #                 return y
+    #             def h():
+    #                 return y + 1
+    #             return g, h
+    #         y = 9
+    #         g, h = f()
+    #         result9 = g()
+    #         result2 = h()
+    #         """, local_ns, global_ns)
+    #     self.assertEqual(2, global_ns["result2"])
+    #     self.assertEqual(9, global_ns["result9"])
+
+    # def testClassNamespaceOverridesClosure(self):
+    #     # See #17853.
+    #     x = 42
+    #     class X:
+    #         locals()["x"] = 43
+    #         y = x
+    #     self.assertEqual(X.y, 43)
+    #     class X:
+    #         locals()["x"] = 43
+    #         del x
+    #     self.assertFalse(hasattr(X, "x"))
+    #     self.assertEqual(x, 42)
+
+    # def testCellLeak(self):
+    #     # Issue 17927.
+    #     #
+    #     # The issue was that if self was part of a cycle involving the
+    #     # frame of a method call, *and* the method contained a nested
+    #     # function referencing self, thereby forcing 'self' into a
+    #     # cell, setting self to None would not be enough to break the
+    #     # frame -- the frame had another reference to the instance,
+    #     # which could not be cleared by the code running in the frame
+    #     # (though it will be cleared when the frame is collected).
+    #     # Without the lambda, setting self to None is enough to break
+    #     # the cycle.
+    #     class Tester:
+    #         def dig(self):
+    #             if 0:
+    #                 lambda: self
+    #             try:
+    #                 1/0
+    #             except Exception as exc:
+    #                 self.exc = exc
+    #             self = None  # Break the cycle
+    #     tester = Tester()
+    #     tester.dig()
+    #     ref = weakref.ref(tester)
+    #     del tester
+    #     self.assertIsNone(ref())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_set.py
+++ b/test/unit3/test_set.py
@@ -1,0 +1,1778 @@
+import unittest
+import operator
+import copy
+from random import randrange, shuffle
+import collections
+
+class PassThru(Exception):
+    pass
+
+def check_pass_thru():
+    # raise PassThru
+    yield 1
+
+class BadCmp:
+    def __hash__(self):
+        return 1
+    def __eq__(self, other):
+        raise RuntimeError
+
+# class ReprWrapper:
+#     'Used to test self-referential repr() calls'
+#     def __repr__(self):
+#         return repr(self.value)
+
+class HashCountingInt(int):
+    'int-like object that counts the number of times __hash__ is called'
+    def __init__(self, *args):
+        self.hash_count = 0
+    def __hash__(self):
+        self.hash_count += 1
+        return int.__hash__(self)
+
+class TestJointOps:
+    # Tests common to both set and frozenset
+
+    def setUp(self):
+        self.word = word = 'simsalabim'
+        self.otherword = 'madagascar'
+        self.letters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        self.s = self.thetype(word)
+        # self.d = dict.fromkeys(word)
+
+    # def test_new_or_init(self):
+    #     self.assertRaises(TypeError, self.thetype, [], 2)
+    #     self.assertRaises(TypeError, set().__init__, a=1)
+
+    def test_uniquification(self):
+        # actual = sorted(self.s)
+        # expected = sorted(self.d)
+        # self.assertEqual(actual, expected)
+        self.assertRaises(TypeError, self.thetype, [[]])
+
+    # def test_len(self):
+    #     self.assertEqual(len(self.s), len(self.d))
+
+    # def test_contains(self):
+    #     for c in self.letters:
+    #         self.assertEqual(c in self.s, c in self.d)
+    #     self.assertRaises(TypeError, self.s.__contains__, [[]])
+    #     s = self.thetype([frozenset(self.letters)])
+    #     self.assertIn(self.thetype(self.letters), s)
+
+    def test_union(self):
+        u = self.s.union(self.otherword)
+        # for c in self.letters:
+        #     self.assertEqual(c in u, c in self.d or c in self.otherword)
+        self.assertEqual(self.s, self.thetype(self.word))
+        self.assertEqual(type(u), self.basetype)
+        # self.assertRaises(PassThru, self.s.union, check_pass_thru())
+        for C in set, str, list, tuple:
+            self.assertEqual(self.thetype('abcba').union(C('cdc')), set('abcd'))
+            self.assertEqual(self.thetype('abcba').union(C('efgfe')), set('abcefg'))
+            self.assertEqual(self.thetype('abcba').union(C('ccb')), set('abc'))
+            self.assertEqual(self.thetype('abcba').union(C('ef')), set('abcef'))
+            self.assertEqual(self.thetype('abcba').union(C('ef'), C('fg')), set('abcefg'))
+
+        # Issue #6573
+        x = self.thetype()
+        self.assertEqual(x.union(set([1]), x, set([2])), self.thetype([1, 2]))
+
+    # def test_or(self):
+    #     i = self.s.union(self.otherword)
+    #     self.assertEqual(self.s | set(self.otherword), i)
+    #     self.assertEqual(self.s | frozenset(self.otherword), i)
+    #     try:
+    #         self.s | self.otherword
+    #     except TypeError:
+    #         pass
+    #     else:
+    #         self.fail("s|t did not screen-out general iterables")
+
+    def test_intersection(self):
+        i = self.s.intersection(self.otherword)
+        # for c in self.letters:
+        #     self.assertEqual(c in i, c in self.d and c in self.otherword)
+        self.assertEqual(self.s, self.thetype(self.word))
+        self.assertEqual(type(i), self.basetype)
+        # self.assertRaises(PassThru, self.s.intersection, check_pass_thru())
+        for C in set, str, list, tuple:
+            self.assertEqual(self.thetype('abcba').intersection(C('cdc')), set('cc'))
+            self.assertEqual(self.thetype('abcba').intersection(C('efgfe')), set(''))
+            self.assertEqual(self.thetype('abcba').intersection(C('ccb')), set('bc'))
+            self.assertEqual(self.thetype('abcba').intersection(C('ef')), set(''))
+            self.assertEqual(self.thetype('abcba').intersection(C('cbcf'), C('bag')), set('b'))
+        # s = self.thetype('abcba')
+        # z = s.intersection()
+        # if self.thetype == frozenset():
+        #     self.assertEqual(id(s), id(z))
+        # else:
+        #     self.assertNotEqual(id(s), id(z))
+
+    def test_isdisjoint(self):
+        def f(s1, s2):
+            'Pure python equivalent of isdisjoint()'
+            return not set(s1).intersection(s2)
+        for larg in '', 'a', 'ab', 'abc', 'ababac', 'cdc', 'cc', 'efgfe', 'ccb', 'ef':
+            s1 = self.thetype(larg)
+            for rarg in '', 'a', 'ab', 'abc', 'ababac', 'cdc', 'cc', 'efgfe', 'ccb', 'ef':
+                for C in set, str, list, tuple:
+                    s2 = C(rarg)
+                    actual = s1.isdisjoint(s2)
+                    expected = f(s1, s2)
+                    self.assertEqual(actual, expected)
+                    self.assertTrue(actual is True or actual is False)
+
+    def test_and(self):
+        i = self.s.intersection(self.otherword)
+        # self.assertEqual(self.s & set(self.otherword), i)
+        # self.assertEqual(self.s & frozenset(self.otherword), i)
+        try:
+            self.s & self.otherword
+        except TypeError:
+            pass
+        else:
+            self.fail("s&t did not screen-out general iterables")
+
+    def test_difference(self):
+        i = self.s.difference(self.otherword)
+        # for c in self.letters:
+        #     self.assertEqual(c in i, c in self.d and c not in self.otherword)
+        self.assertEqual(self.s, self.thetype(self.word))
+        self.assertEqual(type(i), self.basetype)
+        # self.assertRaises(PassThru, self.s.difference, check_pass_thru())
+        # self.assertRaises(TypeError, self.s.difference, [[]])
+        for C in set, str, list, tuple:
+            self.assertEqual(self.thetype('abcba').difference(C('cdc')), set('ab'))
+            self.assertEqual(self.thetype('abcba').difference(C('efgfe')), set('abc'))
+            self.assertEqual(self.thetype('abcba').difference(C('ccb')), set('a'))
+            self.assertEqual(self.thetype('abcba').difference(C('ef')), set('abc'))
+            # self.assertEqual(self.thetype('abcba').difference(), set('abc'))
+            self.assertEqual(self.thetype('abcba').difference(C('a'), C('b')), set('c'))
+
+    # def test_sub(self):
+    #     i = self.s.difference(self.otherword)
+    #     self.assertEqual(self.s - set(self.otherword), i)
+    #     self.assertEqual(self.s - frozenset(self.otherword), i)
+    #     try:
+    #         self.s - self.otherword
+    #     except TypeError:
+    #         pass
+    #     else:
+    #         self.fail("s-t did not screen-out general iterables")
+
+    def test_symmetric_difference(self):
+        i = self.s.symmetric_difference(self.otherword)
+        # for c in self.letters:
+        #     self.assertEqual(c in i, (c in self.d) ^ (c in self.otherword))
+        self.assertEqual(self.s, self.thetype(self.word))
+        self.assertEqual(type(i), self.basetype)
+        # self.assertRaises(PassThru, self.s.symmetric_difference, check_pass_thru())
+        self.assertRaises(TypeError, self.s.symmetric_difference, [[]])
+        for C in set, str, list, tuple:
+            # self.assertEqual(self.thetype('abcba').symmetric_difference(C('cdc')), set('abd'))
+            self.assertEqual(self.thetype('abcba').symmetric_difference(C('efgfe')), set('abcefg'))
+            self.assertEqual(self.thetype('abcba').symmetric_difference(C('ccb')), set('a'))
+            self.assertEqual(self.thetype('abcba').symmetric_difference(C('ef')), set('abcef'))
+
+    def test_xor(self):
+        i = self.s.symmetric_difference(self.otherword)
+        # self.assertEqual(self.s ^ set(self.otherword), i)
+        # self.assertEqual(self.s ^ frozenset(self.otherword), i)
+        try:
+            self.s ^ self.otherword
+        except TypeError:
+            pass
+        else:
+            self.fail("s^t did not screen-out general iterables")
+
+    def test_equality(self):
+        self.assertEqual(self.s, set(self.word))
+        # self.assertEqual(self.s, frozenset(self.word))
+        self.assertEqual(self.s == self.word, False)
+        self.assertNotEqual(self.s, set(self.otherword))
+        # self.assertNotEqual(self.s, frozenset(self.otherword))
+        self.assertEqual(self.s != self.word, True)
+
+    # def test_setOfFrozensets(self):
+    #     t = map(frozenset, ['abcdef', 'bcd', 'bdcb', 'fed', 'fedccba'])
+    #     s = self.thetype(t)
+    #     self.assertEqual(len(s), 3)
+
+    def test_sub_and_super(self):
+        p, q, r = map(self.thetype, ['ab', 'abcde', 'def'])
+        self.assertTrue(p < q)
+        self.assertTrue(p <= q)
+        self.assertTrue(q <= q)
+        self.assertTrue(q > p)
+        self.assertTrue(q >= p)
+        self.assertFalse(q < r)
+        self.assertFalse(q <= r)
+        self.assertFalse(q > r)
+        self.assertFalse(q >= r)
+        self.assertTrue(set('a').issubset('abc'))
+        self.assertTrue(set('abc').issuperset('a'))
+        self.assertFalse(set('a').issubset('cbs'))
+        self.assertFalse(set('cbs').issuperset('a'))
+
+    def test_deepcopy(self):
+        class Tracer:
+            def __init__(self, value):
+                self.value = value
+            def __hash__(self):
+                return self.value
+            # def __deepcopy__(self, memo=None):
+            #     return Tracer(self.value + 1)
+        t = Tracer(10)
+        s = self.thetype([t])
+        dup = copy.deepcopy(s)
+        self.assertNotEqual(id(s), id(dup))
+        # for elem in dup:
+        #     newt = elem
+        # self.assertNotEqual(id(t), id(newt))
+        # self.assertEqual(t.value + 1, newt.value)
+
+    def test_gc(self):
+        # Create a nest of cycles to exercise overall ref count check
+        class A:
+            pass
+        s = set(A() for i in range(1000))
+        for elem in s:
+            elem.cycle = s
+            elem.sub = elem
+            elem.set = set([elem])
+
+    def test_subclass_with_custom_hash(self):
+        # Bug #1257731
+        class H(self.thetype):
+            def __hash__(self):
+                return int(id(self) & 0x7fffffff)
+        s=H()
+        f=set()
+        f.add(s)
+        self.assertIn(s, f)
+        f.remove(s)
+        f.add(s)
+        f.discard(s)
+
+    def test_badcmp(self):
+        s = self.thetype([BadCmp()])
+        # Detect comparison errors during insertion and lookup
+        self.assertRaises(RuntimeError, self.thetype, [BadCmp(), BadCmp()])
+        # self.assertRaises(RuntimeError, s.__contains__, BadCmp())
+        # Detect errors during mutating operations
+        if hasattr(s, 'add'):
+            self.assertRaises(RuntimeError, s.add, BadCmp())
+            self.assertRaises(RuntimeError, s.discard, BadCmp())
+            self.assertRaises(RuntimeError, s.remove, BadCmp())
+
+    # def test_cyclical_repr(self):
+    #     w = ReprWrapper()
+    #     s = self.thetype([w])
+    #     w.value = s
+    #     if self.thetype == set:
+    #         self.assertEqual(repr(s), '{set(...)}')
+    #     else:
+    #         name = repr(s).partition('(')[0]    # strip class name
+    #         self.assertEqual(repr(s), '%s({%s(...)})' % (name, name))
+
+    # def test_do_not_rehash_dict_keys(self):
+    #     n = 10
+    #     d = dict.fromkeys(map(HashCountingInt, range(n)))
+    #     self.assertEqual(sum(elem.hash_count for elem in d), n)
+    #     s = self.thetype(d)
+    #     self.assertEqual(sum(elem.hash_count for elem in d), n)
+    #     s.difference(d)
+    #     self.assertEqual(sum(elem.hash_count for elem in d), n)
+    #     if hasattr(s, 'symmetric_difference_update'):
+    #         s.symmetric_difference_update(d)
+    #     self.assertEqual(sum(elem.hash_count for elem in d), n)
+    #     d2 = dict.fromkeys(set(d))
+    #     self.assertEqual(sum(elem.hash_count for elem in d), n)
+    #     d3 = dict.fromkeys(frozenset(d))
+    #     self.assertEqual(sum(elem.hash_count for elem in d), n)
+    #     d3 = dict.fromkeys(frozenset(d), 123)
+    #     self.assertEqual(sum(elem.hash_count for elem in d), n)
+    #     self.assertEqual(d3, dict.fromkeys(d, 123))
+
+class TestSet(TestJointOps, unittest.TestCase):
+    thetype = set
+    basetype = set
+
+    # def test_init(self):
+    #     s = self.thetype()
+    #     s.__init__(self.word)
+    #     self.assertEqual(s, set(self.word))
+    #     s.__init__(self.otherword)
+    #     self.assertEqual(s, set(self.otherword))
+    #     self.assertRaises(TypeError, s.__init__, s, 2);
+    #     self.assertRaises(TypeError, s.__init__, 1);
+
+    def test_constructor_identity(self):
+        s = self.thetype(range(3))
+        t = self.thetype(s)
+        self.assertNotEqual(id(s), id(t))
+
+    def test_set_literal(self):
+        s = set([1,2,3])
+        t = {1,2,3}
+        self.assertEqual(s, t)
+
+    def test_set_literal_insertion_order(self):
+        # SF Issue #26020 -- Expect left to right insertion
+        s = {1, 1.0, True}
+        self.assertEqual(len(s), 1)
+        stored_value = s.pop()
+        self.assertEqual(type(stored_value), int)
+
+    def test_set_literal_evaluation_order(self):
+        # Expect left to right expression evaluation
+        events = []
+        def record(obj):
+            events.append(obj)
+        s = {record(1), record(2), record(3)}
+        self.assertEqual(events, [1, 2, 3])
+
+    def test_hash(self):
+        self.assertRaises(TypeError, hash, self.s)
+
+    # def test_clear(self):
+    #     self.s.clear()
+    #     self.assertEqual(self.s, set())
+    #     self.assertEqual(len(self.s), 0)
+
+    def test_copy(self):
+        dup = self.s.copy()
+        self.assertEqual(self.s, dup)
+        self.assertNotEqual(id(self.s), id(dup))
+        self.assertEqual(type(dup), self.basetype)
+
+    def test_add(self):
+        self.s.add('Q')
+        self.assertIn('Q', self.s)
+        dup = self.s.copy()
+        self.s.add('Q')
+        self.assertEqual(self.s, dup)
+        self.assertRaises(TypeError, self.s.add, [])
+
+    def test_remove(self):
+        self.s.remove('a')
+        self.assertNotIn('a', self.s)
+        self.assertRaises(KeyError, self.s.remove, 'Q')
+        self.assertRaises(TypeError, self.s.remove, [])
+        # s = self.thetype([frozenset(self.word)])
+        # self.assertIn(self.thetype(self.word), s)
+        # s.remove(self.thetype(self.word))
+        # self.assertNotIn(self.thetype(self.word), s)
+        # self.assertRaises(KeyError, self.s.remove, self.thetype(self.word))
+
+    # def test_remove_keyerror_unpacking(self):
+    #     # bug:  www.python.org/sf/1576657
+    #     for v1 in ['Q', (1,)]:
+    #         try:
+    #             self.s.remove(v1)
+    #         except KeyError as e:
+    #             v2 = e.args[0]
+    #             self.assertEqual(v1, v2)
+    #         else:
+    #             self.fail()
+
+    # def test_remove_keyerror_set(self):
+    #     key = self.thetype([3, 4])
+    #     try:
+    #         self.s.remove(key)
+    #     except KeyError as e:
+    #         self.assertTrue(e.args[0] is key,
+    #                      "KeyError should be {0}, not {1}".format(key,
+    #                                                               e.args[0]))
+    #     else:
+    #         self.fail()
+
+    def test_discard(self):
+        self.s.discard('a')
+        self.assertNotIn('a', self.s)
+        self.s.discard('Q')
+        self.assertRaises(TypeError, self.s.discard, [])
+        # s = self.thetype([frozenset(self.word)])
+        # self.assertIn(self.thetype(self.word), s)
+        # s.discard(self.thetype(self.word))
+        # self.assertNotIn(self.thetype(self.word), s)
+        # s.discard(self.thetype(self.word))
+
+    def test_pop(self):
+        for i in range(len(self.s)):
+            elem = self.s.pop()
+            self.assertNotIn(elem, self.s)
+        self.assertRaises(KeyError, self.s.pop)
+
+    def test_update(self):
+        retval = self.s.update(self.otherword)
+        self.assertEqual(retval, None)
+        for c in (self.word + self.otherword):
+            self.assertIn(c, self.s)
+        # self.assertRaises(PassThru, self.s.update, check_pass_thru())
+        self.assertRaises(TypeError, self.s.update, [[]])
+        for p, q in (('cdc', 'abcd'), ('efgfe', 'abcefg'), ('ccb', 'abc'), ('ef', 'abcef')):
+            for C in set, str, list, tuple:
+                s = self.thetype('abcba')
+                self.assertEqual(s.update(C(p)), None)
+                self.assertEqual(s, set(q))
+        for p in ('cdc', 'efgfe', 'ccb', 'ef', 'abcda'):
+            q = 'ahi'
+            for C in set, str, list, tuple:
+                s = self.thetype('abcba')
+                self.assertEqual(s.update(C(p), C(q)), None)
+                # self.assertEqual(s, set(s) | set(p) | set(q))
+
+    # def test_ior(self):
+    #     self.s |= set(self.otherword)
+    #     for c in (self.word + self.otherword):
+    #         self.assertIn(c, self.s)
+
+    def test_intersection_update(self):
+        retval = self.s.intersection_update(self.otherword)
+        self.assertEqual(retval, None)
+        for c in (self.word + self.otherword):
+            if c in self.otherword and c in self.word:
+                self.assertIn(c, self.s)
+            else:
+                self.assertNotIn(c, self.s)
+        # self.assertRaises(PassThru, self.s.intersection_update, check_pass_thru())
+        # self.assertRaises(TypeError, self.s.intersection_update, [[]])
+        for p, q in (('cdc', 'c'), ('efgfe', ''), ('ccb', 'bc'), ('ef', '')):
+            for C in set, str, list, tuple:
+                s = self.thetype('abcba')
+                self.assertEqual(s.intersection_update(C(p)), None)
+                self.assertEqual(s, set(q))
+                ss = 'abcba'
+                s = self.thetype(ss)
+                t = 'cbc'
+                self.assertEqual(s.intersection_update(C(p), C(t)), None)
+                # self.assertEqual(s, set('abcba')&set(p)&set(t))
+
+    def test_iand(self):
+        # self.s &= set(self.otherword)
+        for c in (self.word + self.otherword):
+            if c in self.otherword and c in self.word:
+                self.assertIn(c, self.s)
+            # else:
+                # self.assertNotIn(c, self.s)
+
+    def test_difference_update(self):
+        retval = self.s.difference_update(self.otherword)
+        self.assertEqual(retval, None)
+        for c in (self.word + self.otherword):
+            if c in self.word and c not in self.otherword:
+                self.assertIn(c, self.s)
+            else:
+                self.assertNotIn(c, self.s)
+        # self.assertRaises(PassThru, self.s.difference_update, check_pass_thru())
+        # self.assertRaises(TypeError, self.s.difference_update, [[]])
+        # self.assertRaises(TypeError, self.s.symmetric_difference_update, [[]])
+        for p, q in (('cdc', 'ab'), ('efgfe', 'abc'), ('ccb', 'a'), ('ef', 'abc')):
+            for C in set, str, list, tuple:
+                s = self.thetype('abcba')
+                self.assertEqual(s.difference_update(C(p)), None)
+                self.assertEqual(s, set(q))
+
+                s = self.thetype('abcdefghih')
+                # s.difference_update()
+                self.assertEqual(s, self.thetype('abcdefghih'))
+
+                s = self.thetype('abcdefghih')
+                s.difference_update(C('aba'))
+                self.assertEqual(s, self.thetype('cdefghih'))
+
+                s = self.thetype('abcdefghih')
+                s.difference_update(C('cdc'), C('aba'))
+                self.assertEqual(s, self.thetype('efghih'))
+
+    # def test_isub(self):
+    #     self.s -= set(self.otherword)
+    #     for c in (self.word + self.otherword):
+    #         if c in self.word and c not in self.otherword:
+    #             self.assertIn(c, self.s)
+    #         else:
+    #             self.assertNotIn(c, self.s)
+
+    def test_symmetric_difference_update(self):
+        retval = self.s.symmetric_difference_update(self.otherword)
+        self.assertEqual(retval, None)
+        for c in (self.word + self.otherword):
+            if (c in self.word) ^ (c in self.otherword):
+                self.assertIn(c, self.s)
+            else:
+                self.assertNotIn(c, self.s)
+        # self.assertRaises(PassThru, self.s.symmetric_difference_update, check_pass_thru())
+        self.assertRaises(TypeError, self.s.symmetric_difference_update, [[]])
+        for p, q in (('cdc', 'abd'), ('efgfe', 'abcefg'), ('ccb', 'a'), ('ef', 'abcef')):
+            for C in set, str, list, tuple:
+                s = self.thetype('abcba')
+                self.assertEqual(s.symmetric_difference_update(C(p)), None)
+                self.assertEqual(s, set(q))
+
+    # def test_ixor(self):
+    #     self.s ^= set(self.otherword)
+    #     for c in (self.word + self.otherword):
+    #         if (c in self.word) ^ (c in self.otherword):
+    #             self.assertIn(c, self.s)
+    #         else:
+    #             self.assertNotIn(c, self.s)
+
+    # def test_inplace_on_self(self):
+    #     t = self.s.copy()
+    #     t |= t
+    #     self.assertEqual(t, self.s)
+    #     t &= t
+    #     self.assertEqual(t, self.s)
+    #     t -= t
+    #     self.assertEqual(t, self.thetype())
+    #     t = self.s.copy()
+    #     t ^= t
+    #     self.assertEqual(t, self.thetype())
+
+    # def test_weakref(self):
+    #     s = self.thetype('gallahad')
+    #     p = weakref.proxy(s)
+    #     self.assertEqual(str(p), str(s))
+    #     s = None
+    #     self.assertRaises(ReferenceError, str, p)
+
+    # def test_rich_compare(self):
+    #     class TestRichSetCompare:
+    #         def __gt__(self, some_set):
+    #             self.gt_called = True
+    #             return False
+    #         def __lt__(self, some_set):
+    #             self.lt_called = True
+    #             return False
+    #         def __ge__(self, some_set):
+    #             self.ge_called = True
+    #             return False
+    #         def __le__(self, some_set):
+    #             self.le_called = True
+    #             return False
+    #
+    #     # This first tries the builtin rich set comparison, which doesn't know
+    #     # how to handle the custom object. Upon returning NotImplemented, the
+    #     # corresponding comparison on the right object is invoked.
+    #     myset = {1, 2, 3}
+    #
+    #     myobj = TestRichSetCompare()
+    #     myset < myobj
+    #     self.assertTrue(myobj.gt_called)
+    #
+    #     myobj = TestRichSetCompare()
+    #     myset > myobj
+    #     self.assertTrue(myobj.lt_called)
+    #
+    #     myobj = TestRichSetCompare()
+    #     myset <= myobj
+    #     self.assertTrue(myobj.ge_called)
+    #
+    #     myobj = TestRichSetCompare()
+    #     myset >= myobj
+    #     self.assertTrue(myobj.le_called)
+
+
+
+class SetSubclass(set):
+    pass
+
+class TestSetSubclass(TestSet):
+    thetype = SetSubclass
+    basetype = set
+
+class SetSubclassWithKeywordArgs(set):
+    def __init__(self, iterable=[], newarg=None):
+        # set.__init__(self, iterable)
+        pass
+
+class TestSetSubclassWithKeywordArgs(TestSet):
+
+    def test_keywords_in_subclass(self):
+        'SF bug #1486663 -- this used to erroneously raise a TypeError'
+        SetSubclassWithKeywordArgs(newarg=1)
+
+# class TestFrozenSet(TestJointOps, unittest.TestCase):
+#     thetype = frozenset
+#     basetype = frozenset
+#
+#     def test_init(self):
+#         s = self.thetype(self.word)
+#         s.__init__(self.otherword)
+#         self.assertEqual(s, set(self.word))
+#
+#     def test_singleton_empty_frozenset(self):
+#         f = frozenset()
+#         efs = [frozenset(), frozenset([]), frozenset(()), frozenset(''),
+#                frozenset(), frozenset([]), frozenset(()), frozenset(''),
+#                frozenset(range(0)), frozenset(frozenset()),
+#                frozenset(f), f]
+#         # All of the empty frozensets should have just one id()
+#         self.assertEqual(len(set(map(id, efs))), 1)
+#
+#     def test_constructor_identity(self):
+#         s = self.thetype(range(3))
+#         t = self.thetype(s)
+#         self.assertEqual(id(s), id(t))
+#
+#     def test_hash(self):
+#         self.assertEqual(hash(self.thetype('abcdeb')),
+#                          hash(self.thetype('ebecda')))
+#
+#         # make sure that all permutations give the same hash value
+#         n = 100
+#         seq = [randrange(n) for i in range(n)]
+#         results = set()
+#         for i in range(200):
+#             shuffle(seq)
+#             results.add(hash(self.thetype(seq)))
+#         self.assertEqual(len(results), 1)
+#
+#     def test_copy(self):
+#         dup = self.s.copy()
+#         self.assertEqual(id(self.s), id(dup))
+#
+#     def test_frozen_as_dictkey(self):
+#         seq = list(range(10)) + list('abcdefg') + ['apple']
+#         key1 = self.thetype(seq)
+#         key2 = self.thetype(reversed(seq))
+#         self.assertEqual(key1, key2)
+#         self.assertNotEqual(id(key1), id(key2))
+#         d = {}
+#         d[key1] = 42
+#         self.assertEqual(d[key2], 42)
+#
+#     def test_hash_caching(self):
+#         f = self.thetype('abcdcda')
+#         self.assertEqual(hash(f), hash(f))
+#
+#     def test_hash_effectiveness(self):
+#         n = 13
+#         hashvalues = set()
+#         addhashvalue = hashvalues.add
+#         elemmasks = [(i+1, 1<<i) for i in range(n)]
+#         for i in range(2**n):
+#             addhashvalue(hash(frozenset([e for e, m in elemmasks if m&i])))
+#         self.assertEqual(len(hashvalues), 2**n)
+#
+#         def zf_range(n):
+#             # https://en.wikipedia.org/wiki/Set-theoretic_definition_of_natural_numbers
+#             nums = [frozenset()]
+#             for i in range(n-1):
+#                 num = frozenset(nums)
+#                 nums.append(num)
+#             return nums[:n]
+#
+# class FrozenSetSubclass(frozenset):
+#     pass
+#
+# class TestFrozenSetSubclass(TestFrozenSet):
+#     thetype = FrozenSetSubclass
+#     basetype = frozenset
+#
+#     def test_constructor_identity(self):
+#         s = self.thetype(range(3))
+#         t = self.thetype(s)
+#         self.assertNotEqual(id(s), id(t))
+#
+#     def test_copy(self):
+#         dup = self.s.copy()
+#         self.assertNotEqual(id(self.s), id(dup))
+#
+#     def test_nested_empty_constructor(self):
+#         s = self.thetype()
+#         t = self.thetype(s)
+#         self.assertEqual(s, t)
+#
+#     def test_singleton_empty_frozenset(self):
+#         Frozenset = self.thetype
+#         f = frozenset()
+#         F = Frozenset()
+#         efs = [Frozenset(), Frozenset([]), Frozenset(()), Frozenset(''),
+#                Frozenset(), Frozenset([]), Frozenset(()), Frozenset(''),
+#                Frozenset(range(0)), Frozenset(Frozenset()),
+#                Frozenset(frozenset()), f, F, Frozenset(f), Frozenset(F)]
+#         # All empty frozenset subclass instances should have different ids
+#         self.assertEqual(len(set(map(id, efs))), len(efs))
+
+# Tests taken from test_sets.py =============================================
+
+empty_set = set()
+
+#==============================================================================
+
+class TestBasicOps:
+
+    def test_repr(self):
+        if self.repr is not None:
+            pass
+            # self.assertEqual(repr(self.set), self.repr)
+
+    def check_repr_against_values(self):
+        text = repr(self.set)
+        self.assertTrue(text.startswith('{'))
+        self.assertTrue(text.endswith('}'))
+
+        result = text[1:-1].split(', ')
+        result.sort()
+        sorted_repr_values = [repr(value) for value in self.values]
+        sorted_repr_values.sort()
+        self.assertEqual(result, sorted_repr_values)
+
+
+    def test_length(self):
+        self.assertEqual(len(self.set), self.length)
+
+    def test_self_equality(self):
+        self.assertEqual(self.set, self.set)
+
+    def test_equivalent_equality(self):
+        self.assertEqual(self.set, self.dup)
+
+    def test_copy(self):
+        self.assertEqual(self.set.copy(), self.dup)
+
+    # def test_self_union(self):
+    #     result = self.set | self.set
+    #     self.assertEqual(result, self.dup)
+
+    # def test_empty_union(self):
+    #     result = self.set | empty_set
+    #     self.assertEqual(result, self.dup)
+
+    # def test_union_empty(self):
+    #     result = empty_set | self.set
+    #     self.assertEqual(result, self.dup)
+
+    # def test_self_intersection(self):
+    #     result = self.set & self.set
+    #     self.assertEqual(result, self.dup)
+
+    # def test_empty_intersection(self):
+    #     result = self.set & empty_set
+    #     self.assertEqual(result, empty_set)
+
+    # def test_intersection_empty(self):
+    #     result = empty_set & self.set
+    #     self.assertEqual(result, empty_set)
+
+    def test_self_isdisjoint(self):
+        result = self.set.isdisjoint(self.set)
+        self.assertEqual(result, not self.set)
+
+    def test_empty_isdisjoint(self):
+        result = self.set.isdisjoint(empty_set)
+        self.assertEqual(result, True)
+
+    def test_isdisjoint_empty(self):
+        result = empty_set.isdisjoint(self.set)
+        self.assertEqual(result, True)
+
+    # def test_self_symmetric_difference(self):
+    #     result = self.set ^ self.set
+    #     self.assertEqual(result, empty_set)
+
+    # def test_empty_symmetric_difference(self):
+    #     result = self.set ^ empty_set
+    #     self.assertEqual(result, self.set)
+
+    # def test_self_difference(self):
+    #     result = self.set - self.set
+    #     self.assertEqual(result, empty_set)
+
+    # def test_empty_difference(self):
+    #     result = self.set - empty_set
+    #     self.assertEqual(result, self.dup)
+
+    # def test_empty_difference_rev(self):
+    #     result = empty_set - self.set
+    #     self.assertEqual(result, empty_set)
+
+    def test_iteration(self):
+        for v in self.set:
+            self.assertIn(v, self.values)
+        # setiter = iter(self.set)
+        # self.assertEqual(setiter.__length_hint__(), len(self.set))
+
+#------------------------------------------------------------------------------
+
+class TestBasicOpsEmpty(TestBasicOps, unittest.TestCase):
+    def setUp(self):
+        self.case   = "empty set"
+        self.values = []
+        self.set    = set(self.values)
+        self.dup    = set(self.values)
+        self.length = 0
+        self.repr   = "set()"
+
+#------------------------------------------------------------------------------
+
+class TestBasicOpsSingleton(TestBasicOps, unittest.TestCase):
+    def setUp(self):
+        self.case   = "unit set (number)"
+        self.values = [3]
+        self.set    = set(self.values)
+        self.dup    = set(self.values)
+        self.length = 1
+        self.repr   = "{3}"
+
+    def test_in(self):
+        self.assertIn(3, self.set)
+
+    def test_not_in(self):
+        self.assertNotIn(2, self.set)
+
+#------------------------------------------------------------------------------
+
+class TestBasicOpsTuple(TestBasicOps, unittest.TestCase):
+    def setUp(self):
+        self.case   = "unit set (tuple)"
+        self.values = [(0, "zero")]
+        self.set    = set(self.values)
+        self.dup    = set(self.values)
+        self.length = 1
+        self.repr   = "{(0, 'zero')}"
+
+    def test_in(self):
+        self.assertIn((0, "zero"), self.set)
+
+    def test_not_in(self):
+        self.assertNotIn(9, self.set)
+
+#------------------------------------------------------------------------------
+
+class TestBasicOpsTriple(TestBasicOps, unittest.TestCase):
+    def setUp(self):
+        self.case   = "triple set"
+        self.values = [0, "zero", operator.add]
+        self.set    = set(self.values)
+        self.dup    = set(self.values)
+        self.length = 3
+        self.repr   = None
+
+#------------------------------------------------------------------------------
+
+class TestBasicOpsString(TestBasicOps, unittest.TestCase):
+    def setUp(self):
+        self.case   = "string set"
+        self.values = ["a", "b", "c"]
+        self.set    = set(self.values)
+        self.dup    = set(self.values)
+        self.length = 3
+
+    def test_repr(self):
+        self.check_repr_against_values()
+
+
+#==============================================================================
+
+def baditer():
+    raise TypeError
+    yield True
+
+def gooditer():
+    yield True
+
+class TestExceptionPropagation(unittest.TestCase):
+    """SF 628246:  Set constructor should not trap iterator TypeErrors"""
+
+    def test_instanceWithException(self):
+        self.assertRaises(TypeError, set, baditer())
+
+    def test_instancesWithoutException(self):
+        # All of these iterables should load without exception.
+        set([1,2,3])
+        set((1,2,3))
+        set({'one':1, 'two':2, 'three':3})
+        set(range(3))
+        set('abc')
+        set(gooditer())
+
+    # def test_changingSizeWhileIterating(self):
+    #     s = set([1,2,3])
+    #     try:
+    #         for i in s:
+    #             s.update([4])
+    #     except RuntimeError:
+    #         pass
+    #     else:
+    #         self.fail("no exception when changing size during iteration")
+
+#==============================================================================
+
+# class TestSetOfSets(unittest.TestCase):
+#     def test_constructor(self):
+#         inner = frozenset([1])
+#         outer = set([inner])
+#         element = outer.pop()
+#         self.assertEqual(type(element), frozenset)
+#         outer.add(inner)        # Rebuild set of sets with .add method
+#         outer.remove(inner)
+#         self.assertEqual(outer, set())   # Verify that remove worked
+#         outer.discard(inner)    # Absence of KeyError indicates working fine
+
+#==============================================================================
+
+class TestBinaryOps(unittest.TestCase):
+    def setUp(self):
+        self.set = set((2, 4, 6))
+
+    def test_eq(self):              # SF bug 643115
+        self.assertEqual(self.set, set({2:1,4:3,6:5}))
+
+    # def test_union_subset(self):
+    #     result = self.set | set([2])
+    #     self.assertEqual(result, set((2, 4, 6)))
+    #
+    # def test_union_superset(self):
+    #     result = self.set | set([2, 4, 6, 8])
+    #     self.assertEqual(result, set([2, 4, 6, 8]))
+    #
+    # def test_union_overlap(self):
+    #     result = self.set | set([3, 4, 5])
+    #     self.assertEqual(result, set([2, 3, 4, 5, 6]))
+    #
+    # def test_union_non_overlap(self):
+    #     result = self.set | set([8])
+    #     self.assertEqual(result, set([2, 4, 6, 8]))
+    #
+    # def test_intersection_subset(self):
+    #     result = self.set & set((2, 4))
+    #     self.assertEqual(result, set((2, 4)))
+    #
+    # def test_intersection_superset(self):
+    #     result = self.set & set([2, 4, 6, 8])
+    #     self.assertEqual(result, set([2, 4, 6]))
+    #
+    # def test_intersection_overlap(self):
+    #     result = self.set & set([3, 4, 5])
+    #     self.assertEqual(result, set([4]))
+    #
+    # def test_intersection_non_overlap(self):
+    #     result = self.set & set([8])
+    #     self.assertEqual(result, empty_set)
+
+    def test_isdisjoint_subset(self):
+        result = self.set.isdisjoint(set((2, 4)))
+        self.assertEqual(result, False)
+
+    def test_isdisjoint_superset(self):
+        result = self.set.isdisjoint(set([2, 4, 6, 8]))
+        self.assertEqual(result, False)
+
+    def test_isdisjoint_overlap(self):
+        result = self.set.isdisjoint(set([3, 4, 5]))
+        self.assertEqual(result, False)
+
+    def test_isdisjoint_non_overlap(self):
+        result = self.set.isdisjoint(set([8]))
+        self.assertEqual(result, True)
+
+    # def test_sym_difference_subset(self):
+    #     result = self.set ^ set((2, 4))
+    #     self.assertEqual(result, set([6]))
+    #
+    # def test_sym_difference_superset(self):
+    #     result = self.set ^ set((2, 4, 6, 8))
+    #     self.assertEqual(result, set([8]))
+    #
+    # def test_sym_difference_overlap(self):
+    #     result = self.set ^ set((3, 4, 5))
+    #     self.assertEqual(result, set([2, 3, 5, 6]))
+    #
+    # def test_sym_difference_non_overlap(self):
+    #     result = self.set ^ set([8])
+    #     self.assertEqual(result, set([2, 4, 6, 8]))
+
+#==============================================================================
+
+class TestUpdateOps(unittest.TestCase):
+    def setUp(self):
+        self.set = set((2, 4, 6))
+
+    # def test_union_subset(self):
+    #     self.set |= set([2])
+    #     self.assertEqual(self.set, set((2, 4, 6)))
+    #
+    # def test_union_superset(self):
+    #     self.set |= set([2, 4, 6, 8])
+    #     self.assertEqual(self.set, set([2, 4, 6, 8]))
+    #
+    # def test_union_overlap(self):
+    #     self.set |= set([3, 4, 5])
+    #     self.assertEqual(self.set, set([2, 3, 4, 5, 6]))
+
+    # def test_union_non_overlap(self):
+    #     self.set |= set([8])
+    #     self.assertEqual(self.set, set([2, 4, 6, 8]))
+
+    def test_union_method_call(self):
+        self.set.update(set([3, 4, 5]))
+        self.assertEqual(self.set, set([2, 3, 4, 5, 6]))
+
+    # def test_intersection_subset(self):
+    #     self.set &= set((2, 4))
+    #     self.assertEqual(self.set, set((2, 4)))
+    #
+    # def test_intersection_superset(self):
+    #     self.set &= set([2, 4, 6, 8])
+    #     self.assertEqual(self.set, set([2, 4, 6]))
+
+    # def test_intersection_overlap(self):
+    #     self.set &= set([3, 4, 5])
+    #     self.assertEqual(self.set, set([4]))
+    #
+    # def test_intersection_non_overlap(self):
+    #     self.set &= set([8])
+    #     self.assertEqual(self.set, empty_set)
+
+    def test_intersection_method_call(self):
+        self.set.intersection_update(set([3, 4, 5]))
+        self.assertEqual(self.set, set([4]))
+
+    # def test_sym_difference_subset(self):
+    #     self.set ^= set((2, 4))
+    #     self.assertEqual(self.set, set([6]))
+    #
+    # def test_sym_difference_superset(self):
+    #     self.set ^= set((2, 4, 6, 8))
+    #     self.assertEqual(self.set, set([8]))
+    #
+    # def test_sym_difference_overlap(self):
+    #     self.set ^= set((3, 4, 5))
+    #     self.assertEqual(self.set, set([2, 3, 5, 6]))
+
+    # def test_sym_difference_non_overlap(self):
+    #     self.set ^= set([8])
+    #     self.assertEqual(self.set, set([2, 4, 6, 8]))
+
+    def test_sym_difference_method_call(self):
+        self.set.symmetric_difference_update(set([3, 4, 5]))
+        self.assertEqual(self.set, set([2, 3, 5, 6]))
+
+    # def test_difference_subset(self):
+    #     self.set -= set((2, 4))
+    #     self.assertEqual(self.set, set([6]))
+
+    # def test_difference_superset(self):
+    #     self.set -= set((2, 4, 6, 8))
+    #     self.assertEqual(self.set, set([]))
+    #
+    # def test_difference_overlap(self):
+    #     self.set -= set((3, 4, 5))
+    #     self.assertEqual(self.set, set([2, 6]))
+
+    # def test_difference_non_overlap(self):
+    #     self.set -= set([8])
+    #     self.assertEqual(self.set, set([2, 4, 6]))
+
+    def test_difference_method_call(self):
+        self.set.difference_update(set([3, 4, 5]))
+        self.assertEqual(self.set, set([2, 6]))
+
+#==============================================================================
+
+class TestMutate(unittest.TestCase):
+    def setUp(self):
+        self.values = ["a", "b", "c"]
+        self.set = set(self.values)
+
+    def test_add_present(self):
+        self.set.add("c")
+        self.assertEqual(self.set, set("abc"))
+
+    def test_add_absent(self):
+        self.set.add("d")
+        self.assertEqual(self.set, set("abcd"))
+
+    def test_add_until_full(self):
+        tmp = set()
+        expected_len = 0
+        for v in self.values:
+            tmp.add(v)
+            expected_len += 1
+            self.assertEqual(len(tmp), expected_len)
+        self.assertEqual(tmp, self.set)
+
+    def test_remove_present(self):
+        self.set.remove("b")
+        self.assertEqual(self.set, set("ac"))
+
+    # def test_remove_absent(self):
+    #     try:
+    #         self.set.remove("d")
+    #         self.fail("Removing missing element should have raised LookupError")
+    #     except LookupError:
+    #         pass
+
+    def test_remove_until_empty(self):
+        expected_len = len(self.set)
+        for v in self.values:
+            self.set.remove(v)
+            expected_len -= 1
+            self.assertEqual(len(self.set), expected_len)
+
+    def test_discard_present(self):
+        self.set.discard("c")
+        self.assertEqual(self.set, set("ab"))
+
+    def test_discard_absent(self):
+        self.set.discard("d")
+        self.assertEqual(self.set, set("abc"))
+
+    # def test_clear(self):
+    #     self.set.clear()
+    #     self.assertEqual(len(self.set), 0)
+
+    def test_pop(self):
+        popped = {}
+        while self.set:
+            popped[self.set.pop()] = None
+        self.assertEqual(len(popped), len(self.values))
+        for v in self.values:
+            self.assertIn(v, popped)
+
+    def test_update_empty_tuple(self):
+        self.set.update(())
+        self.assertEqual(self.set, set(self.values))
+
+    def test_update_unit_tuple_overlap(self):
+        self.set.update(("a",))
+        self.assertEqual(self.set, set(self.values))
+
+    def test_update_unit_tuple_non_overlap(self):
+        self.set.update(("a", "z"))
+        self.assertEqual(self.set, set(self.values + ["z"]))
+
+#==============================================================================
+
+class TestSubsets:
+
+    case2method = {"<=": "issubset",
+                   ">=": "issuperset",
+                  }
+
+    reverse = {"==": "==",
+               "!=": "!=",
+               "<":  ">",
+               ">":  "<",
+               "<=": ">=",
+               ">=": "<=",
+              }
+
+    def test_issubset(self):
+        x = self.left
+        y = self.right
+        for case in "!=", "==", "<", "<=", ">", ">=":
+            expected = case in self.cases
+            # # Test the binary infix spelling.
+            # result = eval("x" + case + "y", locals())
+            # self.assertEqual(result, expected)
+            # Test the "friendly" method-name spelling, if one exists.
+            if case in TestSubsets.case2method:
+                method = getattr(x, TestSubsets.case2method[case])
+                result = method(y)
+                self.assertEqual(result, expected)
+
+            # # Now do the same for the operands reversed.
+            # rcase = TestSubsets.reverse[case]
+            # result = eval("y" + rcase + "x", locals())
+            # self.assertEqual(result, expected)
+            # if rcase in TestSubsets.case2method:
+            #     method = getattr(y, TestSubsets.case2method[rcase])
+            #     result = method(x)
+            #     self.assertEqual(result, expected)
+#------------------------------------------------------------------------------
+
+class TestSubsetEqualEmpty(TestSubsets, unittest.TestCase):
+    left  = set()
+    right = set()
+    name  = "both empty"
+    cases = "==", "<=", ">="
+
+#------------------------------------------------------------------------------
+
+class TestSubsetEqualNonEmpty(TestSubsets, unittest.TestCase):
+    left  = set([1, 2])
+    right = set([1, 2])
+    name  = "equal pair"
+    cases = "==", "<=", ">="
+
+#------------------------------------------------------------------------------
+
+class TestSubsetEmptyNonEmpty(TestSubsets, unittest.TestCase):
+    left  = set()
+    right = set([1, 2])
+    name  = "one empty, one non-empty"
+    cases = "!=", "<", "<="
+
+#------------------------------------------------------------------------------
+
+class TestSubsetPartial(TestSubsets, unittest.TestCase):
+    left  = set([1])
+    right = set([1, 2])
+    name  = "one a non-empty proper subset of other"
+    cases = "!=", "<", "<="
+
+#------------------------------------------------------------------------------
+
+class TestSubsetNonOverlap(TestSubsets, unittest.TestCase):
+    left  = set([1])
+    right = set([2])
+    name  = "neither empty, neither contains"
+    cases = "!="
+
+#==============================================================================
+
+class TestOnlySetsInBinaryOps:
+
+    def test_eq_ne(self):
+        # Unlike the others, this is testing that == and != *are* allowed.
+        self.assertEqual(self.other == self.set, False)
+        self.assertEqual(self.set == self.other, False)
+        self.assertEqual(self.other != self.set, True)
+        self.assertEqual(self.set != self.other, True)
+
+    # def test_ge_gt_le_lt(self):
+    #     self.assertRaises(TypeError, lambda: self.set < self.other)
+    #     self.assertRaises(TypeError, lambda: self.set <= self.other)
+    #     self.assertRaises(TypeError, lambda: self.set > self.other)
+    #     self.assertRaises(TypeError, lambda: self.set >= self.other)
+    #
+    #     self.assertRaises(TypeError, lambda: self.other < self.set)
+    #     self.assertRaises(TypeError, lambda: self.other <= self.set)
+    #     self.assertRaises(TypeError, lambda: self.other > self.set)
+    #     self.assertRaises(TypeError, lambda: self.other >= self.set)
+
+    def test_update_operator(self):
+        try:
+            self.set |= self.other
+        except TypeError:
+            pass
+        else:
+            self.fail("expected TypeError")
+
+    def test_update(self):
+        if self.otherIsIterable:
+            self.set.update(self.other)
+        else:
+            self.assertRaises(TypeError, self.set.update, self.other)
+
+    def test_union(self):
+        self.assertRaises(TypeError, lambda: self.set | self.other)
+        self.assertRaises(TypeError, lambda: self.other | self.set)
+        if self.otherIsIterable:
+            self.set.union(self.other)
+        else:
+            self.assertRaises(TypeError, self.set.union, self.other)
+
+    def test_intersection_update_operator(self):
+        try:
+            self.set &= self.other
+        except TypeError:
+            pass
+        else:
+            self.fail("expected TypeError")
+
+    def test_intersection_update(self):
+        if self.otherIsIterable:
+            # self.set.intersection_update(self.other)
+            pass
+        else:
+            self.assertRaises(TypeError,
+                              self.set.intersection_update,
+                              self.other)
+
+    def test_intersection(self):
+        self.assertRaises(TypeError, lambda: self.set & self.other)
+        self.assertRaises(TypeError, lambda: self.other & self.set)
+        if self.otherIsIterable:
+            # self.set.intersection(self.other)
+            pass
+        else:
+            self.assertRaises(TypeError, self.set.intersection, self.other)
+
+    def test_sym_difference_update_operator(self):
+        try:
+            self.set ^= self.other
+        except TypeError:
+            pass
+        else:
+            self.fail("expected TypeError")
+
+    def test_sym_difference_update(self):
+        if self.otherIsIterable:
+            # self.set.symmetric_difference_update(self.other)
+            pass
+        else:
+            self.assertRaises(TypeError,
+                              self.set.symmetric_difference_update,
+                              self.other)
+
+    def test_sym_difference(self):
+        self.assertRaises(TypeError, lambda: self.set ^ self.other)
+        self.assertRaises(TypeError, lambda: self.other ^ self.set)
+        if self.otherIsIterable:
+            # self.set.symmetric_difference(self.other)
+            pass
+        else:
+            self.assertRaises(TypeError, self.set.symmetric_difference, self.other)
+
+    def test_difference_update_operator(self):
+        try:
+            self.set -= self.other
+        except TypeError:
+            pass
+        else:
+            self.fail("expected TypeError")
+
+    def test_difference_update(self):
+        if self.otherIsIterable:
+            # self.set.difference_update(self.other)
+            pass
+        else:
+            self.assertRaises(TypeError,
+                              self.set.difference_update,
+                              self.other)
+
+    def test_difference(self):
+        self.assertRaises(TypeError, lambda: self.set - self.other)
+        self.assertRaises(TypeError, lambda: self.other - self.set)
+        if self.otherIsIterable:
+            # self.set.difference(self.other)
+            pass
+        else:
+            self.assertRaises(TypeError, self.set.difference, self.other)
+
+#------------------------------------------------------------------------------
+
+class TestOnlySetsNumeric(TestOnlySetsInBinaryOps, unittest.TestCase):
+    def setUp(self):
+        self.set   = set((1, 2, 3))
+        self.other = 19
+        self.otherIsIterable = False
+
+#------------------------------------------------------------------------------
+
+class TestOnlySetsDict(TestOnlySetsInBinaryOps, unittest.TestCase):
+    def setUp(self):
+        self.set   = set((1, 2, 3))
+        self.other = {1:2, 3:4}
+        self.otherIsIterable = True
+
+#------------------------------------------------------------------------------
+
+class TestOnlySetsOperator(TestOnlySetsInBinaryOps, unittest.TestCase):
+    def setUp(self):
+        self.set   = set((1, 2, 3))
+        self.other = operator.add
+        self.otherIsIterable = False
+
+#------------------------------------------------------------------------------
+
+class TestOnlySetsTuple(TestOnlySetsInBinaryOps, unittest.TestCase):
+    def setUp(self):
+        self.set   = set((1, 2, 3))
+        self.other = (2, 4, 6)
+        self.otherIsIterable = True
+
+#------------------------------------------------------------------------------
+
+class TestOnlySetsString(TestOnlySetsInBinaryOps, unittest.TestCase):
+    def setUp(self):
+        self.set   = set((1, 2, 3))
+        self.other = 'abc'
+        self.otherIsIterable = True
+
+#------------------------------------------------------------------------------
+
+class TestOnlySetsGenerator(TestOnlySetsInBinaryOps, unittest.TestCase):
+    def setUp(self):
+        def gen():
+            for i in range(0, 10, 2):
+                yield i
+        self.set   = set((1, 2, 3))
+        self.other = gen()
+        self.otherIsIterable = True
+
+#==============================================================================
+
+class TestCopying:
+
+    def test_copy(self):
+        dup = self.set.copy()
+        dup_list = sorted(dup, key=repr)
+        set_list = sorted(self.set, key=repr)
+        self.assertEqual(len(dup_list), len(set_list))
+        for i in range(len(dup_list)):
+            self.assertTrue(dup_list[i] is set_list[i])
+
+    def test_deep_copy(self):
+        dup = copy.deepcopy(self.set)
+        ##print type(dup), repr(dup)
+        dup_list = sorted(dup, key=repr)
+        set_list = sorted(self.set, key=repr)
+        self.assertEqual(len(dup_list), len(set_list))
+        for i in range(len(dup_list)):
+            self.assertEqual(dup_list[i], set_list[i])
+
+#------------------------------------------------------------------------------
+
+class TestCopyingEmpty(TestCopying, unittest.TestCase):
+    def setUp(self):
+        self.set = set()
+
+#------------------------------------------------------------------------------
+
+class TestCopyingSingleton(TestCopying, unittest.TestCase):
+    def setUp(self):
+        self.set = set(["hello"])
+
+#------------------------------------------------------------------------------
+
+class TestCopyingTriple(TestCopying, unittest.TestCase):
+    def setUp(self):
+        self.set = set(["zero", 0, None])
+
+#------------------------------------------------------------------------------
+
+class TestCopyingTuple(TestCopying, unittest.TestCase):
+    def setUp(self):
+        self.set = set([(1, 2)])
+
+#------------------------------------------------------------------------------
+
+class TestCopyingNested(TestCopying, unittest.TestCase):
+    def setUp(self):
+        self.set = set([((1, 2), (3, 4))])
+
+#==============================================================================
+
+# class TestIdentities(unittest.TestCase):
+#     def setUp(self):
+#         self.a = set('abracadabra')
+#         self.b = set('alacazam')
+
+    # def test_binopsVsSubsets(self):
+    #     a, b = self.a, self.b
+    #     self.assertTrue(a - b < a)
+    #     self.assertTrue(b - a < b)
+    #     self.assertTrue(a & b < a)
+    #     self.assertTrue(a & b < b)
+    #     self.assertTrue(a | b > a)
+    #     self.assertTrue(a | b > b)
+    #     self.assertTrue(a ^ b < a | b)
+
+    # def test_commutativity(self):
+    #     a, b = self.a, self.b
+    #     self.assertEqual(a&b, b&a)
+    #     self.assertEqual(a|b, b|a)
+    #     self.assertEqual(a^b, b^a)
+    #     if a != b:
+    #         self.assertNotEqual(a-b, b-a)
+
+    # def test_summations(self):
+    #     # check that sums of parts equal the whole
+    #     a, b = self.a, self.b
+    #     self.assertEqual((a-b)|(a&b)|(b-a), a|b)
+    #     self.assertEqual((a&b)|(a^b), a|b)
+    #     self.assertEqual(a|(b-a), a|b)
+    #     self.assertEqual((a-b)|b, a|b)
+    #     self.assertEqual((a-b)|(a&b), a)
+    #     self.assertEqual((b-a)|(a&b), b)
+    #     self.assertEqual((a-b)|(b-a), a^b)
+
+    # def test_exclusion(self):
+    #     # check that inverse operations show non-overlap
+    #     a, b, zero = self.a, self.b, set()
+    #     self.assertEqual((a-b)&b, zero)
+    #     self.assertEqual((b-a)&a, zero)
+    #     self.assertEqual((a&b)&(a^b), zero)
+
+# Tests derived from test_itertools.py =======================================
+
+def R(seqn):
+    'Regular generator'
+    for i in seqn:
+        yield i
+
+class G:
+    'Sequence using __getitem__'
+    def __init__(self, seqn):
+        self.seqn = seqn
+    def __getitem__(self, i):
+        return self.seqn[i]
+
+class I:
+    'Sequence using iterator protocol'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __iter__(self):
+        return self
+    def __next__(self):
+        if self.i >= len(self.seqn): raise StopIteration
+        v = self.seqn[self.i]
+        self.i += 1
+        return v
+
+class Ig:
+    'Sequence using iterator protocol defined with a generator'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __iter__(self):
+        for val in self.seqn:
+            yield val
+
+class X:
+    'Missing __getitem__ and __iter__'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __next__(self):
+        if self.i >= len(self.seqn): raise StopIteration
+        v = self.seqn[self.i]
+        self.i += 1
+        return v
+
+class N:
+    'Iterator missing __next__()'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __iter__(self):
+        return self
+
+class E:
+    'Test propagation of exceptions'
+    def __init__(self, seqn):
+        self.seqn = seqn
+        self.i = 0
+    def __iter__(self):
+        return self
+    def __next__(self):
+        3 // 0
+
+class S:
+    'Test immediate stop'
+    def __init__(self, seqn):
+        pass
+    def __iter__(self):
+        return self
+    def __next__(self):
+        raise StopIteration
+
+# def L(seqn):
+#     'Test multiple tiers of iterators'
+#     return chain(map(lambda x:x, R(Ig(G(seqn)))))
+
+class TestVariousIteratorArgs(unittest.TestCase):
+
+    # def test_constructor(self):
+    #     for cons in (set, frozenset):
+    #         for s in ("123", "", range(1000), ('do', 1.2), range(2000,2200,5)):
+    #             for g in (G, I, Ig, S, R):
+    #                 self.assertEqual(sorted(cons(g(s)), key=repr), sorted(g(s), key=repr))
+    #             self.assertRaises(TypeError, cons , X(s))
+    #             self.assertRaises(TypeError, cons , N(s))
+    #             self.assertRaises(ZeroDivisionError, cons , E(s))
+
+    def test_inline_methods(self):
+        s = set('november')
+        for data in ("123", "", range(1000), ('do', 1.2), range(2000,2200,5), 'december'):
+            for meth in (s.union, s.intersection, s.difference, s.symmetric_difference, s.isdisjoint):
+                # for g in (G, I, Ig, R):
+                #     expected = meth(data)
+                #     actual = meth(g(data))
+                #     if isinstance(expected, bool):
+                #         self.assertEqual(actual, expected)
+                #     else:
+                #         self.assertEqual(sorted(actual, key=repr), sorted(expected, key=repr))
+                self.assertRaises(TypeError, meth, X(s))
+                self.assertRaises(TypeError, meth, N(s))
+                # self.assertRaises(ZeroDivisionError, meth, E(s))
+
+    def test_inplace_methods(self):
+        for data in ("123", "", range(1000), ('do', 1.2), range(2000,2200,5), 'december'):
+            for methname in ('update', 'intersection_update',
+                             'difference_update', 'symmetric_difference_update'):
+                # for g in (G, I, Ig, S, R):
+                #     s = set('january')
+                #     t = s.copy()
+                #     getattr(s, methname)(list(g(data)))
+                #     getattr(t, methname)(g(data))
+                #     self.assertEqual(sorted(s, key=repr), sorted(t, key=repr))
+
+                self.assertRaises(TypeError, getattr(set('january'), methname), X(data))
+                self.assertRaises(TypeError, getattr(set('january'), methname), N(data))
+                # self.assertRaises(ZeroDivisionError, getattr(set('january'), methname), E(data))
+
+class bad_eq:
+    def __eq__(self, other):
+        if be_bad:
+            # set2.clear()
+            raise ZeroDivisionError
+        return self is other
+    def __hash__(self):
+        return 0
+
+class bad_dict_clear:
+    def __eq__(self, other):
+        if be_bad:
+            # dict2.clear()
+            pass
+        return self is other
+    def __hash__(self):
+        return 0
+
+class TestWeirdBugs(unittest.TestCase):
+    def test_8420_set_merge(self):
+        # This used to segfault
+        global be_bad, set2, dict2
+        be_bad = False
+        set1 = {bad_eq()}
+        set2 = {bad_eq() for i in range(75)}
+        be_bad = True
+        self.assertRaises(ZeroDivisionError, set1.update, set2)
+
+        be_bad = False
+        set1 = {bad_dict_clear()}
+        dict2 = {bad_dict_clear(): None}
+        be_bad = True
+        set1.symmetric_difference_update(dict2)
+
+    def test_iter_and_mutate(self):
+        # Issue #24581
+        s = set(range(100))
+        # s.clear()
+        s.update(range(100))
+        si = iter(s)
+        # s.clear()
+        a = list(range(100))
+        s.update(range(100))
+        list(si)
+
+    def test_merge_and_mutate(self):
+        class X:
+            def __hash__(self):
+                return hash(0)
+            # def __eq__(self, o):
+            #     other.clear()
+            #     return False
+
+        other = set()
+        other = {X() for i in range(10)}
+        s = {0}
+        s.update(other)
+
+# Application tests (based on David Eppstein's graph recipes ====================================
+
+def powerset(U):
+    """Generates all subsets of a set or sequence U."""
+    U = iter(U)
+    try:
+        x = frozenset([next(U)])
+        for S in powerset(U):
+            yield S
+            yield S | x
+    except StopIteration:
+        yield frozenset()
+
+# def cube(n):
+#     """Graph of n-dimensional hypercube."""
+#     singletons = [frozenset([x]) for x in range(n)]
+#     return dict([(x, frozenset([x^s for s in singletons]))
+#                  for x in powerset(range(n))])
+
+def linegraph(G):
+    """Graph, the vertices of which are edges of G,
+    with two vertices being adjacent iff the corresponding
+    edges share a vertex."""
+    L = {}
+    for x in G:
+        for y in G[x]:
+            nx = [frozenset([x,z]) for z in G[x] if z != y]
+            ny = [frozenset([y,z]) for z in G[y] if z != x]
+            L[frozenset([x,y])] = frozenset(nx+ny)
+    return L
+
+def faces(G):
+    'Return a set of faces in G.  Where a face is a set of vertices on that face'
+    # currently limited to triangles,squares, and pentagons
+    f = set()
+    for v1, edges in G.items():
+        for v2 in edges:
+            for v3 in G[v2]:
+                if v1 == v3:
+                    continue
+                if v1 in G[v3]:
+                    f.add(frozenset([v1, v2, v3]))
+                else:
+                    for v4 in G[v3]:
+                        if v4 == v2:
+                            continue
+                        if v1 in G[v4]:
+                            f.add(frozenset([v1, v2, v3, v4]))
+                        else:
+                            for v5 in G[v4]:
+                                if v5 == v3 or v5 == v2:
+                                    continue
+                                if v1 in G[v5]:
+                                    f.add(frozenset([v1, v2, v3, v4, v5]))
+    return f
+
+
+# class TestGraphs(unittest.TestCase):
+
+    # def test_cube(self):
+    #
+    #     g = cube(3)                             # vert --> {v1, v2, v3}
+    #     vertices1 = set(g)
+    #     self.assertEqual(len(vertices1), 8)     # eight vertices
+    #     for edge in g.values():
+    #         self.assertEqual(len(edge), 3)      # each vertex connects to three edges
+    #     vertices2 = set(v for edges in g.values() for v in edges)
+    #     self.assertEqual(vertices1, vertices2)  # edge vertices in original set
+    #
+    #     cubefaces = faces(g)
+    #     self.assertEqual(len(cubefaces), 6)     # six faces
+    #     for face in cubefaces:
+    #         self.assertEqual(len(face), 4)      # each face is a square
+
+    # def test_cuboctahedron(self):
+    #
+    #     # http://en.wikipedia.org/wiki/Cuboctahedron
+    #     # 8 triangular faces and 6 square faces
+    #     # 12 identical vertices each connecting a triangle and square
+    #
+    #     g = cube(3)
+    #     cuboctahedron = linegraph(g)            # V( --> {V1, V2, V3, V4}
+    #     self.assertEqual(len(cuboctahedron), 12)# twelve vertices
+    #
+    #     vertices = set(cuboctahedron)
+    #     for edges in cuboctahedron.values():
+    #         self.assertEqual(len(edges), 4)     # each vertex connects to four other vertices
+    #     othervertices = set(edge for edges in cuboctahedron.values() for edge in edges)
+    #     self.assertEqual(vertices, othervertices)   # edge vertices in original set
+    #
+    #     cubofaces = faces(cuboctahedron)
+    #     facesizes = collections.defaultdict(int)
+    #     for face in cubofaces:
+    #         facesizes[len(face)] += 1
+    #     self.assertEqual(facesizes[3], 8)       # eight triangular faces
+    #     self.assertEqual(facesizes[4], 6)       # six square faces
+    #
+    #     for vertex in cuboctahedron:
+    #         edge = vertex                       # Cuboctahedron vertices are edges in Cube
+    #         self.assertEqual(len(edge), 2)      # Two cube vertices define an edge
+    #         for cubevert in edge:
+    #             self.assertIn(cubevert, g)
+
+
+#==============================================================================
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_sort.py
+++ b/test/unit3/test_sort.py
@@ -1,0 +1,252 @@
+import random
+import unittest
+
+nerrors = 0
+
+
+def check(tag, expected, raw, compare=None):
+    global nerrors
+
+    orig = raw[:]   # save input in case of error
+    if compare:
+        raw.sort()
+    else:
+        raw.sort()
+
+    if len(expected) != len(raw):
+        print("error in", tag)
+        print("length mismatch;", len(expected), len(raw))
+        print(expected)
+        print(orig)
+        print(raw)
+        nerrors += 1
+        return
+
+    for i, good in enumerate(expected):
+        maybe = raw[i]
+        if good is not maybe:
+            print("error in", tag)
+            print("out of order at index", i, good, maybe)
+            print(expected)
+            print(orig)
+            print(raw)
+            nerrors += 1
+            return
+
+# class TestBase(unittest.TestCase):
+#     def testStressfully(self):
+#         # Try a variety of sizes at and around powers of 2, and at powers of 10.
+#         sizes = [0]
+#         for power in range(1, 10):
+#             n = 2 ** power
+#             sizes.extend(range(n-1, n+2))
+#         sizes.extend([10, 100, 1000])
+#
+#         class Complains(object):
+#             maybe_complain = True
+#
+#             def __init__(self, i):
+#                 self.i = i
+#
+#             # def __lt__(self, other):
+#             #     if Complains.maybe_complain and random.random() < 0.001:
+#             #         raise RuntimeError
+#             #     return self.i < other.i
+#
+#             def __repr__(self):
+#                 return "Complains(%d)" % self.i
+#
+#         class Stable(object):
+#             def __init__(self, key, i):
+#                 self.key = key
+#                 self.index = i
+#
+#             def __lt__(self, other):
+#                 return self.key < other.key
+#
+#             def __repr__(self):
+#                 return "Stable(%d, %d)" % (self.key, self.index)
+#
+#         for n in sizes:
+#             x = list(range(n))
+#
+#             s = x[:]
+#             check("identity", x, s)
+#
+#             s = x[:]
+#             s.reverse()
+#             check("reversed", x, s)
+#
+#             s = x[:]
+#             random.shuffle(s)
+#             check("random permutation", x, s)
+#
+#             y = x[:]
+#             y.reverse()
+#             s = x[:]
+#             check("reversed via function", y, s, lambda a, b: (b>a)-(b<a))
+#
+#             s = x[:]
+#             s.sort()
+#             check("an insane function left some permutation", x, s)
+#
+#             if len(x) >= 2:
+#                 def bad_key(x):
+#                     raise RuntimeError
+#                 s = x[:]
+#                 # self.assertRaises(RuntimeError, s.sort, key=bad_key)
+#
+#             x = [Complains(i) for i in x]
+#             s = x[:]
+#             random.shuffle(s)
+#             Complains.maybe_complain = True
+#             it_complained = False
+#             try:
+#                 s.sort()
+#             except RuntimeError:
+#                 it_complained = True
+#             if it_complained:
+#                 Complains.maybe_complain = False
+#                 check("exception during sort left some permutation", x, s)
+#
+#             s = [Stable(random.randrange(10), i) for i in range(n)]
+#             augmented = [(e, e.index) for e in s]
+#             augmented.sort()    # forced stable because ties broken by index
+#             x = [e for e, i in augmented] # a stable sort of s
+#             check("stability", x, s)
+
+#==============================================================================
+
+# class TestBugs(unittest.TestCase):
+
+    # def test_bug453523(self):
+    #     # bug 453523 -- list.sort() crasher.
+    #     # If this fails, the most likely outcome is a core dump.
+    #     # Mutations during a list sort should raise a ValueError.
+    #
+    #     class C:
+    #         def __lt__(self, other):
+    #             if L and random.random() < 0.75:
+    #                 L.pop()
+    #             else:
+    #                 L.append(3)
+    #             return random.random() < 0.5
+    #
+    #     L = [C() for i in range(50)]
+    #     self.assertRaises(ValueError, L.sort)
+
+    # def test_undetected_mutation(self):
+    #     # Python 2.4a1 did not always detect mutation
+    #     memorywaster = []
+    #     for i in range(20):
+    #         def mutating_cmp(x, y):
+    #             L.append(3)
+    #             L.pop()
+    #             return (x > y) - (x < y)
+    #         L = [1,2]
+    #         self.assertRaises(ValueError, L.sort)
+    #         def mutating_cmp(x, y):
+    #             L.append(3)
+    #             del L[:]
+    #             return (x > y) - (x < y)
+    #         # self.assertRaises(ValueError, L.sort, key=cmp_to_key(mutating_cmp))
+    #         memorywaster = [memorywaster]
+
+#==============================================================================
+
+class TestDecorateSortUndecorate(unittest.TestCase):
+
+    def test_decorated(self):
+        data = 'The quick Brown fox Jumped over The lazy Dog'.split()
+        copy = data[:]
+        random.shuffle(data)
+        data.sort(key=str.lower)
+        def my_cmp(x, y):
+            xlower, ylower = x.lower(), y.lower()
+            return (xlower > ylower) - (xlower < ylower)
+        copy.sort()
+
+    def test_baddecorator(self):
+        data = 'The quick Brown fox Jumped over The lazy Dog'.split()
+        # self.assertRaises(TypeError, data.sort, key=lambda x,y: 0)
+
+    def test_stability(self):
+        data = [(random.randrange(100), i) for i in range(200)]
+        copy = data[:]
+        data.sort(key=lambda t: t[0])   # sort on the random first field
+        copy.sort()                     # sort using both fields
+        self.assertEqual(data, copy)    # should get the same result
+
+    def test_key_with_exception(self):
+        # Verify that the wrapper has been removed
+        data = list(range(-2, 2))
+        dup = data[:]
+        # self.assertRaises(ZeroDivisionError, data.sort, key=lambda x: 1/x)
+        self.assertEqual(data, dup)
+
+    def test_key_with_mutation(self):
+        data = list(range(10))
+        def k(x):
+            del data[:]
+            data[:] = range(20)
+            return x
+        # self.assertRaises(ValueError, data.sort, key=k)
+
+    # def test_key_with_mutating_del(self):
+    #     data = list(range(10))
+    #     class SortKiller(object):
+    #         def __init__(self, x):
+    #             pass
+    #         def __del__(self):
+    #             del data[:]
+    #             data[:] = range(20)
+    #         def __lt__(self, other):
+    #             return id(self) < id(other)
+        # self.assertRaises(ValueError, data.sort, key=SortKiller)
+
+    def test_key_with_mutating_del_and_exception(self):
+        data = list(range(10))
+        ## dup = data[:]
+        class SortKiller(object):
+            def __init__(self, x):
+                if x > 2:
+                    raise RuntimeError
+            # def __del__(self):
+            #     del data[:]
+            #     data[:] = list(range(20))
+        # self.assertRaises(RuntimeError, data.sort, key=SortKiller)
+        ## major honking subtlety: we *can't* do:
+        ##
+        ## self.assertEqual(data, dup)
+        ##
+        ## because there is a reference to a SortKiller in the
+        ## traceback and by the time it dies we're outside the call to
+        ## .sort() and so the list protection gimmicks are out of
+        ## date (this cost some brain cells to figure out...).
+
+    def test_reverse(self):
+        data = list(range(100))
+        random.shuffle(data)
+        data.sort(reverse=True)
+        self.assertEqual(data, list(range(99,-1,-1)))
+
+    def test_reverse_stability(self):
+        data = [(random.randrange(100), i) for i in range(200)]
+        copy1 = data[:]
+        copy2 = data[:]
+        def my_cmp(x, y):
+            x0, y0 = x[0], y[0]
+            return (x0 > y0) - (x0 < y0)
+        def my_cmp_reversed(x, y):
+            x0, y0 = x[0], y[0]
+            return (y0 > x0) - (y0 < x0)
+        data.sort()
+        copy1.sort()
+        self.assertEqual(data, copy1)
+        copy2.sort(key=lambda x: x[0], reverse=True)
+        # self.assertEqual(data, copy2)
+
+#==============================================================================
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_strcount.py
+++ b/test/unit3/test_strcount.py
@@ -1,0 +1,37 @@
+import unittest
+
+class string_count(unittest.TestCase):
+    def test_singles(self):
+        self.assertEqual(1, 'abc'.count('a'))
+        self.assertEqual(2, 'abcab'.count('b'))
+        self.assertEqual(2, 'abc..abc'.count('.'))
+
+    def test_multiples(self):
+        self.assertEqual(2, 'abab'.count('ab'))
+        self.assertEqual(2, 'abcab'.count('ab'))
+
+        self.assertEqual(1, 'aaa'.count('aa'))
+
+    def test_specials(self):
+        self.assertEqual(2, '-abc-'.count('-'))
+        self.assertEqual(2, '[[abc]'.count('['))
+        self.assertEqual(2, '\\abc\\'.count('\\'))
+        self.assertEqual(4, ']]]abc]'.count(']'))
+        self.assertEqual(2, '{{}}'.count('{'))
+        self.assertEqual(3, '{}}}'.count('}'))
+        self.assertEqual(1, '(abc]'.count('('))
+        self.assertEqual(2, 'abc))'.count(')'))
+        self.assertEqual(3, 'a*b*c*d'.count('*'))
+        self.assertEqual(2, 'a+b+c'.count('+'))
+        self.assertEqual(2, '?abc?'.count('?'))
+        self.assertEqual(2, 'abc..abc'.count('.'))
+        self.assertEqual(4, 'a, b, c, d, '.count(','))
+        self.assertEqual(1, 'a^b*c'.count('^'))
+        self.assertEqual(3, '$$$'.count('$'))
+        self.assertEqual(2, 'a|b|c'.count('|'))
+        self.assertEqual(1, '#abc'.count('#'))
+        self.assertEqual(1, ' '.count(' '))
+        self.assertEqual(3, '   '.count(' '))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_strformat.py
+++ b/test/unit3/test_strformat.py
@@ -1,0 +1,77 @@
+__author__ = "gerbal"
+
+import unittest
+
+class string_format(unittest.TestCase):
+    def test_simple_position(self):
+        self.assertEqual('a, b, c', '{0}, {1}, {2}'.format('a', 'b', 'c'))
+        self.assertEqual('a, b, c', '{}, {}, {}'.format('a', 'b', 'c'))
+        self.assertEqual('c, b, a',  '{2}, {1}, {0}'.format('a', 'b', 'c'))
+        self.assertEqual('c, b, a', '{2}, {1}, {0}'.format(*'abc'))
+        self.assertEqual('abracadabra', '{0}{1}{0}'.format('abra', 'cad'))
+
+    #Kwargs don't work
+    def test_arg_names(self):
+        self.assertEqual('Coordinates: 37.24N, -115.81W', 'Coordinates: {latitude}, {longitude}'.format(latitude='37.24N', longitude='-115.81W'))
+        ## **kwargs does not work properly in Skulpt
+        # coord = {'latitude': '37.24N', 'longitude': '-115.81W'}
+        # self.assertEqual('Coordinates: 37.24N, -115.81W', 'Coordinates: {latitude}, {longitude}'.format(**coord))
+    
+    ## Complex Numbers Currently unsupported
+    
+    # def test_arg_attr(self):
+    #     c = 3-5j
+    #     self.assertEqual('The complex number (3-5j) is formed from the real part 3.0 and the imaginary part -5.0.', ('The complex number {0} is formed from the real part {0.real} and the imaginary part {0.imag}.').format(c))
+    #     class Point(object):
+    #         def __init__(self, x, y):
+    #             self.x, self.y = x, y
+    #         def __str__(self):
+    #             return 'Point({self.x}, {self.y})'.format(self=self)
+    #     self.assertEqual('Point(4, 2)', str(Point(4, 2)))
+
+    def test_arg_items(self):
+        coord = (3, 5)
+        self.assertEqual('X: 3;  Y: 5','X: {0[0]};  Y: {0[1]}'.format(coord))
+#        self.assertEqual('My name is Fred',"My name is {0[name]}".format({'name':'Fred'}))
+
+# TODO:  make these pass
+#    def test_width(self):
+#        self.assertEqual('         2,2',"{0:10},{0}".format(2))
+#        self.assertEqual('foo bar baz ',"{0:4}{1:4}{2:4}".format("foo","bar","baz")) 
+        
+
+    def test_conversion(self):
+        self.assertEqual("repr() shows quotes: 'test1'; str() doesn't: test2", "repr() shows quotes: {!r}; str() doesn't: {!s}".format('test1', 'test2'))
+
+    def test_expansion(self):
+        self.assertEqual('left aligned                  ', '{:<30}'.format('left aligned'))
+        self.assertEqual('                 right aligned', '{:>30}'.format('right aligned'))
+        self.assertEqual('           centered           ', '{:^30}'.format('centered'))
+        self.assertEqual('***********centered***********', '{:*^30}'.format('centered'))
+
+    def test_fixed_point(self):
+        self.assertEqual('+3.140000; -3.140000', '{:+f}; {:+f}'.format(3.14, -3.14))
+        self.assertEqual(' 3.140000; -3.140000', '{: f}; {: f}'.format(3.14, -3.14))
+        self.assertEqual('3.140000; -3.140000',  '{:-f}; {:-f}'.format(3.14, -3.14))
+
+    def test_hex_oct(self):
+        self.assertEqual('int: 42;  hex: 2a;  oct: 52;  bin: 101010', "int: {0:d};  hex: {0:x};  oct: {0:o};  bin: {0:b}".format(42))
+        self.assertEqual('int: 42;  hex: 0x2a;  oct: 0o52;  bin: 0b101010', "int: {0:d};  hex: {0:#x};  oct: {0:#o};  bin: {0:#b}".format(42))
+
+    def test_comma_sep(self):
+        self.assertEqual('1,234,567,890',  '{:,}'.format(1234567890))
+
+    def test_percentage(self):
+        points = 19.5
+        total = 22
+        self.assertEqual('Correct answers: 88.64%', 'Correct answers: {:.2%}'.format(points/total))
+
+    ## Datetime requires more work.
+    
+    # def test_datetome(self):
+    #     import datetime
+    #     d = datetime.datetime(2010, 7, 4, 12, 15, 58)
+    #     self.assertEqual('2010-07-04 12:15:58', '{:%Y-%m-%d %H:%M:%S}'.format(d))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_string.py
+++ b/test/unit3/test_string.py
@@ -1,0 +1,35 @@
+import unittest
+import string
+
+
+class ModuleTest(unittest.TestCase):
+
+    def test_attrs(self):
+        # While the exact order of the items in these attributes is not
+        # technically part of the "language spec", in practice there is almost
+        # certainly user code that depends on the order, so de-facto it *is*
+        # part of the spec.
+        # self.assertEqual(string.whitespace, ' \t\n\r\x0b\x0c')
+        self.assertEqual(string.ascii_lowercase, 'abcdefghijklmnopqrstuvwxyz')
+        self.assertEqual(string.ascii_uppercase, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+        self.assertEqual(string.ascii_letters, string.ascii_lowercase + string.ascii_uppercase)
+        self.assertEqual(string.digits, '0123456789')
+        self.assertEqual(string.hexdigits, string.digits + 'abcdefABCDEF')
+        self.assertEqual(string.octdigits, '01234567')
+        self.assertEqual(string.punctuation, '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~')
+        # self.assertEqual(string.printable, string.digits + string.ascii_lowercase + string.ascii_uppercase + string.punctuation + string.whitespace)
+
+    def test_capwords(self):
+        self.assertEqual(string.capwords('abc def ghi'), 'Abc Def Ghi')
+        # self.assertEqual(string.capwords('abc\tdef\nghi'), 'Abc Def Ghi')
+        # self.assertEqual(string.capwords('abc\t   def  \nghi'), 'Abc Def Ghi')
+        self.assertEqual(string.capwords('ABC DEF GHI'), 'Abc Def Ghi')
+        self.assertEqual(string.capwords('ABC-DEF-GHI', '-'), 'Abc-Def-Ghi')
+        self.assertEqual(string.capwords('ABC-def DEF-ghi GHI'), 'Abc-def Def-ghi Ghi')
+        # self.assertEqual(string.capwords('   aBc  DeF   '), 'Abc Def')
+        # self.assertEqual(string.capwords('\taBc\tDeF\t'), 'Abc Def')
+        # self.assertEqual(string.capwords('\taBc\tDeF\t', '\t'), '\tAbc\tDef\t')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_structseq.py
+++ b/test/unit3/test_structseq.py
@@ -1,0 +1,130 @@
+__author__ = 'Jacco Kulman'
+
+import unittest
+import time
+
+class StructSeqTest(unittest.TestCase):
+
+    def _test_tuple(self):
+        t = time.gmtime()
+        self.assertIsInstance(t, tuple)
+        astuple = tuple(t)
+        self.assertEqual(len(t), len(astuple))
+        self.assertEqual(t, astuple)
+
+        # Check that slicing works the same way; at one point, slicing t[i:j] with
+        # 0 < i < j could produce NULLs in the result.
+        for i in range(-len(t), len(t)):
+            self.assertEqual(t[i:], astuple[i:])
+            for j in range(-len(t), len(t)):
+                self.assertEqual(t[i:j], astuple[i:j])
+
+        for j in range(-len(t), len(t)):
+            self.assertEqual(t[:j], astuple[:j])
+
+        self.assertRaises(IndexError, lambda: t.__getitem__(-len(t)-1))
+        self.assertRaises(IndexError, lambda: t.__getitem__(len(t)))
+        for i in range(-len(t), len(t)-1):
+            self.assertEqual(t[i], astuple[i])
+
+    def test_repr(self):
+        t = time.gmtime()
+        self.assertTrue(repr(t))
+        t = time.gmtime(0)
+        self.assertEqual(repr(t),
+            "time.struct_time(tm_year=1970, tm_mon=1, tm_mday=1, tm_hour=0, "
+            "tm_min=0, tm_sec=0, tm_wday=3, tm_yday=1, tm_isdst=0)")
+
+    def test_concat(self):
+        t1 = time.gmtime()
+        t2 = t1 + tuple(t1)
+        for i in range(len(t1)):
+            # changed from for i in xrange(len(t1)):
+            self.assertEqual(t2[i], t2[i+len(t1)])
+
+    def test_repeat(self):
+        t1 = time.gmtime()
+        t2 = 3 * t1
+        for i in range(len(t1)):
+            # changed from for i in xrange(len(t1)):
+            self.assertEqual(t2[i], t2[i+len(t1)])
+            self.assertEqual(t2[i], t2[i+2*len(t1)])
+
+    def test_contains(self):
+        t1 = time.gmtime()
+        for item in t1:
+            self.assertIn(item, t1)
+        self.assertNotIn(-42, t1)
+
+    def test_hash(self):
+        t1 = time.gmtime()
+        self.assertEqual(hash(t1), hash(tuple(t1)))
+
+    def test_cmp(self):
+        t1 = time.gmtime()
+        t2 = type(t1)(t1)
+        self.assertEqual(t1, t2)
+        self.assertTrue(not (t1 < t2))
+        self.assertTrue(t1 <= t2)
+        self.assertTrue(not (t1 > t2))
+        self.assertTrue(t1 >= t2)
+        self.assertTrue(not (t1 != t2))
+
+    def _test_fields(self):
+        t = time.gmtime()
+        self.assertEqual(len(t), t.n_fields)
+        self.assertEqual(t.n_fields, t.n_sequence_fields+t.n_unnamed_fields)
+
+    def test_getattr(self):
+        t = time.gmtime(0)
+        self.assertEqual(t.tm_year, 1970)
+        self.assertRaises(AttributeError, lambda : t.tm_nonexistent_attr)
+
+    def test_constructor(self):
+        t = time.struct_time
+
+        self.assertRaises(TypeError, t)
+        self.assertRaises(TypeError, t, None)
+        self.assertRaises(TypeError, t, "123")
+        #self.assertRaises(TypeError,t, "123", dict={})
+        #self.assertRaises(ValueError,t, "123456789", dict=None)
+
+        s = "123456789"
+        self.assertEqual("".join(t(s)), s)
+
+    def test_eviltuple(self):
+
+        # Devious code could crash structseqs' contructors
+        class C:
+            def __getitem__(self, i):
+                raise TypeError("eviltuple error")
+            def __len__(self):
+                return 9
+
+        self.assertRaises(TypeError, time.struct_time, C())
+
+    def _test_reduce(self):
+        t = time.gmtime()
+        x = t.__reduce__()
+
+    def test_extended_getslice(self):
+        # Test extended slicing by comparing with list slicing.
+        t = time.gmtime()
+        L = list(t)
+        indices = (0, None, 1, 3, 19, 300, -1, -2, -31, -300)
+        for start in indices:
+            for stop in indices:
+                # Skip step 0 (invalid)
+                for step in indices[1:]:
+                    self.assertEqual(list(t[start:stop:step]),
+                                     L[start:stop:step])
+
+    def _test_writability(self):
+        def change(s):
+            s.tm_mon = 30
+
+        x = time.struct_time((1,2,3,4,5,6,7,8,9))
+        self.assertRaises(AttributeError, lambda: change(x))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_time.py
+++ b/test/unit3/test_time.py
@@ -1,0 +1,57 @@
+__author__ = 'Jacco Kulman'
+
+import unittest
+import time
+
+class TimeTestCase(unittest.TestCase):
+    def setUp(self):
+        self.t = time.time()
+        
+    def test_data_attributes(self):
+        time.altzone
+        time.daylight
+        time.timezone
+        time.tzname
+
+    def test_clock(self):
+        time.clock()
+
+    def test_conversions(self):
+        self.assertTrue(time.ctime(self.t)
+                     == time.asctime(time.localtime(self.t)))
+        self.assertTrue(int(time.mktime(time.localtime(self.t)))
+                     == int(self.t))
+        # changed long to int
+
+    def test_sleep(self):
+        time.sleep(0.01)
+
+    def test_strftime(self):
+        self.assertEqual(time.strftime("%b %d %Y %H:%M:%S", time.localtime(3661 + time.timezone)), "Jan 01 1970 01:01:01");
+
+    def _test_dir(self):
+        # this test fails because the compare 
+        self.assertEqual(dir(time), [
+            '__file__'
+            '__name__', 
+            '__package__', 
+            'accept2dyear', 
+            'altzone', 
+            'asctime', 
+            'clock', 
+            'ctime', 
+            'daylight', 
+            'gmtime', 
+            'localtime', 
+            'mktime', 
+            'sleep', 
+            'strftime', 
+            'strptime', 
+            'struct_time', 
+            'time', 
+            'timezone', 
+            'tzname', 
+            'tzset']);
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_tuple.py
+++ b/test/unit3/test_tuple.py
@@ -45,16 +45,16 @@ class IterInheritsTestCase(unittest.TestCase):
                     self.current += 1
                     return self.current - 1
 
-        l = tuple(Counter(1,12))
-        print(l)
-        self.assertTrue(5 in l)
-
-        class Foo(Counter):
-            pass
-
-        l = tuple(Foo(100,120))
-        print(l)
-        self.assertTrue(105 in l)
+        # l = tuple(Counter(1,12))
+        # print(l)
+        # self.assertTrue(5 in l)
+        #
+        # class Foo(Counter):
+        #     pass
+        #
+        # l = tuple(Foo(100,120))
+        # print(l)
+        # self.assertTrue(105 in l)
 
 
 

--- a/test/unit3/test_tuple.py
+++ b/test/unit3/test_tuple.py
@@ -1,0 +1,64 @@
+"""Test compiler changes for unary ops (+, -, ~) introduced in Python 2.2"""
+
+import unittest
+
+
+class IterInheritsTestCase(unittest.TestCase):
+
+
+    def test_generator(self):
+        def counter(low, high):
+            current = low
+            while current <= high:
+                yield current
+                current += 1
+
+        l = tuple(counter(1,12))
+        t = 4 in l
+        print(t, l)
+        self.assertTrue(t)
+
+    def test_getitem(self):
+        class Counter:
+           def __getitem__(self,idx):
+              if idx < 13:
+                 return idx
+              else:
+                 raise StopIteration
+        l = tuple(Counter())
+        print(l)
+        self.assertTrue(5 in l)
+
+    def test_dunderiter(self):
+        class Counter:
+            def __init__(self, low, high):
+                self.current = low
+                self.high = high
+
+            def __iter__(self):
+                return self
+
+            def __next__(self): # Python 3: def __next__(self)
+                if self.current > self.high:
+                    raise StopIteration
+                else:
+                    self.current += 1
+                    return self.current - 1
+
+        l = tuple(Counter(1,12))
+        print(l)
+        self.assertTrue(5 in l)
+
+        class Foo(Counter):
+            pass
+
+        l = tuple(Foo(100,120))
+        print(l)
+        self.assertTrue(105 in l)
+
+
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_unary.py
+++ b/test/unit3/test_unary.py
@@ -1,0 +1,63 @@
+"""Test compiler changes for unary ops (+, -, ~) introduced in Python 2.2"""
+
+import unittest
+
+
+class UnaryOpTestCase(unittest.TestCase):
+
+    def test_negative(self):
+        self.assertTrue(-2 == 0 - 2)
+        self.assertTrue(-0 == 0)
+        self.assertTrue(--2 == 2)
+        self.assertTrue(-2 == 0 - 2)
+        # removed Ls
+        self.assertTrue(-2.0 == 0 - 2.0)
+        #self.assertTrue(-2j == 0 - 2j)
+
+    def test_positive(self):
+        self.assertTrue(+2 == 2)
+        self.assertTrue(+0 == 0)
+        self.assertTrue(++2 == 2)
+        self.assertTrue(+2 == 2)
+        # removed Ls
+        self.assertTrue(+2.0 == 2.0)
+        #self.assertTrue(+2j == 2j)
+
+    def test_invert(self):
+        self.assertTrue(-2 == 0 - 2)
+        self.assertTrue(-0 == 0)
+        self.assertTrue(--2 == 2)
+        self.assertTrue(-2 == 0 - 2)
+        # removed Ls
+        self.assertTrue(~1 == 0 - 2)
+        # removed Ls
+        self.assertTrue(~1000000 == -1000001)
+        # removed Ls
+
+    def test_no_overflow(self):
+        nines = "9" * 32
+        #self.assertTrue(eval("+" + nines) == eval("+" + nines + "L"))
+        #self.assertTrue(eval("-" + nines) == eval("-" + nines + "L"))
+        #self.assertTrue(eval("~" + nines) == eval("~" + nines + "L"))
+
+    def test_negation_of_exponentiation(self):
+        # Make sure '**' does the right thing; these form a
+        # regression test for SourceForge bug #456756.
+        self.assertEqual(-2 ** 3, -8)
+        self.assertEqual((-2) ** 3, -8)
+        self.assertEqual(-2 ** 4, -16)
+        self.assertEqual((-2) ** 4, 16)
+
+#    def test_bad_types(self):
+#        for op in '+', '-', '~':
+#            self.assertRaises(TypeError, eval, op + "'a'")
+#            if have_unicode:
+#                self.assertRaises(TypeError, eval, op + "u'a'")
+
+#        self.assertRaises(TypeError, eval, "~2j")
+#        self.assertRaises(TypeError, eval, "~2.0")
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_unpack.py
+++ b/test/unit3/test_unpack.py
@@ -1,0 +1,111 @@
+# Unpack tests from CPython converted from doctest to unittest
+
+import unittest
+
+class UnpackTest(unittest.TestCase):
+
+    def test_basic(self):
+        t = (1, 2, 3)
+        a, b, c = t
+        self.assertEqual(a, 1)
+        self.assertEqual(b, 2)
+        self.assertEqual(c, 3)
+
+        l = [4, 5, 6]
+        a, b, c = l
+        self.assertEqual(a, 4)
+        self.assertEqual(b, 5)
+        self.assertEqual(c, 6)
+
+        a, b, c = 7, 8, 9
+        self.assertEqual(a, 7)
+        self.assertEqual(b, 8)
+        self.assertEqual(c, 9)
+
+        s = 'one'
+        a, b, c = s
+        self.assertEqual(a, 'o')
+        self.assertEqual(b, 'n')
+        self.assertEqual(c, 'e')
+
+    def test_single(self):
+        st = (99,)
+        sl = [100]
+
+        a, = st
+        self.assertEqual(a, 99)
+
+        b, = sl
+        self.assertEqual(b, 100)
+        
+    def test_non_sequence(self):
+        def unpack():
+            a, b, c = 7
+        # Currently has incorrect message
+        self.assertRaises(TypeError, unpack)
+
+    def test_wrong_size(self):
+        def tup_too_big():
+            t = (1, 2, 3)
+            a, b = t
+        def list_too_big():
+            l = [4, 5, 6]
+            a, b = l
+        def tup_too_small():
+            t = (1, 2, 3)
+            a, b, c, d = t
+        def list_too_small():
+            l = [4, 5, 6]
+            a, b, c, d = l
+            
+        self.assertRaises(ValueError, tup_too_big)
+        self.assertRaises(ValueError, list_too_big)
+        self.assertRaises(ValueError, tup_too_small)
+        self.assertRaises(ValueError, list_too_small)
+
+    def test_class(self):
+        class Seq:
+            def __getitem__(self, i):
+                if i >= 0 and i < 3: return i
+                raise IndexError
+
+        a, b, c = Seq()
+        self.assertEqual(a, 0)
+        self.assertEqual(b, 1)
+        self.assertEqual(c, 2)
+
+    def test_class_fail(self):
+        class Seq:
+            def __getitem__(self, i):
+                if i >= 0 and i < 3: return i
+                raise IndexError
+
+        def too_small():
+            a, b, c, d = Seq()
+        def too_big():
+            a, b = Seq()
+
+        self.assertRaises(ValueError, too_small)
+        self.assertRaises(ValueError, too_big)
+
+    def test_bad_class(self):
+        class BadSeq:
+            def __getitem__(self, i):
+                if i >=0 and i < 3:
+                    return i
+                elif i ==3:
+                    raise NameError
+                else:
+                    raise IndexError
+
+        def raise_bad_error1():
+            a, b, c, d, e = BadSeq()
+
+        def raise_bad_error2():
+            a, b, c = BadSeq()
+
+        self.assertRaises(NameError, raise_bad_error1)
+        self.assertRaises(NameError, raise_bad_error2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request adds a "test3" command to skulpt.py.  It also adds a directory (unit3) to the test directory with Python 3 unit tests.  Initially, these tests are taken from our Python 2 unit tests.  The included tests all pass in CPython 3.  They do not all pass in Skulpt.

We did not change the Python 2 unit test directory to be called unit2, but that might make sense.

I see this as a jumping off point to start testing Skulpt in Python 3 mode, and to start exposing bugs.  The test3 command is not run automatically anywhere, so this should have no impact on normal use.  Presumably, dist should eventually run the Python 3 tests, too (perhaps optionally?), but at least not until they all pass.

I am submitting this largely to get feedback from the community to make sure we are headed in a direction everyone is comfortable with before going too far down this path.