### PR TITLE
Allow modules to report their type as "module" properly.

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -8,3 +8,4 @@ goog.exportSymbol("Sk.builtin.module", Sk.builtin.module);
 Sk.builtin.module.prototype.ob$type = Sk.builtin.type.makeIntoTypeObj("module", Sk.builtin.module);
 Sk.builtin.module.prototype.tp$getattr = Sk.builtin.object.prototype.GenericGetAttr;
 Sk.builtin.module.prototype.tp$setattr = Sk.builtin.object.prototype.GenericSetAttr;
+Sk.builtin.module.prototype.tp$name = "module";


### PR DESCRIPTION
Previously:

import sys
sys.fooo

AttributeError: '<invalid type>' object has no attribute 'fooo'

Now:

AttributeError: 'module' object has no attribute 'fooo'