### PR TITLE
Exec for Skulpt

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -1329,6 +1329,45 @@ Sk.builtin.delattr = function delattr (obj, attr) {
     throw new Sk.builtin.TypeError("can't set attributes of built-in/extension type '" + obj.tp$name + "'");
 };
 
+var extractDict = function(obj) {
+    ret = {};
+    for (iter = obj.tp$iter(), k = iter.tp$iternext();
+         k !== undefined;
+         k = iter.tp$iternext()) {
+        v = obj.mp$subscript(k);
+        if (v === undefined) {
+            v = null;
+        }
+        kAsJs = Sk.ffi.remapToJs(k);
+        // todo; assert that this is a reasonble lhs?
+        ret[kAsJs] = v;
+    }
+    return ret;
+}
+Sk.builtin.execf = function execf(python_code, new_globals) {
+    Sk.builtin.pyCheckArgs("execf", arguments, 1, 2);
+    var backupRG = Sk.retainGlobals;
+    Sk.retainGlobals = true;
+    var filename = 'test.py';
+    new_globals_copy = extractDict(new_globals);
+    if (!new_globals_copy.__file__) {
+        new_globals_copy.__file__ = Sk.ffi.remapToPy(filename);
+    }
+    if (!new_globals_copy.__name__) {
+        new_globals_copy.__name__ = Sk.ffi.remapToPy(filename);
+    }
+    var backupGlobals = Sk.globals;
+    Sk.globals = new_globals_copy; // Possibly copy over some "default" ones?
+    python_code = Sk.ffi.remapToJs(python_code);
+    Sk.importMainWithBody(filename, false, python_code, true);
+    Sk.globals = backupGlobals;
+    for (var key in new_globals_copy) {
+        pykey = Sk.ffi.remapToPy(key);
+        Sk.builtin.dict.prototype.mp$ass_subscript.call(new_globals, pykey, new_globals_copy[key])
+    }
+    Sk.retainGlobals = backupRG;
+};
+
 Sk.builtin.execfile = function execfile () {
     throw new Sk.builtin.NotImplementedError("execfile is not yet implemented");
 };

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -92,6 +92,7 @@ Sk.builtins = {
     "delattr"   : Sk.builtin.delattr,
     "eval_$rn$" : Sk.builtin.eval_,
     "execfile"  : Sk.builtin.execfile,
+    "execf"     : Sk.builtin.execf,
     "frozenset" : Sk.builtin.frozenset,
     "help"      : Sk.builtin.help,
     "locals"    : Sk.builtin.locals,

--- a/test/exec_test.py
+++ b/test/exec_test.py
@@ -1,0 +1,8 @@
+a = 3
+dummy_space = {'a': 5}
+assert callable(execf)
+execf('a=6', dummy_space)
+assert a == 3, 'Make sure that the actual a is unchanged from 3'
+assert dummy_space['a'] != 5, 'Make sure that the dummy a was not left at 5'
+assert dummy_space['a'] == 6, 'Make sure that the dummy a is changed to 6'
+print("All done")


### PR DESCRIPTION
So, here's some code I've written that seems to work from my limited testing. Perhaps you could comment on my approach? The core idea is to temporarily enable retainGlobals, swap out the global dictionary with the user provided one, exec the given code, swap the global dictionary back, and then copy over any updated variables into the user provided one.

* I cannot name the function `exec`, because that's a (unimplemented) statement in Skulpt's parser. So for now, I'm creating a thing called `execf`. I don't think I'll have the energy to fight the whole tokenizer and make it a function like it's supposed to be.
* I would like a better way to match up the user provided variables with the pseudo-globals dictionary that gets created before the import, but I wasn't sure if that was possible. It's strange to me that the Sk.globals dictionary seems to be a JS object instead of a Python Dictionary.
* I'm also concerned that I've failed to account for something that would allow scopes to escape.
* Finally, the code is hackish. If this is the right approach, you'll want me to clean this up and provide some docs. For now, I just want to know if this rings true for you.