### PR TITLE
Prevent time.js exploding if no timezone available

### DIFF
--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -104,7 +104,8 @@ var $builtinmodule = function (name) {
     }
 
     function timeZoneName(date) {
-        return /\((.*)\)/.exec(date.toString())[1];
+        var i = /\((.*)\)/.exec(date.toString());
+        return i ? i[1] : "UTC";
     }
 
     function timeZoneNames() {


### PR DESCRIPTION
It now defaults to UTC if there's no timezone in the browser's default string representation, which will be an unpleasant surprise but beats an ExternalError and is probably a sensible default.