### PR TITLE
remove calls to jscs and jshint in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - nvm use node
 - npm install npm@latest -g
 - npm install
-- pip install "GitPython>=0.2.0-beta1" --use-mirrors
+- pip install "GitPython>=0.2.0-beta1"
 - mkdir -p vendors
 script:
 - npm run build-min

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ install:
 - nvm use node
 - npm install npm@latest -g
 - npm install
-- jscs -V
-- jshint -v
 - pip install "GitPython>=0.2.0-beta1" --use-mirrors
 - mkdir -p vendors
 script:

--- a/skulpt.py
+++ b/skulpt.py
@@ -239,17 +239,12 @@ def test(debug_mode=False, p3=False):
             jshintcmd = "jshint " + folders
             jscscmd = "jscs " + folders + " --reporter=inline"
 
-        print jshintcmd
-        print jscscmd
         ret2 = os.system(jshintcmd)
         print "Running JSCS"
         ret3 = os.system(jscscmd)
-        print ret3
-        #ret3 = os.system(jscscmd)
         print "Now running new unit tests"
         ret4 = rununits(p3=p3, debug_mode=debug_mode)
 
-    print (ret1, ret2, ret3, ret4)
     return ret1 | ret2 | ret3 | ret4
 
 def parse_time_args(argv):

--- a/skulpt.py
+++ b/skulpt.py
@@ -21,6 +21,7 @@ import pprint
 import json
 import shutil
 import time
+from itertools import chain
 
 # Assume that the GitPython module is available until proven otherwise.
 GIT_MODULE_AVAILABLE = True
@@ -228,19 +229,27 @@ def test(debug_mode=False, p3=False):
     if ret1 == 0:
         print "Running jshint"
         base_dirs = ["src", "debugger"]
-        for base_dir in base_dirs:
-            if sys.platform == "win32":
-                jshintcmd = "{0} {1}".format("jshint", ' '.join(f for f in glob.glob(base_dir + "/*.js")))
-                jscscmd = "{0} {1} --reporter=inline".format("jscs", ' '.join(f for f in glob.glob(base_dir + "/*.js")))
-            else:
-                jshintcmd = "jshint " + base_dir + "/*.js"
-                jscscmd = "jscs " + base_dir + "/*.js --reporter=inline"
+
+        if sys.platform == "win32":
+            files = list(chain.from_iterable([ glob.glob(d + "/*.js") for d in base_dirs ]))
+            jshintcmd = "jshint {1}".format(' '.join(files))
+            jscscmd = "jscs {1} --reporter=inline".format(' '.join(files))
+        else:
+            folders = ' '.join([ d + "/*.js" for d in base_dirs ])
+            jshintcmd = "jshint " + folders
+            jscscmd = "jscs " + folders + " --reporter=inline"
+
+        print jshintcmd
+        print jscscmd
         ret2 = os.system(jshintcmd)
         print "Running JSCS"
         ret3 = os.system(jscscmd)
+        print ret3
         #ret3 = os.system(jscscmd)
         print "Now running new unit tests"
         ret4 = rununits(p3=p3, debug_mode=debug_mode)
+
+    print (ret1, ret2, ret3, ret4)
     return ret1 | ret2 | ret3 | ret4
 
 def parse_time_args(argv):
@@ -1312,13 +1321,13 @@ def main():
         f.write(getInternalCodeAsJson() + ";")
 
     if cmd == "test":
-        test()
+        exit(bool(test()))
     elif cmd == "test3":
-        test(p3=True)
+        exit(bool(test(p3=True)))
     elif cmd == "testdebug":
-        test(debug_mode=True)
+        exit(bool(test(debug_mode=True)))
     elif cmd == "test3debug":
-        test(debug_mode=True, p3=True)
+        exit(bool(test(debug_mode=True, p3=True)))
     elif cmd == "dist":
         dist(options)
     elif cmd == "regengooglocs":

--- a/src/file.js
+++ b/src/file.js
@@ -162,8 +162,8 @@ Sk.builtin.file.$readline = function (self, size, prompt) {
     }
 };
 
-Sk.builtin.file.prototype["readline"] = new Sk.builtin.func(function readline(self, size) { 
-    return Sk.builtin.file.$readline(self, size, undefined); 
+Sk.builtin.file.prototype["readline"] = new Sk.builtin.func(function readline(self, size) {
+    return Sk.builtin.file.$readline(self, size, undefined);
 });
 
 Sk.builtin.file.prototype["readlines"] = new Sk.builtin.func(function readlines(self, sizehint) {
@@ -185,7 +185,7 @@ Sk.builtin.file.prototype["seek"] = new Sk.builtin.func(function seek(self, offs
     if (whence === undefined) {
         whence = 0;
     }
-    if (whence == 0) {
+    if (whence === 0) {
         self.pos$ = l_offset;
     } else if (whence == 1) {
         self.pos$ = self.data$.length + l_offset;

--- a/src/set.js
+++ b/src/set.js
@@ -146,19 +146,19 @@ Sk.builtin.set.prototype.ob$ge = function (other) {
 
 Sk.builtin.set.prototype.nb$and = function(other){
     return this["intersection"].func_code(this, other);
-}
+};
 
 Sk.builtin.set.prototype.nb$or = function(other){
     return this["union"].func_code(this, other);
-}
+};
 
 Sk.builtin.set.prototype.nb$xor = function(other){
     return this["symmetric_difference"].func_code(this, other);
-}
+};
 
 Sk.builtin.set.prototype.nb$subtract = function(other){
     return this["difference"].func_code(this, other);
-}
+};
 
 Sk.builtin.set.prototype["__iter__"] = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, false, true);
@@ -244,7 +244,7 @@ Sk.builtin.set.prototype["union"] = new Sk.builtin.func(function (self) {
 
 Sk.builtin.set.prototype["intersection"] = new Sk.builtin.func(function (self) {
     var S, i, new_args;
-    
+
     Sk.builtin.pyCheckArgs("intersection", arguments, 1);
 
     S = Sk.builtin.set.prototype["copy"].func_code(self);
@@ -259,7 +259,7 @@ Sk.builtin.set.prototype["intersection"] = new Sk.builtin.func(function (self) {
 
 Sk.builtin.set.prototype["difference"] = new Sk.builtin.func(function (self, other) {
     var S, i, new_args;
-    
+
     Sk.builtin.pyCheckArgs("difference", arguments, 2);
 
     S = Sk.builtin.set.prototype["copy"].func_code(self);


### PR DESCRIPTION
At some point in the past `jscs` and `jshint` weren't called with the correct args anymore, and because we don't globally install jscs and jshint anymore, the script broke. This PR addresses these things and fixes the collected lint over time. 