### PR TITLE
Repl exception reporting

### DIFF
--- a/repl/repl.js
+++ b/repl/repl.js
@@ -23,7 +23,8 @@ var compilableLines = [],
     //an identifier followed with some whitspace and then an = and then some more white space.
     //it also checks if the identifier is a tuple.
     assignment = /^((\s*\(\s*(\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*,)*\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*\)\s*)|(\s*\s*(\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*,)*\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*\s*))([+-/*%&\^\|]?|[/<>*]{2})=/, 
-    lines = [];
+    lines = [],
+    origLines;
 
 print("Python 2.6(ish) (skulpt, " + new Date() + ")");
 print("[v8: " + version() + "] on a system");
@@ -65,6 +66,8 @@ while (true) {
     //See if it is ready to be evaluated;
     if (!isBalanced(lines)) { continue; }
 
+    origLines = lines.slice();
+
     //it's a one-liner
     if (lines.length === 1) {
         //if it's a statement that should be printed (not containing an = or def or class or an empty line)
@@ -103,7 +106,7 @@ while (true) {
         var line = 0;
         //print the accumulated code with a ">" before the broken line.
         //Don't add the last statement to the accumulated code
-        print(lines.map(function (str) {
+        print(origLines.map(function (str) {
             return ++line + (index === line ? ">" : " ") + ": " + str;
         }).join('\n'));
     } finally {

--- a/repl/repl.js
+++ b/repl/repl.js
@@ -58,7 +58,7 @@ while (true) {
 
     //Read
     var l = readline();
-    if(l===undefined){
+    if (l === undefined) {
         quit();
     }
     lines.push(l);

--- a/repl/repl.js
+++ b/repl/repl.js
@@ -56,12 +56,16 @@ while (true) {
     write(isBalanced(lines) ? '>>> ' : '... ');
 
     //Read
-    lines.push(readline());
-	
+    var l = readline();
+    if(l===undefined){
+        quit();
+    }
+    lines.push(l);
+
     //See if it is ready to be evaluated;
     if (!isBalanced(lines)) { continue; }
 
-    //it's a onliner
+    //it's a one-liner
     if (lines.length === 1) {
         //if it's a statement that should be printed (not containing an = or def or class or an empty line)
         if (!assignment.test(lines[0]) && !defre.test(lines[0]) && !importre.test(lines[0]) && !comment.test(lines[0]) && lines[0].length > 0) {


### PR DESCRIPTION
In the REPL there is a bug with single-line expressions that throw an exception:

```
>>> fjeiosjfoesjfoes
NameError: name 'fjeiosjfoesjfoes' is not defined on line 1
1>: evaluationresult = fjeiosjfoesjfoes
2 : if not evaluationresult == None: print repr(evaluationresult)
>>> 
```

What is all of that evaluationresult stuff? The repl inserts it into your code and then doesn't remove it before showing you your code again. This small patch does that.
