### PR TITLE
remove unused __get__ on object

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -351,14 +351,6 @@ Sk.builtin.object.prototype["__ge__"] = function (self, other) {
     return self.ob$ge(other);
 };
 
-Sk.builtin.object.prototype.__get__ = function __get__(self, instance, owner) {
-    Sk.builtin.pyCheckArgs("__get__", arguments, 1, 2, false, true);
-
-    var l_owner = !owner ? instance.ob$type : owner;
-
-    return self.tp$descr_get(instance, l_owner);
-};
-
 /** Default implementations of Javascript functions used in dunder methods */
 
 /**
@@ -492,7 +484,7 @@ Sk.builtin.object.prototype.ob$ge = function (other) {
 Sk.builtin.object.pythonFunctions = ["__repr__", "__str__", "__hash__",
                                      "__eq__", "__ne__", "__lt__", "__le__",
                                      "__gt__", "__ge__", "__getattribute__",
-                                     "__setattr__", "__format__", "__get__"];
+                                     "__setattr__", "__format__"];
 
 /**
  * @constructor

--- a/test/run/t407.py.real
+++ b/test/run/t407.py.real
@@ -1,3 +1,3 @@
-['__eq__', '__format__', '__ge__', '__get__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
-['__eq__', '__format__', '__ge__', '__get__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
+['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']


### PR DESCRIPTION
@meredydd you were right, `__get__` doesn't belong on object and wasn't used at all.