### PR TITLE
spruce up jseval

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -862,7 +862,16 @@ Sk.builtin.raw_input = function (prompt) {
 Sk.builtin.input = Sk.builtin.raw_input;
 
 Sk.builtin.jseval = function jseval (evalcode) {
-    goog.global["eval"](Sk.ffi.remapToJs(evalcode));
+    var result = goog.global["eval"](Sk.ffi.remapToJs(evalcode));
+    try {
+        return Sk.ffi.remapToPy(result);
+    } catch (err) {
+        if (err.constructor === goog.asserts.AssertionError) {
+            return Sk.builtin.none.none$;
+        }
+
+        throw err;
+    }
 };
 
 Sk.builtin.jsmillis = function jsmillis () {


### PR DESCRIPTION
@prescod have a play with this see if this works for you.

`jseval("5")` will return `5`

and

`jseval("window.alert('test')")` also still works and returns `None`

and 

`jseval("throw new Error('testing!');")` also still "works"