### PR TITLE
Implement explicit dunder-functions in list class

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -293,6 +293,11 @@ Sk.builtin.list.prototype.sq$contains = function (item) {
     }
     return false;
 };
+
+Sk.builtin.list.prototype.__contains__ = function(self, item) {
+    return Sk.builtin.list.prototype.sq$contains.call(self, item);
+};
+
 /*
  Sk.builtin.list.prototype.sq$inplace_concat = list_inplace_concat;
  Sk.builtin.list.prototype.sq$inplace_repeat = list_inplace_repeat;
@@ -401,6 +406,14 @@ Sk.builtin.list.prototype.mp$del_subscript = Sk.builtin.list.prototype.list_del_
 
 Sk.builtin.list.prototype.__getitem__ = new Sk.builtin.func(function (self, index) {
     return Sk.builtin.list.prototype.list_subscript_.call(self, index);
+});
+
+Sk.builtin.list.prototype.__setitem__ = new Sk.builtin.func(function (self, index, val) {
+    return Sk.builtin.list.prototype.list_ass_subscript_.call(self, index, val);
+});
+
+Sk.builtin.list.prototype.__delitem__ = new Sk.builtin.func(function (self, index) {
+    return Sk.builtin.list.prototype.list_del_subscript_.call(self, index);
 });
 
 /**

--- a/src/list.js
+++ b/src/list.js
@@ -294,9 +294,9 @@ Sk.builtin.list.prototype.sq$contains = function (item) {
     return false;
 };
 
-Sk.builtin.list.prototype.__contains__ = function(self, item) {
+Sk.builtin.list.prototype.__contains__ = new Sk.builtin.func(function(self, item) {
     return Sk.builtin.list.prototype.sq$contains.call(self, item);
-};
+});
 
 /*
  Sk.builtin.list.prototype.sq$inplace_concat = list_inplace_concat;

--- a/test/unit/test_list.py
+++ b/test/unit/test_list.py
@@ -271,6 +271,21 @@ class IterInheritsTestCase(unittest.TestCase):
         a = self.type2test(range(10))
         del a[9::1<<333]
 
+    def test_explicit_dunders(self):
+        l = [1]
+        list.__setitem__(l, 0, 42)
+        self.assertEqual(l[0], 42)
+        self.assertEqual(list.__getitem__(l, 0), 42)
+        self.assertEqual(list.__len__(l), 1)
+
+        l2 = [i for i in list.__iter__(l)]
+        self.assertEqual(l2, [42])
+
+        self.assertTrue(list.__contains__(l, 42))
+
+
+
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
We didn't have explicit dunder-functions (eg `__setitem__`/`__getitem__`) for the list class. This made subclassing it a pain. Now we do.