### PR TITLE
'import *' should ignore names beginning with underscores

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -641,13 +641,11 @@ Sk.importStar = function (module, loc, global) {
     // from the global scope, globals and locals can be the same.  So the loop below
     // could accidentally overwrite __name__, erasing __main__.
     var i;
-    var nn = global["__name__"];
     var props = Object["getOwnPropertyNames"](module["$d"]);
     for (i in props) {
-        loc[props[i]] = module["$d"][props[i]];
-    }
-    if (global["__name__"] !== nn) {
-        global["__name__"] = nn;
+        if(i.charAt[0] != "_") {
+            loc[props[i]] = module["$d"][props[i]];
+        }
     }
 };
 


### PR DESCRIPTION
Looks like we somehow regressed on the issue originally addressed by #750. `import *` should not import any name that begins with an underscore. Right now we have a special-case exception for `__name__`, but as it begins with an underscore, this is correctly covered by the more general rule.