### PR TITLE
Platform Module

### DIFF
--- a/skulpt.py
+++ b/skulpt.py
@@ -866,7 +866,7 @@ def make_skulpt_js(options,dest):
     if sys.platform != "win32":
         os.chmod(os.path.join(dest, OUTFILE_REG), 0o444)
 
-def run_in_browser(fn, options, debug_mode=False):
+def run_in_browser(fn, options, debug_mode=False, p3=False):
     shutil.rmtree(RUN_DIR, ignore_errors=True)
     if not os.path.exists(RUN_DIR): os.mkdir(RUN_DIR)
     docbi(options,RUN_DIR)
@@ -881,7 +881,7 @@ def run_in_browser(fn, options, debug_mode=False):
 
     with open('support/run_template.html') as tpfile:
         page = tpfile.read()
-        page = page % dict(code=prog,scripts=scripts,debug_mode=str(debug_mode).lower(),root="")
+        page = page % dict(code=prog,scripts=scripts,debug_mode=str(debug_mode).lower(),p3=str(p3).lower(),root="")
 
     with open("{0}/run.html".format(RUN_DIR),"w") as htmlfile:
         htmlfile.write(page)
@@ -1330,7 +1330,9 @@ def main():
     elif cmd == "brun":
         run_in_browser(sys.argv[2], options)
     elif cmd == "brundebug":
