### PR TITLE
Support constructing a dict with kwargs

### DIFF
--- a/src/dict.js
+++ b/src/dict.js
@@ -49,8 +49,21 @@ Sk.builtin.dict = function dict (L) {
     }
 
     this.__class__ = Sk.builtin.dict;
+    this.tp$call = undefined; // Not callable, even though constructor is
 
     return this;
+};
+
+Sk.builtin.dict.tp$call = function(args, kw) {
+    var d, i;
+    Sk.builtin.pyCheckArgs("dict", args, 0, 1);
+    d = new Sk.builtin.dict(args[0]);
+    if (kw) {
+        for (i = 0; i < kw.length; i += 2) {
+            d.mp$ass_subscript(new Sk.builtin.str(kw[i]), kw[i+1]);
+        }
+    }
+    return d;
 };
 
 Sk.abstr.setUpInheritance("dict", Sk.builtin.dict, Sk.builtin.object);

--- a/test/unit/test_dict.py
+++ b/test/unit/test_dict.py
@@ -9,6 +9,8 @@ class DictTest(unittest.TestCase):
         self.assertEqual(dict(), {})
         self.assertIsNot(dict(), {})
 
+        self.assertEqual(dict(a='b', b='c'), {'a':'b', 'b': 'c'})
+
     def test_bool(self):
         self.assertIs(not {}, True)
         self.assertTrue({1: 2})


### PR DESCRIPTION
This change supports supplying keyword arguments to the `dict()` constructor.

By defining a `tp$call` slot on the `Sk.builtin.dict()` function, I could separate out the Python and JS call paths, and add kwarg handling neatly.