### PR TITLE
Implement the `with` statement

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -71,6 +71,7 @@ function CompilerUnit () {
     // stack of where to go on a continue
     this.continueBlocks = [];
     this.exceptBlocks = [];
+    // state of where to go on a return
     this.finallyBlocks = [];
 }
 
@@ -298,6 +299,10 @@ Compiler.prototype._jumpfalse = function (test, block) {
 
 Compiler.prototype._jumpundef = function (test, block) {
     out("if(", test, "===undefined){$blk=", block, ";continue;}");
+};
+
+Compiler.prototype._jumpnotundef = function (test, block) {
+    out("if(", test, "!==undefined){$blk=", block, ";continue;}");
 };
 
 Compiler.prototype._jumptrue = function (test, block) {
@@ -891,10 +896,13 @@ Compiler.prototype.popExceptBlock = function () {
 
 Compiler.prototype.pushFinallyBlock = function (n) {
     goog.asserts.assert(n >= 0 && n < this.u.blocknum);
-    this.u.finallyBlocks.push(n);
+    this.u.finallyBlocks.push({blk: n, breakDepth: this.u.breakBlocks.length, continueDepth: this.u.continueBlocks.length});
 };
 Compiler.prototype.popFinallyBlock = function () {
     this.u.finallyBlocks.pop();
+};
+Compiler.prototype.peekFinallyBlock = function() {
+    return (this.u.finallyBlocks.length > 0) ? this.u.finallyBlocks[this.u.finallyBlocks.length-1] : undefined;
 };
 
 Compiler.prototype.setupExcept = function (eb) {
@@ -939,7 +947,7 @@ Compiler.prototype.outputSuspensionHelpers = function (unit) {
     var output = (localsToSave.length > 0 ? ("var " + localsToSave.join(",") + ";") : "") +
                  "var $wakeFromSuspension = function() {" +
                     "var susp = "+unit.scopename+".$wakingSuspension; delete "+unit.scopename+".$wakingSuspension;" +
-                    "$blk=susp.$blk; $loc=susp.$loc; $gbl=susp.$gbl; $exc=susp.$exc; $err=susp.$err;" +
+                    "$blk=susp.$blk; $loc=susp.$loc; $gbl=susp.$gbl; $exc=susp.$exc; $err=susp.$err; $postfinally=susp.$postfinally;" +
                     "$currLineNo=susp.$lineno; $currColNo=susp.$colno; Sk.lastYield=Date.now();" +
                     (hasCell?"$cell=susp.$cell;":"");
 
@@ -957,7 +965,7 @@ Compiler.prototype.outputSuspensionHelpers = function (unit) {
     output += "var $saveSuspension = function($child, $filename, $lineno, $colno) {" +
                 "var susp = new Sk.misceval.Suspension(); susp.child=$child;" +
                 "susp.resume=function(){"+unit.scopename+".$wakingSuspension=susp; return "+unit.scopename+"("+(unit.ste.generator?"$gen":"")+"); };" +
-                "susp.data=susp.child.data;susp.$blk=$blk;susp.$loc=$loc;susp.$gbl=$gbl;susp.$exc=$exc;susp.$err=$err;" +
+                "susp.data=susp.child.data;susp.$blk=$blk;susp.$loc=$loc;susp.$gbl=$gbl;susp.$exc=$exc;susp.$err=$err;susp.$postfinally=$postfinally;" +
                 "susp.$filename=$filename;susp.$lineno=$lineno;susp.$colno=$colno;" +
                 "susp.optional=susp.child.optional;" +
                 (hasCell ? "susp.$cell=$cell;" : "");
@@ -1268,8 +1276,11 @@ Compiler.prototype.ctryfinally = function (s) {
     var finalBody = this.newBlock("finalbody");
     var exceptionHandler = this.newBlock("finalexh")
     var exceptionToReRaise = this._gr("finally_reraise", "undefined");
+    var thisFinally, nextFinally;
     this.u.tempsToSave.push(exceptionToReRaise);
 
+    this.pushFinallyBlock(finalBody);
+    thisFinally = this.peekFinallyBlock();
     this.setupExcept(exceptionHandler);
     this.vseqstmt(s.body);
     this.endExcept();
@@ -1283,10 +1294,33 @@ Compiler.prototype.ctryfinally = function (s) {
     this._jump(finalBody);
 
     this.setBlock(finalBody);
+    this.popFinallyBlock();
     this.vseqstmt(s.finalbody);
     // If finalbody executes normally, AND we have an exception
     // to re-raise, we raise it.
     out("if(",exceptionToReRaise,"!==undefined) { throw ",exceptionToReRaise,";}");
+    if (this.u.finallyBlocks.length == 0) {
+        out("if($postfinally!==undefined) { if ($postfinally.returning) { return $postfinally.returning; } else { $blk=$postfinally.gotoBlock; $postfinally=undefined; continue; } }");
+    } else {
+        // If this was a nonlocal return, we need to work out where to go.
+        // If it's a return, we always continue the finally chain.
+        // If it's a break or continue, we need to work out whether our parent
+        // finally-block is at the same break/continue depth as us (ie whether there's
+        // a loop/breakable-block boundary between us and it).
+
+        nextFinally = this.peekFinallyBlock();
+        
+        out("if($postfinally!==undefined) {",
+                "if ($postfinally.returning",
+                    (nextFinally.breakDepth == thisFinally.breakDepth) ? "|| $postfinally.isBreak" : "",
+                    (nextFinally.continueDepth == thisFinally.continueDepth) ? "|| $postfinally.isContinue" : "", ") {",
+
+                        "$blk=",nextFinally.blk,";continue;",
+                "} else {",
+                    "$blk=$postfinally.gotoBlock;$postfinally=undefined;continue;",
+                "}",
+            "}");
+    }
     // Else, we continue from here.
 };
 
@@ -1537,7 +1571,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
 
     // note special usage of 'this' to avoid having to slice globals into
     // all function invocations in call
-    this.u.varDeclsCode += "var $blk=" + entryBlock + ",$exc=[],$loc=" + locals + cells + ",$gbl=this,$err=undefined,$ret=undefined,$currLineNo=undefined,$currColNo=undefined;";
+    this.u.varDeclsCode += "var $blk=" + entryBlock + ",$exc=[],$loc=" + locals + cells + ",$gbl=this,$err=undefined,$ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;";
     if (Sk.execLimit !== null) {
         this.u.varDeclsCode += "if (typeof Sk.execStart === 'undefined') {Sk.execStart = Date.now()}";
     }
@@ -1875,7 +1909,7 @@ Compiler.prototype.cclass = function (s) {
 
     this.u.prefixCode = "var " + scopename + "=(function $" + s.name.v + "$class_outer($globals,$locals,$rest){var $gbl=$globals,$loc=$locals;";
     this.u.switchCode += "(function $" + s.name.v + "$_closure(){";
-    this.u.switchCode += "var $blk=" + entryBlock + ",$exc=[],$ret=undefined,$currLineNo=undefined,$currColNo=undefined;"
+    this.u.switchCode += "var $blk=" + entryBlock + ",$exc=[],$ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;"
     if (Sk.execLimit !== null) {
         this.u.switchCode += "if (typeof Sk.execStart === 'undefined') {Sk.execStart = Date.now()}";
     }
@@ -1908,12 +1942,32 @@ Compiler.prototype.cclass = function (s) {
 };
 
 Compiler.prototype.ccontinue = function (s) {
-    if (this.u.continueBlocks.length === 0) {
+    var nextFinally = this.peekFinallyBlock(), gotoBlock;
+    if (this.u.continueBlocks.length == 0) {
         throw new SyntaxError("'continue' outside loop");
     }
     // todo; continue out of exception blocks
-    this._jump(this.u.continueBlocks[this.u.continueBlocks.length - 1]);
+    gotoBlock = this.u.continueBlocks[this.u.continueBlocks.length - 1];
+    if (nextFinally && nextFinally.continueDepth == this.u.continueBlocks.length) {
+        out("$postfinally={isContinue:true,gotoBlock:",gotoBlock,"};");
+    } else {
+        this._jump(gotoBlock);
+    }
 };
+
+Compiler.prototype.cbreak = function (s) {
+    var nextFinally = this.peekFinallyBlock(), gotoBlock;
+
+    if (this.u.breakBlocks.length === 0) {
+        throw new SyntaxError("'break' outside loop");
+    }
+    gotoBlock = this.u.breakBlocks[this.u.breakBlocks.length - 1];
+    if (nextFinally && nextFinally.breakDepth == this.u.breakBlocks.length) {
+        out("$postfinally={isBreak:true,gotoBlock:",gotoBlock,"};");
+    } else {
+        this._jump(gotoBlock);
+    }
+}
 
 /**
  * compiles a statement
@@ -1953,11 +2007,12 @@ Compiler.prototype.vstmt = function (s) {
             if (this.u.ste.blockType !== FunctionBlock) {
                 throw new SyntaxError("'return' outside function");
             }
-            if (s.value) {
-                out("return ", this.vexpr(s.value), ";");
-            }
-            else {
-                out("return Sk.builtin.none.none$;");
+            val = s.value ? this.vexpr(s.value) : "Sk.builtin.none.none$";
+            if (this.u.finallyBlocks.length == 0) {
+                out("return ", val, ";");
+            } else {
+                out("$postfinally={returning:",val,"};");
+                this._jump(this.peekFinallyBlock().blk);
             }
             break;
         case Delete_:
@@ -2001,10 +2056,7 @@ Compiler.prototype.vstmt = function (s) {
         case Pass:
             break;
         case Break_:
-            if (this.u.breakBlocks.length === 0) {
-                throw new SyntaxError("'break' outside loop");
-            }
-            this._jump(this.u.breakBlocks[this.u.breakBlocks.length - 1]);
+            this.cbreak(s);
             break;
         case Continue_:
             this.ccontinue(s);
@@ -2280,7 +2332,7 @@ Compiler.prototype.cmod = function (mod) {
     this.u.varDeclsCode =
         "var $gbl = {}, $blk=" + entryBlock +
         ",$exc=[],$loc=$gbl,$err=undefined;$gbl.__name__=$modname;$loc.__file__=new Sk.builtins.str('" + this.filename +
-        "');var $ret=undefined,$currLineNo=undefined,$currColNo=undefined;";
+        "');var $ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;";
 
     if (Sk.execLimit !== null) {
         this.u.varDeclsCode += "if (typeof Sk.execStart === 'undefined') {Sk.execStart = Date.now()}";

--- a/src/compile.js
+++ b/src/compile.js
@@ -896,7 +896,8 @@ Compiler.prototype.popExceptBlock = function () {
 
 Compiler.prototype.pushFinallyBlock = function (n) {
     goog.asserts.assert(n >= 0 && n < this.u.blocknum);
-    this.u.finallyBlocks.push({blk: n, breakDepth: this.u.breakBlocks.length, continueDepth: this.u.continueBlocks.length});
+    goog.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
+    this.u.finallyBlocks.push({blk: n, breakDepth: this.u.breakBlocks.length});
 };
 Compiler.prototype.popFinallyBlock = function () {
     this.u.finallyBlocks.pop();
@@ -1274,21 +1275,40 @@ Compiler.prototype.ctryexcept = function (s) {
 Compiler.prototype.outputFinallyCascade = function (thisFinally) {
     var nextFinally;
     
+    // What do we do when we're done executing a 'finally' block?
+    // Normally you just fall off the end. If we're 'return'ing,
+    // 'continue'ing or 'break'ing, $postfinally tells us what to do.
+    //
+    // But we might be in a nested pair of 'finally' blocks. If so, we need
+    // to work out whether to jump to the outer finally block.
+    //
+    // (NB we do NOT deal with re-raising exceptions here. That's handled
+    // elsewhere, because 'with' does special things with exceptions.)
+
     if (this.u.finallyBlocks.length == 0) {
+        // No nested 'finally' block. Easy.
         out("if($postfinally!==undefined) { if ($postfinally.returning) { return $postfinally.returning; } else { $blk=$postfinally.gotoBlock; $postfinally=undefined; continue; } }");
     } else {
-        // If this was a nonlocal return, we need to work out where to go.
-        // If it's a return, we always continue the finally chain.
-        // If it's a break or continue, we need to work out whether our parent
-        // finally-block is at the same break/continue depth as us (ie whether there's
-        // a loop/breakable-block boundary between us and it).
+
+        // OK, we're nested. Do we jump straight to the outer 'finally' block?
+        // Depends on how we got here here.
+
+        // Normal execution ($postfinally===undefined)? No, we're done here.
+
+        // Returning ($postfinally.returning)? Yes, we want to execute all the
+        // 'finally' blocks on the way out.
+
+        // Breaking ($postfinally.isBreak)? It depends. Is the outer 'finally'
+        // block inside or outside the loop we're breaking out of? We compare
+        // its breakDepth to ours to find out. If we're at the same breakDepth,
+        // we're both inside the innermost loop, so we both need to execute.
+        // ('continue' is the same thing as 'break' for us)
 
         nextFinally = this.peekFinallyBlock();
         
         out("if($postfinally!==undefined) {",
                 "if ($postfinally.returning",
-                    (nextFinally.breakDepth == thisFinally.breakDepth) ? "|| $postfinally.isBreak" : "",
-                    (nextFinally.continueDepth == thisFinally.continueDepth) ? "|| $postfinally.isContinue" : "", ") {",
+                    (nextFinally.breakDepth == thisFinally.breakDepth) ? "|| $postfinally.isBreak" : "", ") {",
 
                         "$blk=",nextFinally.blk,";continue;",
                 "} else {",
@@ -1296,7 +1316,7 @@ Compiler.prototype.outputFinallyCascade = function (thisFinally) {
                 "}",
             "}");
     }
-}
+};
 
 Compiler.prototype.ctryfinally = function (s) {
 
@@ -2022,8 +2042,9 @@ Compiler.prototype.ccontinue = function (s) {
     }
     // todo; continue out of exception blocks
     gotoBlock = this.u.continueBlocks[this.u.continueBlocks.length - 1];
-    if (nextFinally && nextFinally.continueDepth == this.u.continueBlocks.length) {
-        out("$postfinally={isContinue:true,gotoBlock:",gotoBlock,"};");
+    goog.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
+    if (nextFinally && nextFinally.breakDepth == this.u.continueBlocks.length) {
+        out("$postfinally={isBreak:true,gotoBlock:",gotoBlock,"};");
     } else {
         this._jump(gotoBlock);
     }
@@ -2041,7 +2062,7 @@ Compiler.prototype.cbreak = function (s) {
     } else {
         this._jump(gotoBlock);
     }
-}
+};
 
 /**
  * compiles a statement

--- a/src/errors.js
+++ b/src/errors.js
@@ -536,4 +536,15 @@ Sk.abstr.setUpInheritance("StopIteration", Sk.builtin.StopIteration, Sk.builtin.
 goog.exportSymbol("Sk.builtin.StopIteration", Sk.builtin.StopIteration);
 
 
+// TODO: Extract into sys.exc_info(). Work out how the heck
+// to find out what exceptions are being processed by parent stack frames...
+Sk.builtin.getExcInfo = function(e) {
+    var v = [e.ob$type || Sk.builtin.none.none$, e, Sk.builtin.none.none$];
+
+    // TODO create a Traceback object for the third tuple element
+
+    return new Sk.builtin.tuple(v);
+};
+// NOT exported
+
 goog.exportSymbol("Sk", Sk);

--- a/test/unit/test_exceptions.py
+++ b/test/unit/test_exceptions.py
@@ -1,0 +1,38 @@
+import unittest
+
+class ExceptionTest(unittest.TestCase):
+	def test_finally(self):
+		finally_ran = False
+		try:
+			pass
+		finally:
+			finally_ran = True
+		self.assertTrue(finally_ran)
+
+
+		finally_ran = False
+		try:
+			raise Exception()
+		except:
+			pass
+		else:
+			self.assertFalse(True, "'else' should not fire if exception raised")
+		finally:
+			finally_ran = True
+		self.assertTrue(finally_ran)
+
+
+		finally_ran = False
+		try:
+			try:
+				raise Exception()
+			finally:
+				finally_ran = True
+
+			self.assertTrue(False, "No re-raise after 'finally'")
+		except:
+			pass
+		self.assertTrue(finally_ran)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_exceptions.py
+++ b/test/unit/test_exceptions.py
@@ -34,5 +34,110 @@ class ExceptionTest(unittest.TestCase):
 			pass
 		self.assertTrue(finally_ran)
 
+	def test_finally_return(self):
+		finally_ran = [False]
+		def r1():
+			try:
+				return 42
+				self.assertTrue(False, "Execution continued after return")
+			finally:
+				finally_ran[0] = True
+		self.assertEqual(r1(), 42)
+		self.assertTrue(finally_ran[0], "'finally' block did not run")
+
+		def r2():
+			try:
+				return 42
+				self.assertTrue(False, "Execution continued after return")
+			finally:
+				return 43
+		self.assertEqual(r2(), 43)
+
+		def r3():
+			try:
+				raise Exception()
+			finally:
+				return 42
+		self.assertEqual(r3(), 42)
+
+		finally_ran = [False]
+		def r4():
+			try:
+				raise Exception()
+			except:
+				return 42
+			finally:
+				finally_ran[0] = True
+		self.assertEqual(r4(), 42);
+		self.assertTrue(finally_ran[0], "'finally' block did not run")
+
+		def r5():
+			try:
+				raise Exception()
+			except:
+				return 42
+			finally:
+				return 43
+		self.assertEqual(r5(), 43)
+
+		finally_ran = [False, False]
+		def r6():
+			try:
+				try:
+					raise Exception()
+				finally:
+					finally_ran[0] = True
+					return 42
+			finally:
+				finally_ran[1] = True
+		self.assertEqual(r6(), 42)
+		self.assertEqual(finally_ran, [True, True])
+
+		def r7():
+			try:
+				return 42
+			finally:
+				raise Exception()
+		self.assertRaises(Exception, r7)
+
+	def test_finally_break_continue(self):
+		finally_ran = [False,False]
+		normal_execution_continued = False
+		try:
+			while True:
+				try:
+					try:
+						break
+					finally:
+						finally_ran[0] = True
+					self.assertFalse(True, "Execution got past 'break' statement")
+				finally:
+					finally_ran[1] = True
+				self.assertFalse(True, "Execution got past 'break' statement")
+			normal_execution_continued = True
+		finally:
+			self.assertEqual(finally_ran, [True, True]);
+			self.assertTrue(normal_execution_continued, "'break' skipped too many finallies")
+
+
+		finally_ran = [False,False]
+		normal_execution_continued = False
+		try:
+			while not finally_ran[0]:
+				try: 
+					try:
+						continue
+					finally:
+						finally_ran[0] = True
+					self.assertFalse(True, "Execution got past 'continue' statement")
+				finally:
+					finally_ran[1] = True
+				self.assertFalse(True, "Execution got past 'continue' statement")
+			normal_execution_continued = True
+		finally:
+			self.assertEqual(finally_ran, [True, True]);
+			self.assertTrue(normal_execution_continued, "'continue' skipped too many finallies")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_with.py
+++ b/test/unit/test_with.py
@@ -1,0 +1,89 @@
+import unittest
+
+class CtxMgr:
+	def __init__(self, swallow_exception=False):
+		self.n_enter = self.n_exit = 0
+		self.exc_info = None
+		self.swallow_exception = swallow_exception
+
+	def __enter__(self):
+		self.n_enter += 1
+		return 42
+
+	def __exit__(self, x, y, z):
+		self.n_exit += 1
+		if x is not None:
+			self.exc_info = (x, y, z)
+		return self.swallow_exception
+
+	def check_inside(self, testcase):
+		testcase.assertEqual(self.n_enter, 1, "__enter__ not called before body")
+		testcase.assertEqual(self.n_exit, 0, "__exit__ called before body")
+
+	def check(self, testcase, expect_exception = False):
+		testcase.assertEqual(self.n_enter, 1, "__enter__ called wrong number of times")
+		testcase.assertEqual(self.n_exit, 1, "__exit__ called wrong number of times")
+		if expect_exception:
+			testcase.assertIsNotNone(self.exc_info, "No exception passed to __exit__")
+		else:
+			testcase.assertIsNone(self.exc_info, "Unexpected exception passed to __exit__")
+
+
+class WithTest(unittest.TestCase):
+	def test_with(self):
+		# Straightforward execution
+		ctxmgr = CtxMgr()
+		with ctxmgr as foo:
+			self.assertEqual(foo, 42)
+			ctxmgr.check_inside(self)
+		ctxmgr.check(self)
+
+		# Exception handling
+		ctxmgr = CtxMgr()
+		def with_exc():
+			with ctxmgr:
+				raise Exception
+			self.assertFalse(True, "Execution continued after raise-within-with")
+		self.assertRaises(Exception, with_exc)
+		ctxmgr.check(self, expect_exception=True)
+		self.assertEqual(ctxmgr.exc_info[0], Exception)
+
+		# Exception swallowing
+		ctxmgr = CtxMgr(swallow_exception=True)
+		with ctxmgr:
+			raise Exception()
+		ctxmgr.check(self, expect_exception=True)
+
+		# Break from within 'with'
+		ctxmgr = CtxMgr()
+		while True:
+			with ctxmgr:
+				break
+		ctxmgr.check(self)
+
+		# Chain correctly to and from other 'finally' clauses
+		# (also test 'continue' while we're at it)
+		ctxmgr = CtxMgr()
+		finally_ran = [False, False, False]
+		code_continued = False
+		try:
+			while not finally_ran[0]:
+				try:
+					with ctxmgr:
+						try:
+							continue
+						finally:
+							finally_ran[0] = True
+						self.assertFalse(True, "Execution got past 'continue' statement (within 'with')")
+					self.assertFalse(True, "Execution got past 'continue' statement (outside 'with')")
+				finally:
+					finally_ran[1] = True
+			code_continued = True
+		finally:
+			pass
+		ctxmgr.check(self)
+		self.assertTrue(code_continued)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR supports the `with` statement (PEP 343) in Skulpt. Context managers ahoy!

Many thanks to @albertjan for the parser patch that made this possible.

(This PR builds on my #680 `try`/`finally` implementation, as `with` uses many of the same mechanisms)