-        run_in_browser(sys.argv[2], options, True)
+        run_in_browser(sys.argv[2], options, debug_mode=True)
+    elif cmd == "brun3":
+        run_in_browser(sys.argv[2], options, p3=True)
     elif cmd == 'rununits':
         rununits()
     elif cmd == "runopt":

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -1,0 +1,72 @@
+var $builtinmodule = function(name){
+    var mod = {};
+    var inBrowser = (typeof window != "undefined") && (typeof window.navigator != "undefined");
+    mod.python_implementation = new Sk.builtin.func(function() {
+        // This checks that the correct number of arguments were passed
+        Sk.builtin.pyCheckArgs("python_implementation", arguments, 0, 0);
+        return new Sk.builtin.str("Skulpt");
+    })
+    mod.node = new Sk.builtin.func(function() {
+        Sk.builtin.pyCheckArgs("node", arguments, 0, 0);
+        return new Sk.builtin.str("");
+    })
+    mod.version = new Sk.builtin.func(function() {
+        var vers;
+        Sk.builtin.pyCheckArgs("version", arguments, 0, 0);
+        if (Sk.python3) {
+            vers = "3.2.0";
+        }
+        else {
+            vers = "2.7.0";
+        }
+        return new Sk.builtin.str(vers);
+    })
+    mod.system = new Sk.builtin.func(function() {
+        var sys;
+        Sk.builtin.pyCheckArgs("system", arguments, 0, 0);
+        if (inBrowser) {
+            sys = window.navigator.appCodeName;
+        }
+        else {
+            sys = "";
+        }
+        return new Sk.builtin.str(sys);
+    })
+    mod.machine = new Sk.builtin.func(function() {
+        var plat;
+        Sk.builtin.pyCheckArgs("machine", arguments, 0, 0);
+        if (inBrowser) {
+            plat = window.navigator.platform;
+        }
+        else {
+            plat = "";
+        }
+        return new Sk.builtin.str(plat);
+    })
+    mod.release = new Sk.builtin.func(function() {
+        var appVers;
+        Sk.builtin.pyCheckArgs("release", arguments, 0, 0);
+        if (inBrowser) {
+            appVers = window.navigator.appVersion;
+        }
+        else {
+            appVers = "";
+        }
+        return new Sk.builtin.str(appVers);
+    })
+    mod.architecture = new Sk.builtin.func(function() {
+        Sk.builtin.pyCheckArgs("architecture", arguments, 0, 0);
+        return new Sk.builtin.str("('64bit', '')");
+    })
+//    mod.processor = new Sk.builtin.func(function() {
+//        Sk.builtin.pyCheckArgs("processor", arguments, 0, 0);
+//        //implementation
+//        return new Sk.builtin.str(...);
+//    })
+//    mod.uname = new Sk.builtin.func(function() {
+//        Sk.builtin.pyCheckArgs("uname", arguments, 0, 0);
+//       //implementation
+//       return new Sk.builtin.str(...);
+//    })
+    return mod;
+};

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -1,18 +1,25 @@
 var $builtinmodule = function(name){
     var mod = {};
     var inBrowser = (typeof window != "undefined") && (typeof window.navigator != "undefined");
+
     mod.python_implementation = new Sk.builtin.func(function() {
-        // This checks that the correct number of arguments were passed
         Sk.builtin.pyCheckArgs("python_implementation", arguments, 0, 0);
         return new Sk.builtin.str("Skulpt");
-    })
+    });
+
     mod.node = new Sk.builtin.func(function() {
         Sk.builtin.pyCheckArgs("node", arguments, 0, 0);
         return new Sk.builtin.str("");
-    })
+    });
+
     mod.version = new Sk.builtin.func(function() {
-        var vers;
         Sk.builtin.pyCheckArgs("version", arguments, 0, 0);
+        return new Sk.builtin.str("");
+    });
+
+    mod.python_version = new Sk.builtin.func(function() {
+        var vers;
+        Sk.builtin.pyCheckArgs("python_version", arguments, 0, 0);
         if (Sk.python3) {
             vers = "3.2.0";
         }
@@ -20,7 +27,8 @@ var $builtinmodule = function(name){
             vers = "2.7.0";
         }
         return new Sk.builtin.str(vers);
-    })
+    });
+
     mod.system = new Sk.builtin.func(function() {
         var sys;
         Sk.builtin.pyCheckArgs("system", arguments, 0, 0);
@@ -31,7 +39,8 @@ var $builtinmodule = function(name){
             sys = "";
         }
         return new Sk.builtin.str(sys);
-    })
+    });
+
     mod.machine = new Sk.builtin.func(function() {
         var plat;
         Sk.builtin.pyCheckArgs("machine", arguments, 0, 0);
@@ -42,7 +51,8 @@ var $builtinmodule = function(name){
             plat = "";
         }
         return new Sk.builtin.str(plat);
-    })
+    });
+
     mod.release = new Sk.builtin.func(function() {
         var appVers;
         Sk.builtin.pyCheckArgs("release", arguments, 0, 0);
@@ -53,20 +63,18 @@ var $builtinmodule = function(name){
             appVers = "";
         }
         return new Sk.builtin.str(appVers);
-    })
+    });
+
     mod.architecture = new Sk.builtin.func(function() {
         Sk.builtin.pyCheckArgs("architecture", arguments, 0, 0);
-        return new Sk.builtin.str("('64bit', '')");
-    })
-//    mod.processor = new Sk.builtin.func(function() {
-//        Sk.builtin.pyCheckArgs("processor", arguments, 0, 0);
-//        //implementation
-//        return new Sk.builtin.str(...);
-//    })
-//    mod.uname = new Sk.builtin.func(function() {
-//        Sk.builtin.pyCheckArgs("uname", arguments, 0, 0);
-//       //implementation
-//       return new Sk.builtin.str(...);
-//    })
+        return new Sk.builtin.tuple([new Sk.builtin.str("64bit"),
+                                     new Sk.builtin.str("")]);
+    });
+
+    mod.processor = new Sk.builtin.func(function() {
+        Sk.builtin.pyCheckArgs("processor", arguments, 0, 0);
+        return new Sk.builtin.str("");
+    });
+
     return mod;
 };

--- a/support/run_template.html
+++ b/support/run_template.html
@@ -76,7 +76,9 @@ function runit(myDiv) {
         read: builtinRead,
         inputfunTakesPrompt: true,
         debugout: showjs,
-        debugging: %(debug_mode)s
+        debugging: %(debug_mode)s,
+        python3: %(p3)s
+
     });
 
     var myPromise = Sk.misceval.asyncToPromise(function() {


### PR DESCRIPTION
This pull request adds a rudimentary platform module.  Perhaps most interestingly ```platform.python_implementation()``` returns ```"Skulpt"```, allowing you to check if you are running in Skulpt or another interpreter.

Also, a ```brun3``` command is added to skulpt.py to run Python 3 in the browser.

The Python versions are arbitrarily set to 2.7.0 and 3.2.0 for ```platform.version()```.  Not sure if those are the best values or not.