### PR TITLE
Implement object.__getattribute__; tidy up attribute getting

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -1049,26 +1049,7 @@ Sk.builtin.hasattr = function hasattr (obj, attr) {
         if (obj.tp$getattr(attr.v)) {
             return Sk.builtin.bool.true$;
         } else {
-            special = Sk.abstr.lookupSpecial(obj, "__getattr__");
-            if (special) {
-                ret = Sk.misceval.tryCatch(function () {
-                    var val = Sk.misceval.callsim(special, obj, attr);
-                    if (val) {
-                        return Sk.builtin.bool.true$;
-                    } else {
-                        return Sk.builtin.bool.false$;
-                    }
-                }, function(e) {
-                    if (e instanceof Sk.builtin.AttributeError) {
-                        return Sk.builtin.bool.false$;
-                    } else {
-                        throw e;
-                    }
-                });
-                return ret;
-            } else {
-                return Sk.builtin.bool.false$;
-            }
+            return Sk.builtin.bool.false$;
         }
     } else {
         throw new Sk.builtin.AttributeError("Object has no tp$getattr method");

--- a/src/dict.js
+++ b/src/dict.js
@@ -452,9 +452,9 @@ Sk.builtin.dict.prototype.__len__ = new Sk.builtin.func(function (self) {
     return Sk.builtin.dict.prototype.mp$length.call(self);
 });
 
-Sk.builtin.dict.prototype.__getattr__ = new Sk.builtin.func(function (self, attr) {
-    Sk.builtin.pyCheckArgs("__getattr__", arguments, 1, 1, false, true);
-    if (!Sk.builtin.checkString(attr)) { throw new Sk.builtin.TypeError("__getattr__ requires a string"); }
+Sk.builtin.dict.prototype.__getattribute__ = new Sk.builtin.func(function (self, attr) {
+    Sk.builtin.pyCheckArgs("__getattribute__", arguments, 1, 1, false, true);
+    if (!Sk.builtin.checkString(attr)) { throw new Sk.builtin.TypeError("__getattribute__ requires a string"); }
     return Sk.builtin.dict.prototype.tp$getattr.call(self, Sk.ffi.remapToJs(attr));
 });
 

--- a/src/object.js
+++ b/src/object.js
@@ -84,7 +84,7 @@ Sk.builtin.object.prototype.GenericGetAttr = function (name, canSuspend) {
     if (descr !== undefined && descr !== null) {
         f = descr.tp$descr_get;
         if (f) {
-            getf = f.call(descr, this, this.ob$type, canSuspend);
+            getf = f.call(descr, this, this.ob$type);
         } else {
             getf = descr;
         }

--- a/src/object.js
+++ b/src/object.js
@@ -38,6 +38,7 @@ Sk.builtin.object.prototype.GenericGetAttr = function (name, canSuspend) {
     var descr;
     var tp;
     var dict;
+    var getf;
     var pyName = new Sk.builtin.str(name);
     goog.asserts.assert(typeof name === "string");
 
@@ -53,7 +54,6 @@ Sk.builtin.object.prototype.GenericGetAttr = function (name, canSuspend) {
         } else if (dict.mp$subscript) {
             res = _tryGetSubscript(dict, pyName);
         } else if (typeof dict === "object") {
-            // todo; definitely the wrong place for this. other custom tp$getattr won't work on object -- bnm -- implemented custom __getattr__ in abstract.js
             res = dict[name];
         }
         if (res !== undefined) {
@@ -78,12 +78,40 @@ Sk.builtin.object.prototype.GenericGetAttr = function (name, canSuspend) {
         return descr;
     }
 
+    // OK, try __getattr__
+
+    descr = Sk.builtin.type.typeLookup(tp, "__getattr__");
+    if (descr !== undefined && descr !== null) {
+        f = descr.tp$descr_get;
+        if (f) {
+            getf = f.call(descr, this, this.ob$type, canSuspend);
+        } else {
+            getf = descr;
+        }
+
+        res = Sk.misceval.tryCatch(function() {
+            return Sk.misceval.callsimOrSuspend(getf, pyName);
+        }, function(e) {
+            if (e instanceof Sk.builtin.AttributeError) {
+                return undefined;
+            } else {
+                throw e;
+            }
+        });
+        return canSuspend ? res : Sk.misceval.retryOptionalSuspensionOrThrow(res);
+    }
+
+
     return undefined;
 };
 goog.exportSymbol("Sk.builtin.object.prototype.GenericGetAttr", Sk.builtin.object.prototype.GenericGetAttr);
 
 Sk.builtin.object.prototype.GenericPythonGetAttr = function(self, name) {
-    return Sk.builtin.object.prototype.GenericGetAttr.call(self, name.v);
+    var r = Sk.builtin.object.prototype.GenericGetAttr.call(self, name.v, true);
+    if (r === undefined) {
+        throw new Sk.builtin.AttributeError(name);
+    }
+    return r;
 };
 goog.exportSymbol("Sk.builtin.object.prototype.GenericPythonGetAttr", Sk.builtin.object.prototype.GenericPythonGetAttr);
 
@@ -145,8 +173,8 @@ Sk.builtin.object.prototype.tp$getattr = Sk.builtin.object.prototype.GenericGetA
 Sk.builtin.object.prototype.tp$setattr = Sk.builtin.object.prototype.GenericSetAttr;
 
 // Although actual attribute-getting happens in pure Javascript via tp$getattr, classes
-// overriding __getattr__ etc need to be able to call object.__getattr__ etc from Python
-Sk.builtin.object.prototype["__getattr__"] = Sk.builtin.object.prototype.GenericPythonGetAttr;
+// overriding __getattribute__ etc need to be able to call object.__getattribute__ etc from Python
+Sk.builtin.object.prototype["__getattribute__"] = Sk.builtin.object.prototype.GenericPythonGetAttr;
 Sk.builtin.object.prototype["__setattr__"] = Sk.builtin.object.prototype.GenericPythonSetAttr;
 
 /**
@@ -438,7 +466,7 @@ Sk.builtin.object.prototype.ob$ge = function (other) {
  */
 Sk.builtin.object.pythonFunctions = ["__repr__", "__str__", "__hash__",
                                      "__eq__", "__ne__", "__lt__", "__le__",
-                                     "__gt__", "__ge__", "__getattr__",
+                                     "__gt__", "__ge__", "__getattribute__",
                                      "__setattr__", "__format__"];
 
 /**

--- a/src/type.js
+++ b/src/type.js
@@ -273,17 +273,17 @@ Sk.builtin.type = function (name, bases, dict) {
         };
 
         klass.prototype.tp$getattr = function(name, canSuspend) {
-            var r, /** @type {(Object|undefined)} */ getf;
+            var r, descr, /** @type {(Object|undefined)} */ getf;
 
-            getf = Sk.builtin.object.prototype.GenericGetAttr.call(this, "__getattribute__");
+            // Find __getattribute__ on this type if we can
+            descr = Sk.builtin.type.typeLookup(klass, "__getattribute__");
+
+            if (descr !== undefined && descr !== null && descr.tp$descr_get !== undefined) {
+                getf = descr.tp$descr_get.call(descr, this, klass);
+            }
+
             if (getf === undefined) {
-                getf = function(pyName) {
-                    var r = Sk.builtin.object.prototype.GenericGetAttr.call(this, name);
-                    if (r === undefined) {
-                        throw new Sk.builtin.AttributeError(name);
-                    }
-                    return r;
-                }.bind(this);
+                getf = Sk.builtin.object.prototype.GenericPythonGetAttr.bind(null, this);
             }
 
             // Convert AttributeErrors back into 'undefined' returns to match the tp$getattr

--- a/test/run/t407.py.real
+++ b/test/run/t407.py.real
@@ -1,3 +1,3 @@
-['__eq__', '__format__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
-['__eq__', '__format__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
+['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']

--- a/test/run/t407.py.real.force
+++ b/test/run/t407.py.real.force
@@ -1,3 +1,3 @@
-['__eq__', '__format__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
-['__eq__', '__format__', '__ge__', '__getattr__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
+['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']

--- a/test/unit/test_attrs.py
+++ b/test/unit/test_attrs.py
@@ -1,0 +1,43 @@
+"""Tests for attributes."""
+
+import unittest
+
+#import datetime
+
+class AttributeGetter(object):
+    def __getattribute__(self, attr_name):
+        if attr_name == "foo":
+            return 42
+
+        try:
+            return object.__getattribute__(self, attr_name)
+        except AttributeError:
+            if attr_name == "bar":
+                return 42
+            raise
+
+
+
+class AttrTestCase(unittest.TestCase):
+
+    def test_attr(self):
+        AttrTestCase.foo = 42
+        self.assertEqual(AttrTestCase.foo, 42)
+
+    def test_cascading_getattribute(self):
+        ag = AttributeGetter()
+        self.assertEqual(ag.foo, 42)
+        self.assertEqual(ag.bar, 42)
+        self.assertRaises(AttributeError, lambda: ag.baz)
+        ag.foo = 0
+        ag.bar = 0
+        ag.baz = 0
+        self.assertEqual(ag.foo, 42)
+        self.assertEqual(ag.bar, 0)
+        self.assertEqual(ag.baz, 0)
+
+
+AttrTestCase.x = 42
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_inheritance.py
+++ b/test/unit/test_inheritance.py
@@ -3,7 +3,7 @@ __author__ = 'mchat'
 import unittest
 
 object_methods = ["__repr__", "__str__", "__hash__", "__eq__", "__ne__",
-    "__lt__", "__le__", "__gt__", "__ge__", "__getattr__", "__setattr__"]
+    "__lt__", "__le__", "__gt__", "__ge__", "__getattribute__", "__setattr__"]
 
 numeric_methods = ["__abs__", "__neg__", "__pos__", "__int__", "__long__",
     "__float__", "__add__", "__radd__", "__sub__", "__rsub__", "__mul__",


### PR DESCRIPTION
Skulpt's implementation of `object.__getattr__` was incorrect (`object.__getattr__` does not exist in CPython).

In CPython, `object.__getattribute__` is the default implementation of the "get attribute" slot (`tp$getattr` in Skulpt), and it falls back to `__getattr__` if it doesn't find anything. I have updated the Skulpt implementation to do the same thing.

This means that the `type.js` implementation of `tp$getattr` just got a whole lot simpler - and we can actually use `object.__getattribute__` from Python code now.

In addition, `object.__getattribute__` now actually throws an `AttributeError` instead of returning `undefined` (which is not a legal Python value, and confuses the heck out of calling code) - which was the original bug that prompted this change. The yak hair is piled deep around my ankles this afternoon ;)