### PR TITLE
Fix function return values lost while using debugger step-by-step

### DIFF
--- a/debugger/debugger.js
+++ b/debugger/debugger.js
@@ -250,7 +250,9 @@ Sk.Debugger.prototype.success = function(r) {
             var parent_suspension = this.get_active_suspension();
             // The child has completed the execution. So override the child's resume
             // so we can continue the execution.
-            parent_suspension.child.resume = function() {};
+            parent_suspension.child.resume = function() {
+                return r;
+            };
             this.resume();
         } else {
             this.print("Program execution complete");


### PR DESCRIPTION
Hello,

Here's my proposed fix for an issue with the debugger and functions (defined in the Python code) returning values.

**Issue** : while using the debugger step-by-step mode, if a function returns a value, that value is lost as if the function returned `None` / `undefined`.

**Steps to reproduce** on http://www.skulpt.org (easiest way) :
- Enter code :
```
def test():
    return 4
print(test()+2)
```
- In the debugger, enable step mode by typing `step`
- In the debugger, `run` and then repeat `step`
- The debugger wil display `NameError: Undefined variable in expression`

However, the same code run outside of the debugger step-by-step mode will work and display `6` as expected.

**Proposed fix:** Return the value again in the `resume` function that overwrites the child suspension's `resume`.

Thank you in advance for your time reviewing that pull request!

PS : I'm sorry but I have no idea how to write a unit test for this issue, as suggested by `CONTRIBUTING.md`.