### PR TITLE
Stop passing "arguments" to do check on number of arguments.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -561,7 +561,7 @@ module:
 
     var plotk_f = function(kwa)
         {
-            Sk.builtin.pyCheckArgs("plotk", arguments, 0, Infinity, true, false)
+            Sk.builtin.pyCheckArgsLen("plotk", arguments.length, 0, Infinity, true, false)
             args = new Sk.builtins['tuple'](Array.prototype.slice.call(arguments, 1)); /*vararg*/
             kwargs = new Sk.builtins['dict'](kwa);
 

--- a/src/bool.js
+++ b/src/bool.js
@@ -14,7 +14,7 @@
  * @return {Sk.builtin.bool} Sk.builtin.bool.true$ if x is true, Sk.builtin.bool.false$ otherwise
  */
 Sk.builtin.bool = function (x) {
-    Sk.builtin.pyCheckArgs("bool", arguments, 1);
+    Sk.builtin.pyCheckArgsLen("bool", arguments.length, 1);
     if (Sk.misceval.isTrue(x)) {
         return Sk.builtin.bool.true$;
     } else {

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -9,7 +9,7 @@ Sk.builtin.range = function range (start, stop, step) {
     var ret = [];
     var i;
 
-    Sk.builtin.pyCheckArgs("range", arguments, 1, 3);
+    Sk.builtin.pyCheckArgsLen("range", arguments.length, 1, 3);
     Sk.builtin.pyCheckType("start", "integer", Sk.builtin.checkInt(start));
     if (stop !== undefined) {
         Sk.builtin.pyCheckType("stop", "integer", Sk.builtin.checkInt(stop));
@@ -212,7 +212,7 @@ goog.exportSymbol("Sk.builtin.asnum$nofloat", Sk.builtin.asnum$nofloat);
 
 Sk.builtin.round = function round (number, ndigits) {
     var special;
-    Sk.builtin.pyCheckArgs("round", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("round", arguments.length, 1, 2);
 
     if (!Sk.builtin.checkNumber(number)) {
         if (!Sk.builtin.checkFunction(number)) {
@@ -249,7 +249,7 @@ Sk.builtin.round = function round (number, ndigits) {
 Sk.builtin.len = function len (item) {
     var intcheck;
     var special;
-    Sk.builtin.pyCheckArgs("len", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("len", arguments.length, 1, 1);
 
     var int_ = function(i) { return new Sk.builtin.int_(i); };
     intcheck = function(j) {
@@ -296,7 +296,7 @@ Sk.builtin.min = function min () {
     var i;
     var lowest;
     var args;
-    Sk.builtin.pyCheckArgs("min", arguments, 1);
+    Sk.builtin.pyCheckArgsLen("min", arguments.length, 1);
 
     args = Sk.misceval.arrayFromArguments(arguments);
     lowest = args[0];
@@ -317,7 +317,7 @@ Sk.builtin.max = function max () {
     var i;
     var highest;
     var args;
-    Sk.builtin.pyCheckArgs("max", arguments, 1);
+    Sk.builtin.pyCheckArgsLen("max", arguments.length, 1);
 
     args = Sk.misceval.arrayFromArguments(arguments);
     highest = args[0];
@@ -337,7 +337,7 @@ Sk.builtin.max = function max () {
 Sk.builtin.any = function any (iter) {
     var it, i;
 
-    Sk.builtin.pyCheckArgs("any", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("any", arguments.length, 1, 1);
     if (!Sk.builtin.checkIterable(iter)) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(iter) +
             "' object is not iterable");
@@ -356,7 +356,7 @@ Sk.builtin.any = function any (iter) {
 Sk.builtin.all = function all (iter) {
     var it, i;
 
-    Sk.builtin.pyCheckArgs("all", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("all", arguments.length, 1, 1);
     if (!Sk.builtin.checkIterable(iter)) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(iter) +
             "' object is not iterable");
@@ -378,7 +378,7 @@ Sk.builtin.sum = function sum (iter, start) {
     var it, i;
     var has_float;
 
-    Sk.builtin.pyCheckArgs("sum", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("sum", arguments.length, 1, 2);
     Sk.builtin.pyCheckType("iter", "iterable", Sk.builtin.checkIterable(iter));
     if (start !== undefined && Sk.builtin.checkString(start)) {
         throw new Sk.builtin.TypeError("sum() can't sum strings [use ''.join(seq) instead]");
@@ -459,7 +459,7 @@ Sk.builtin.zip = function zip () {
 };
 
 Sk.builtin.abs = function abs (x) {
-    Sk.builtin.pyCheckArgs("abs", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("abs", arguments.length, 1, 1);
 
     if (x instanceof Sk.builtin.int_) {
         return new Sk.builtin.int_(Math.abs(x.v));
@@ -489,7 +489,7 @@ Sk.builtin.fabs = function fabs(x) {
 };
 
 Sk.builtin.ord = function ord (x) {
-    Sk.builtin.pyCheckArgs("ord", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("ord", arguments.length, 1, 1);
 
     if (!Sk.builtin.checkString(x)) {
         throw new Sk.builtin.TypeError("ord() expected a string of length 1, but " + Sk.abstr.typeName(x) + " found");
@@ -500,7 +500,7 @@ Sk.builtin.ord = function ord (x) {
 };
 
 Sk.builtin.chr = function chr (x) {
-    Sk.builtin.pyCheckArgs("chr", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("chr", arguments.length, 1, 1);
     if (!Sk.builtin.checkInt(x)) {
         throw new Sk.builtin.TypeError("an integer is required");
     }
@@ -515,7 +515,7 @@ Sk.builtin.chr = function chr (x) {
 };
 
 Sk.builtin.unichr = function unichr (x) {
-    Sk.builtin.pyCheckArgs("chr", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("chr", arguments.length, 1, 1);
     if (!Sk.builtin.checkInt(x)) {
         throw new Sk.builtin.TypeError("an integer is required");
     }
@@ -557,7 +557,7 @@ Sk.builtin.int2str_ = function helper_ (x, radix, prefix) {
 };
 
 Sk.builtin.hex = function hex (x) {
-    Sk.builtin.pyCheckArgs("hex", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("hex", arguments.length, 1, 1);
     if (!Sk.misceval.isIndex(x)) {
         throw new Sk.builtin.TypeError("hex() argument can't be converted to hex");
     }
@@ -565,7 +565,7 @@ Sk.builtin.hex = function hex (x) {
 };
 
 Sk.builtin.oct = function oct (x) {
-    Sk.builtin.pyCheckArgs("oct", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("oct", arguments.length, 1, 1);
     if (!Sk.misceval.isIndex(x)) {
         throw new Sk.builtin.TypeError("oct() argument can't be converted to hex");
     }
@@ -577,7 +577,7 @@ Sk.builtin.oct = function oct (x) {
 };
 
 Sk.builtin.bin = function bin (x) {
-    Sk.builtin.pyCheckArgs("bin", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("bin", arguments.length, 1, 1);
     if (!Sk.misceval.isIndex(x)) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(x) + "' object can't be interpreted as an index");
     }
@@ -595,7 +595,7 @@ Sk.builtin.dir = function dir (x) {
     var k;
     var names;
     var getName;
-    Sk.builtin.pyCheckArgs("dir", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("dir", arguments.length, 1, 1);
 
     getName = function (k) {
         var s = null;
@@ -706,13 +706,13 @@ Sk.builtin.dir.slotNameToRichName = function (k) {
 };
 
 Sk.builtin.repr = function repr (x) {
-    Sk.builtin.pyCheckArgs("repr", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("repr", arguments.length, 1, 1);
 
     return Sk.misceval.objectRepr(x);
 };
 
 Sk.builtin.open = function open (filename, mode, bufsize) {
-    Sk.builtin.pyCheckArgs("open", arguments, 1, 3);
+    Sk.builtin.pyCheckArgsLen("open", arguments.length, 1, 3);
     if (mode === undefined) {
         mode = new Sk.builtin.str("r");
     }
@@ -729,7 +729,7 @@ Sk.builtin.open = function open (filename, mode, bufsize) {
 Sk.builtin.isinstance = function isinstance (obj, type) {
     var issubclass;
     var i;
-    Sk.builtin.pyCheckArgs("isinstance", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("isinstance", arguments.length, 2, 2);
     if (!Sk.builtin.checkClass(type) && !(type instanceof Sk.builtin.tuple)) {
         throw new Sk.builtin.TypeError("isinstance() arg 2 must be a class, type, or tuple of classes and types");
     }
@@ -786,7 +786,7 @@ Sk.builtin.isinstance = function isinstance (obj, type) {
 
 Sk.builtin.hash = function hash (value) {
     var junk;
-    Sk.builtin.pyCheckArgs("hash", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("hash", arguments.length, 1, 1);
 
     // Useless object to get compiler to allow check for __hash__ property
     junk = {__hash__: function () {
@@ -821,7 +821,7 @@ Sk.builtin.hash = function hash (value) {
 
 Sk.builtin.getattr = function getattr (obj, name, default_) {
     var ret, mangledName;
-    Sk.builtin.pyCheckArgs("getattr", arguments, 2, 3);
+    Sk.builtin.pyCheckArgsLen("getattr", arguments.length, 2, 3);
     if (!Sk.builtin.checkString(name)) {
         throw new Sk.builtin.TypeError("attribute name must be string");
     }
@@ -839,7 +839,7 @@ Sk.builtin.getattr = function getattr (obj, name, default_) {
 };
 
 Sk.builtin.setattr = function setattr (obj, name, value) {
-    Sk.builtin.pyCheckArgs("setattr", arguments, 3, 3);
+    Sk.builtin.pyCheckArgsLen("setattr", arguments.length, 3, 3);
     // cannot set or del attr from builtin type
     if (obj === undefined || obj["$r"] === undefined || obj["$r"]().v.slice(1,5) !== "type") {
         if (!Sk.builtin.checkString(name)) {
@@ -905,7 +905,7 @@ Sk.builtin.map = function map (fun, seq) {
     var i;
     var iterables;
     var combined;
-    Sk.builtin.pyCheckArgs("map", arguments, 2);
+    Sk.builtin.pyCheckArgsLen("map", arguments.length, 2);
 
     if (arguments.length > 2) {
         // Pack sequences into one list of Javascript Arrays
@@ -975,7 +975,7 @@ Sk.builtin.reduce = function reduce (fun, seq, initializer) {
     var item;
     var accum_value;
     var iter;
-    Sk.builtin.pyCheckArgs("reduce", arguments, 2, 3);
+    Sk.builtin.pyCheckArgsLen("reduce", arguments.length, 2, 3);
     if (!Sk.builtin.checkIterable(seq)) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(seq) + "' object is not iterable");
     }
@@ -1004,7 +1004,7 @@ Sk.builtin.filter = function filter (fun, iterable) {
     var ret;
     var add;
     var ctor;
-    Sk.builtin.pyCheckArgs("filter", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("filter", arguments.length, 2, 2);
 
     if (!Sk.builtin.checkIterable(iterable)) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(iterable) + "' object is not iterable");
@@ -1057,7 +1057,7 @@ Sk.builtin.filter = function filter (fun, iterable) {
 };
 
 Sk.builtin.hasattr = function hasattr (obj, attr) {
-    Sk.builtin.pyCheckArgs("hasattr", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("hasattr", arguments.length, 2, 2);
     var special, ret;
     if (!Sk.builtin.checkString(attr)) {
         throw new Sk.builtin.TypeError("hasattr(): attribute name must be string");
@@ -1083,7 +1083,7 @@ Sk.builtin.pow = function pow (a, b, c) {
     var c_num;
     var b_num;
     var a_num;
-    Sk.builtin.pyCheckArgs("pow", arguments, 2, 3);
+    Sk.builtin.pyCheckArgsLen("pow", arguments.length, 2, 3);
 
     if (c instanceof Sk.builtin.none) {
         c = undefined;
@@ -1157,7 +1157,7 @@ Sk.builtin.quit = function quit (msg) {
 Sk.builtin.issubclass = function issubclass (c1, c2) {
     var i;
     var issubclass_internal;
-    Sk.builtin.pyCheckArgs("issubclass", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("issubclass", arguments.length, 2, 2);
     if (!Sk.builtin.checkClass(c1)) {
         throw new Sk.builtin.TypeError("issubclass() arg 1 must be a class");
     }
@@ -1234,7 +1234,7 @@ Sk.builtin.divmod = function divmod (a, b) {
  * built-in types: Format Specification Mini-Language.
  */
 Sk.builtin.format = function format (value, format_spec) {
-    Sk.builtin.pyCheckArgs("format", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("format", arguments.length, 1, 2);
 
     if (format_spec === undefined) {
         format_spec = Sk.builtin.str.$emptystr;
@@ -1244,7 +1244,7 @@ Sk.builtin.format = function format (value, format_spec) {
 };
 
 Sk.builtin.reversed = function reversed (seq) {
-    Sk.builtin.pyCheckArgs("reversed", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("reversed", arguments.length, 1, 1);
 
     var special = Sk.abstr.lookupSpecial(seq, "__reversed__");
     if (special != null) {
@@ -1292,7 +1292,7 @@ Sk.builtin.reversed = function reversed (seq) {
 };
 
 Sk.builtin.id = function (obj) {
-    Sk.builtin.pyCheckArgs("id", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("id", arguments.length, 1, 1);
 
     if (obj.__id === undefined) {
         Sk.builtin.idCount += 1;
@@ -1308,7 +1308,7 @@ Sk.builtin.bytearray = function bytearray () {
 
 Sk.builtin.callable = function callable (obj) {
     // check num of args
-    Sk.builtin.pyCheckArgs("callable", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("callable", arguments.length, 1, 1);
 
     if (Sk.builtin.checkCallable(obj)) {
         return Sk.builtin.bool.true$;
@@ -1317,7 +1317,7 @@ Sk.builtin.callable = function callable (obj) {
 };
 
 Sk.builtin.delattr = function delattr (obj, attr) {
-    Sk.builtin.pyCheckArgs("delattr", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("delattr", arguments.length, 2, 2);
     if (obj["$d"][attr.v] !== undefined) {
         var ret = Sk.misceval.tryCatch(function() {
             var try1 = Sk.builtin.setattr(obj, attr, undefined);
@@ -1360,7 +1360,7 @@ Sk.builtin.help = function help () {
 };
 
 Sk.builtin.iter = function iter (obj, sentinel) {
-    Sk.builtin.pyCheckArgs("iter", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("iter", arguments.length, 1, 2);
     if (arguments.length === 1) {
         if (!Sk.builtin.checkIterable(obj)) {
             throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(obj) +
@@ -1386,7 +1386,7 @@ Sk.builtin.memoryview = function memoryview () {
 
 Sk.builtin.next_ = function next_ (iter, default_) {
     var nxt;
-    Sk.builtin.pyCheckArgs("next", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("next", arguments.length, 1, 2);
     if (!iter.tp$iternext) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(iter) +
             "' object is not an iterator");

--- a/src/compile.js
+++ b/src/compile.js
@@ -1760,8 +1760,8 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         minargs = args ? args.args.length - defaults.length : 0;
         maxargs = vararg ? Infinity : (args ? args.args.length : 0);
         kw = kwarg ? true : false;
-        this.u.varDeclsCode += "Sk.builtin.pyCheckArgs(\"" + coname.v +
-            "\", arguments, " + minargs + ", " + maxargs + ", " + kw +
+        this.u.varDeclsCode += "Sk.builtin.pyCheckArgsLen(\"" + coname.v +
+            "\", arguments.length, " + minargs + ", " + maxargs + ", " + kw +
             ", " + hasFree + ");";
     }
 
@@ -1888,13 +1888,13 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     // The call to pyCheckArgs assumes they can't be true.
     {
         if (args && args.args.length > 0) {
-            return this._gr("gener", "new Sk.builtins['function']((function(){var $origargs=Array.prototype.slice.call(arguments);Sk.builtin.pyCheckArgs(\"",
-                coname.v, "\",arguments,", args.args.length - defaults.length, ",", args.args.length,
+            return this._gr("gener", "new Sk.builtins['function']((function(){var $origargs=Array.prototype.slice.call(arguments);Sk.builtin.pyCheckArgsLen(\"",
+                coname.v, "\",arguments.length,", args.args.length - defaults.length, ",", args.args.length,
                 ");return new Sk.builtins['generator'](", scopename, ",$gbl,$origargs", frees, ");}))");
         }
         else {
-            return this._gr("gener", "new Sk.builtins['function']((function(){Sk.builtin.pyCheckArgs(\"", coname.v,
-                "\",arguments,0,0);return new Sk.builtins['generator'](", scopename, ",$gbl,[]", frees, ");}))");
+            return this._gr("gener", "new Sk.builtins['function']((function(){Sk.builtin.pyCheckArgsLen(\"", coname.v,
+                "\",arguments.length,0,0);return new Sk.builtins['generator'](", scopename, ",$gbl,[]", frees, ");}))");
         }
     }
     else {

--- a/src/complex.js
+++ b/src/complex.js
@@ -27,7 +27,7 @@ Math.hypot = Math.hypot || function() {
  * 
  */
 Sk.builtin.complex = function (real, imag) {
-    Sk.builtin.pyCheckArgs("complex", arguments, 0, 2);
+    Sk.builtin.pyCheckArgsLen("complex", arguments.length, 0, 2);
 
     var r, i, tmp; // PyObject
     var nbr, nbi; // real, imag as numbers
@@ -962,14 +962,14 @@ Sk.builtin.complex.prototype.int$bool.co_name = new Sk.builtin.str("__bool__");
 Sk.builtin.complex.prototype.__bool__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$bool); 
 
 Sk.builtin.complex.prototype.int$truediv = function __truediv__(self, other){
-    Sk.builtin.pyCheckArgs("__truediv__", arguments, 1, 1, true);
+    Sk.builtin.pyCheckArgsLen("__truediv__", arguments.length, 1, 1, true);
     return self.nb$divide.call(self, other);
 };
 Sk.builtin.complex.prototype.int$truediv.co_name = new Sk.builtin.str("__truediv__");
 Sk.builtin.complex.prototype.__truediv__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$truediv); 
 
 Sk.builtin.complex.prototype.int$hash = function __hash__(self){
-    Sk.builtin.pyCheckArgs("__hash__", arguments, 0, 0, true);
+    Sk.builtin.pyCheckArgsLen("__hash__", arguments.length, 0, 0, true);
 
     return self.tp$hash.call(self);
 };
@@ -977,7 +977,7 @@ Sk.builtin.complex.prototype.int$hash.co_name = new Sk.builtin.str("__hash__");
 Sk.builtin.complex.prototype.__hash__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$hash); 
 
 Sk.builtin.complex.prototype.int$add = function __add__(self, other){
-    Sk.builtin.pyCheckArgs("__add__", arguments, 1, 1, true);
+    Sk.builtin.pyCheckArgsLen("__add__", arguments.length, 1, 1, true);
     return self.nb$add.call(self, other);
 };
 Sk.builtin.complex.prototype.int$add.co_name = new Sk.builtin.str("__add__");
@@ -985,7 +985,7 @@ Sk.builtin.complex.prototype.__add__ = new Sk.builtin.func(Sk.builtin.complex.pr
 
 
 Sk.builtin.complex.prototype.int$repr = function __repr__(self){
-    Sk.builtin.pyCheckArgs("__repr__", arguments, 0, 0, true);
+    Sk.builtin.pyCheckArgsLen("__repr__", arguments.length, 0, 0, true);
 
     return self["r$"].call(self);
 };
@@ -993,7 +993,7 @@ Sk.builtin.complex.prototype.int$repr.co_name = new Sk.builtin.str("__repr__");
 Sk.builtin.complex.prototype.__repr__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$repr); 
 
 Sk.builtin.complex.prototype.int$str = function __str__(self){
-    Sk.builtin.pyCheckArgs("__str__", arguments, 0, 0, true);
+    Sk.builtin.pyCheckArgsLen("__str__", arguments.length, 0, 0, true);
 
     return self.tp$str.call(self);
 };
@@ -1001,62 +1001,62 @@ Sk.builtin.complex.prototype.int$str.co_name = new Sk.builtin.str("__str__");
 Sk.builtin.complex.prototype.__str__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$str); 
 
 Sk.builtin.complex.prototype.int$sub = function __sub__(self, other){
-    Sk.builtin.pyCheckArgs("__sub__", arguments, 1, 1, true);
+    Sk.builtin.pyCheckArgsLen("__sub__", arguments.length, 1, 1, true);
     return self.nb$subtract.call(self, other);
 };
 Sk.builtin.complex.prototype.int$sub.co_name = new Sk.builtin.str("__sub__");
 Sk.builtin.complex.prototype.__sub__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$sub); 
 
 Sk.builtin.complex.prototype.int$mul = function __mul__(self, other){
-    Sk.builtin.pyCheckArgs("__mul__", arguments, 1, 1, true);
+    Sk.builtin.pyCheckArgsLen("__mul__", arguments.length, 1, 1, true);
     return self.nb$multiply.call(self, other);
 };
 Sk.builtin.complex.prototype.int$mul.co_name = new Sk.builtin.str("__mul__");
 Sk.builtin.complex.prototype.__mul__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$mul); 
 
 Sk.builtin.complex.prototype.int$div = function __div__(self, other){
-    Sk.builtin.pyCheckArgs("__div__", arguments, 1, 1, true);
+    Sk.builtin.pyCheckArgsLen("__div__", arguments.length, 1, 1, true);
     return self.nb$divide.call(self, other);
 };
 Sk.builtin.complex.prototype.int$div.co_name = new Sk.builtin.str("__div__");
 Sk.builtin.complex.prototype.__div__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$div); 
 
 Sk.builtin.complex.prototype.int$floordiv = function __floordiv__(self, other){
-    Sk.builtin.pyCheckArgs("__floordiv__", arguments, 1, 1, true);
+    Sk.builtin.pyCheckArgsLen("__floordiv__", arguments.length, 1, 1, true);
     return self.nb$floor_divide.call(self, other);
 };
 Sk.builtin.complex.prototype.int$floordiv.co_name = new Sk.builtin.str("__floordiv__");
 Sk.builtin.complex.prototype.__floordiv__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$floordiv); 
 
 Sk.builtin.complex.prototype.int$mod = function __mod__(self, other){
-    Sk.builtin.pyCheckArgs("__mod__", arguments, 1, 1, true);
+    Sk.builtin.pyCheckArgsLen("__mod__", arguments.length, 1, 1, true);
     return self.nb$remainder.call(self, other);
 };
 Sk.builtin.complex.prototype.int$mod.co_name = new Sk.builtin.str("__mod__");
 Sk.builtin.complex.prototype.__mod__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$mod); 
 
 Sk.builtin.complex.prototype.int$pow = function __pow__(self, other, z){
-    Sk.builtin.pyCheckArgs("__pow__", arguments, 1, 2, true);
+    Sk.builtin.pyCheckArgsLen("__pow__", arguments.length, 1, 2, true);
     return self.nb$power.call(self, other, z);
 };
 Sk.builtin.complex.prototype.int$pow.co_name = new Sk.builtin.str("__pow__");
 Sk.builtin.complex.prototype.__pow__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$pow); 
 
 Sk.builtin.complex.prototype.int$neg = function __neg__(self){
-    Sk.builtin.pyCheckArgs("__neg__", arguments, 0, 0, true);
+    Sk.builtin.pyCheckArgsLen("__neg__", arguments.length, 0, 0, true);
     return self.nb$negative.call(self);
 };
 Sk.builtin.complex.prototype.__neg__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$neg); 
 
 Sk.builtin.complex.prototype.int$pos = function __pos__(self){
-    Sk.builtin.pyCheckArgs("__pos__", arguments, 0, 0, true);
+    Sk.builtin.pyCheckArgsLen("__pos__", arguments.length, 0, 0, true);
     return self.nb$positive.call(self);
 };
 Sk.builtin.complex.prototype.int$pos.co_name = new Sk.builtin.str("__pos__");
 Sk.builtin.complex.prototype.__pos__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$pos); 
 
 Sk.builtin.complex.prototype.int$conjugate = function conjugate(self){
-    Sk.builtin.pyCheckArgs("conjugate", arguments, 0, 0, true);
+    Sk.builtin.pyCheckArgsLen("conjugate", arguments.length, 0, 0, true);
     var _imag = self.imag.v;
     _imag = -_imag;
 
@@ -1067,7 +1067,7 @@ Sk.builtin.complex.prototype.conjugate = new Sk.builtin.func(Sk.builtin.complex.
 
 // deprecated
 Sk.builtin.complex.prototype.int$divmod = function __divmod__(self, other){
-    Sk.builtin.pyCheckArgs("__divmod__", arguments, 1, 1, true);
+    Sk.builtin.pyCheckArgsLen("__divmod__", arguments.length, 1, 1, true);
 
     var div, mod; // Py_complex
     var d, m, z; // PyObject
@@ -1090,7 +1090,7 @@ Sk.builtin.complex.prototype.int$divmod.co_name = new Sk.builtin.str("__divmod__
 Sk.builtin.complex.prototype.__divmod__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$divmod); 
 
 Sk.builtin.complex.prototype.int$getnewargs = function __getnewargs__(self){
-    Sk.builtin.pyCheckArgs("__getnewargs__", arguments, 0, 0, true);
+    Sk.builtin.pyCheckArgsLen("__getnewargs__", arguments.length, 0, 0, true);
 
     return new Sk.builtin.tuple([self.real, self.imag]);
 };
@@ -1098,7 +1098,7 @@ Sk.builtin.complex.prototype.int$getnewargs.co_name = new Sk.builtin.str("__getn
 Sk.builtin.complex.prototype.__getnewargs__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$getnewargs); 
 
 Sk.builtin.complex.prototype.int$nonzero = function __nonzero__(self){
-    Sk.builtin.pyCheckArgs("__nonzero__", arguments, 0, 0, true);
+    Sk.builtin.pyCheckArgsLen("__nonzero__", arguments.length, 0, 0, true);
 
     if(self.real.v !== 0.0 || self.imag.v !== 0.0) {
         return Sk.builtin.bool.true$;

--- a/src/dict.js
+++ b/src/dict.js
@@ -56,7 +56,7 @@ Sk.builtin.dict = function dict (L) {
 
 Sk.builtin.dict.tp$call = function(args, kw) {
     var d, i;
-    Sk.builtin.pyCheckArgs("dict", args, 0, 1);
+    Sk.builtin.pyCheckArgsLen("dict", args, 0, 1);
     d = new Sk.builtin.dict(args[0]);
     if (kw) {
         for (i = 0; i < kw.length; i += 2) {
@@ -124,7 +124,7 @@ Sk.builtin.dict.prototype.mp$lookup = function (key) {
 };
 
 Sk.builtin.dict.prototype.mp$subscript = function (key) {
-    Sk.builtin.pyCheckArgs("[]", arguments, 1, 2, false, false);
+    Sk.builtin.pyCheckArgsLen("[]", arguments.length, 1, 2, false, false);
     var s;
     var res = this.mp$lookup(key);
 
@@ -171,7 +171,7 @@ Sk.builtin.dict.prototype.mp$ass_subscript = function (key, w) {
 };
 
 Sk.builtin.dict.prototype.mp$del_subscript = function (key) {
-    Sk.builtin.pyCheckArgs("del", arguments, 1, 1, false, false);
+    Sk.builtin.pyCheckArgsLen("del", arguments.length, 1, 1, false, false);
     var k = kf(key);
     var bucket = this.buckets[k.v];
     var item;
@@ -220,7 +220,7 @@ Sk.builtin.dict.prototype.mp$length = function () {
 };
 
 Sk.builtin.dict.prototype["get"] = new Sk.builtin.func(function (self, k, d) {
-    Sk.builtin.pyCheckArgs("get()", arguments, 1, 2, false, true);
+    Sk.builtin.pyCheckArgsLen("get()", arguments.length, 1, 2, false, true);
     var ret;
 
     if (d === undefined) {
@@ -236,7 +236,7 @@ Sk.builtin.dict.prototype["get"] = new Sk.builtin.func(function (self, k, d) {
 });
 
 Sk.builtin.dict.prototype["pop"] = new Sk.builtin.func(function (self, key, d) {
-    Sk.builtin.pyCheckArgs("pop()", arguments, 1, 2, false, true);
+    Sk.builtin.pyCheckArgsLen("pop()", arguments.length, 1, 2, false, true);
     var k = kf(key);
     var bucket = self.buckets[k.v];
     var item;
@@ -260,12 +260,12 @@ Sk.builtin.dict.prototype["pop"] = new Sk.builtin.func(function (self, key, d) {
 });
 
 Sk.builtin.dict.prototype["has_key"] = new Sk.builtin.func(function (self, k) {
-    Sk.builtin.pyCheckArgs("has_key()", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("has_key()", arguments.length, 1, 1, false, true);
     return new Sk.builtin.bool( self.sq$contains(k));
 });
 
 Sk.builtin.dict.prototype["items"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("items()", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("items()", arguments.length, 0, 0, false, true);
     var v;
     var iter, k;
     var ret = [];
@@ -284,7 +284,7 @@ Sk.builtin.dict.prototype["items"] = new Sk.builtin.func(function (self) {
 });
 
 Sk.builtin.dict.prototype["keys"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("keys()", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("keys()", arguments.length, 0, 0, false, true);
     var iter, k;
     var ret = [];
 
@@ -297,7 +297,7 @@ Sk.builtin.dict.prototype["keys"] = new Sk.builtin.func(function (self) {
 });
 
 Sk.builtin.dict.prototype["values"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("values()", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("values()", arguments.length, 0, 0, false, true);
     var v;
     var iter, k;
     var ret = [];
@@ -315,7 +315,7 @@ Sk.builtin.dict.prototype["values"] = new Sk.builtin.func(function (self) {
 });
 
 Sk.builtin.dict.prototype["clear"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("clear()", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("clear()", arguments.length, 0, 0, false, true);
     var k;
     var iter;
 
@@ -418,7 +418,7 @@ update_f.co_kwargs = true;
 Sk.builtin.dict.prototype.update = new Sk.builtin.func(update_f);
 
 Sk.builtin.dict.prototype.__contains__ = new Sk.builtin.func(function (self, item) {
-    Sk.builtin.pyCheckArgs("__contains__", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("__contains__", arguments.length, 2, 2);
     return new Sk.builtin.bool(self.sq$contains(item));
 });
 
@@ -428,38 +428,38 @@ Sk.builtin.dict.prototype.__cmp__ = new Sk.builtin.func(function (self, other, o
 });
 
 Sk.builtin.dict.prototype.__delitem__ = new Sk.builtin.func(function (self, item) {
-    Sk.builtin.pyCheckArgs("__delitem__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__delitem__", arguments.length, 1, 1, false, true);
     return Sk.builtin.dict.prototype.mp$del_subscript.call(self, item);
 });
 
 Sk.builtin.dict.prototype.__getitem__ = new Sk.builtin.func(function (self, item) {
-    Sk.builtin.pyCheckArgs("__getitem__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__getitem__", arguments.length, 1, 1, false, true);
     return Sk.builtin.dict.prototype.mp$subscript.call(self, item);
 });
 
 Sk.builtin.dict.prototype.__setitem__ = new Sk.builtin.func(function (self, item, value) {
-    Sk.builtin.pyCheckArgs("__setitem__", arguments, 2, 2, false, true);
+    Sk.builtin.pyCheckArgsLen("__setitem__", arguments.length, 2, 2, false, true);
     return Sk.builtin.dict.prototype.mp$ass_subscript.call(self, item, value);
 });
 
 Sk.builtin.dict.prototype.__hash__ = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__hash__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__hash__", arguments.length, 0, 0, false, true);
     return Sk.builtin.dict.prototype.tp$hash.call(self);
 });
 
 Sk.builtin.dict.prototype.__len__ = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__len__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__len__", arguments.length, 0, 0, false, true);
     return Sk.builtin.dict.prototype.mp$length.call(self);
 });
 
 Sk.builtin.dict.prototype.__getattribute__ = new Sk.builtin.func(function (self, attr) {
-    Sk.builtin.pyCheckArgs("__getattribute__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__getattribute__", arguments.length, 1, 1, false, true);
     if (!Sk.builtin.checkString(attr)) { throw new Sk.builtin.TypeError("__getattribute__ requires a string"); }
     return Sk.builtin.dict.prototype.tp$getattr.call(self, Sk.ffi.remapToJs(attr));
 });
 
 Sk.builtin.dict.prototype.__iter__ = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 0, 0, false, true);
 
     return new Sk.builtin.dict_iter_(self);
 });
@@ -469,7 +469,7 @@ Sk.builtin.dict.prototype.tp$iter = function () {
 };
 
 Sk.builtin.dict.prototype.__repr__ = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__repr__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__repr__", arguments.length, 0, 0, false, true);
     return Sk.builtin.dict.prototype["$r"].call(self);
 });
 
@@ -519,7 +519,7 @@ Sk.builtin.dict.prototype.ob$ne = function (other) {
 };
 
 Sk.builtin.dict.prototype["copy"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("copy", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("copy", arguments.length, 0, 0, false, true);
 
     var it; // Iterator
     var k; // Key of dict item
@@ -544,14 +544,14 @@ Sk.builtin.dict.$fromkeys = function fromkeys(self, seq, value) {
 
     if (self instanceof Sk.builtin.dict) {
         // instance call
-        Sk.builtin.pyCheckArgs("fromkeys", arguments, 1, 2, false, true);
+        Sk.builtin.pyCheckArgsLen("fromkeys", arguments.length, 1, 2, false, true);
 
         res = self;
         iterable = seq;
         val = value === undefined ? Sk.builtin.none.none$ : value;
     } else {
         // static call
-        Sk.builtin.pyCheckArgs("fromkeys", arguments, 1, 2, false, false);
+        Sk.builtin.pyCheckArgsLen("fromkeys", arguments.length, 1, 2, false, false);
 
         res = new Sk.builtin.dict([]);
         iterable = self;

--- a/src/enumerate.js
+++ b/src/enumerate.js
@@ -11,7 +11,7 @@ Sk.builtin.enumerate = function (iterable, start) {
     }
 
 
-    Sk.builtin.pyCheckArgs("enumerate", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("enumerate", arguments.length, 1, 2);
     if (!Sk.builtin.checkIterable(iterable)) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(iterable) + "' object is not iterable");
     }

--- a/src/float.js
+++ b/src/float.js
@@ -771,7 +771,7 @@ Sk.builtin.float_.prototype.ob$ge = function (other) {
  * @return {Sk.builtin.float_|Sk.builtin.int_} The rounded float.
  */
 Sk.builtin.float_.prototype.round$ = function (self, ndigits) {
-    Sk.builtin.pyCheckArgs("__round__", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("__round__", arguments.length, 1, 2);
 
     var result, multiplier, number, num10, rounded, bankRound, ndigs;
 
@@ -806,7 +806,7 @@ Sk.builtin.float_.prototype.round$ = function (self, ndigits) {
 
 Sk.builtin.float_.prototype.__format__= function (obj, format_spec) {
     var formatstr;
-    Sk.builtin.pyCheckArgs("__format__", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
 
     if (!Sk.builtin.checkString(format_spec)) {
         if (Sk.__future__.exceptions) {

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -8,7 +8,7 @@ var format = function (kwa) {
     var replFunc;
     var arg_dict = {};
 
-    Sk.builtin.pyCheckArgs("format", arguments, 0, Infinity, true, true);
+    Sk.builtin.pyCheckArgsLen("format", arguments.length, 0, Infinity, true, true);
 
 
     args = new Sk.builtins["tuple"](Array.prototype.slice.call(arguments, 1)); /*vararg*/

--- a/src/function.js
+++ b/src/function.js
@@ -45,6 +45,45 @@ Sk.builtin.pyCheckArgs = function (name, args, minargs, maxargs, kwargs, free) {
 goog.exportSymbol("Sk.builtin.pyCheckArgs", Sk.builtin.pyCheckArgs);
 
 /**
+ * Check arguments to Python functions to ensure the correct number of
+ * arguments are passed.
+ *
+ * @param {string} name the name of the function
+ * @param {number} nargs the args passed to the function
+ * @param {number} minargs the minimum number of allowable arguments
+ * @param {number=} maxargs optional maximum number of allowable
+ * arguments (default: Infinity)
+ * @param {boolean=} kwargs optional true if kwargs, false otherwise
+ * (default: false)
+ * @param {boolean=} free optional true if free vars, false otherwise
+ * (default: false)
+ */
+Sk.builtin.pyCheckArgsLen = function (name, nargs, minargs, maxargs, kwargs, free) {
+    var msg = "";
+
+    if (maxargs === undefined) {
+        maxargs = Infinity;
+    }
+    if (kwargs) {
+        nargs -= 1;
+    }
+    if (free) {
+        nargs -= 1;
+    }
+    if ((nargs < minargs) || (nargs > maxargs)) {
+        if (minargs === maxargs) {
+            msg = name + "() takes exactly " + minargs + " arguments";
+        } else if (nargs < minargs) {
+            msg = name + "() takes at least " + minargs + " arguments";
+        } else {
+            msg = name + "() takes at most " + maxargs + " arguments";
+        }
+        msg += " (" + nargs + " given)";
+        throw new Sk.builtin.TypeError(msg);
+    }
+};
+
+/**
  * Check type of argument to Python functions.
  *
  * @param {string} name the name of the argument
@@ -238,7 +277,7 @@ Sk.builtin.func.prototype.tp$descr_get = function (obj, objtype) {
 Sk.builtin.func.pythonFunctions = ["__get__"];
 
 Sk.builtin.func.prototype.__get__ = function __get__(self, instance, owner) {
-    Sk.builtin.pyCheckArgs("__get__", arguments, 1, 2, false, true);
+    Sk.builtin.pyCheckArgsLen("__get__", arguments.length, 1, 2, false, true);
     if (instance === Sk.builtin.none.none$ && owner === Sk.builtin.none.none$) {
         throw new Sk.builtin.TypeError("__get__(None, None) is invalid");
     }

--- a/src/int.js
+++ b/src/int.js
@@ -970,7 +970,7 @@ Sk.builtin.int_.prototype.ob$ge = function (other) {
  * @return {Sk.builtin.int_} The rounded integer.
  */
 Sk.builtin.int_.prototype.round$ = function (self, ndigits) {
-    Sk.builtin.pyCheckArgs("__round__", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("__round__", arguments.length, 1, 2);
 
     var result, multiplier, number, num10, rounded, bankRound, ndigs;
 
@@ -1001,7 +1001,7 @@ Sk.builtin.int_.prototype.round$ = function (self, ndigits) {
 
 Sk.builtin.int_.prototype.__format__= function (obj, format_spec) {
     var formatstr;
-    Sk.builtin.pyCheckArgs("__format__", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
 
     if (!Sk.builtin.checkString(format_spec)) {
         if (Sk.__future__.exceptions) {

--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -80,7 +80,7 @@ $builtinmodule = function (name) {
 
     var array = function ($gbl, $loc) {
         $loc.__init__ = new Sk.builtin.func(function (self, typecode, initialiser) {
-            Sk.builtin.pyCheckArgs("__init__", arguments, 2, 3);
+            Sk.builtin.pyCheckArgsLen("__init__", arguments.length, 2, 3);
 
             if (typecodes.indexOf(Sk.ffi.remapToJs(typecode)) == -1) {
                 throw new Sk.builtin.ValueError("bad typecode (must be c, b, B, u, h, H, i, I, l, L, f or d)")
@@ -137,7 +137,7 @@ $builtinmodule = function (name) {
         });
 
         $loc.extend = new Sk.builtin.func(function(self, iterable) {
-            Sk.builtin.pyCheckArgs("__init__", arguments, 2, 2);
+            Sk.builtin.pyCheckArgsLen("__init__", arguments.length, 2, 2);
 
             if (!Sk.builtin.checkIterable(iterable)) {
                 throw new Sk.builtin.TypeError("iteration over non-sequence");

--- a/src/lib/collections.js
+++ b/src/lib/collections.js
@@ -40,7 +40,7 @@ var $builtinmodule = function (name) {
         };
 
         mod.defaultdict.prototype['__missing__'] = function (key) {
-            Sk.builtin.pyCheckArgs('__missing__', arguments, 0, 1);
+            Sk.builtin.pyCheckArgsLen('__missing__', arguments.length, 0, 1);
             if (key) {
                 throw new Sk.builtin.KeyError(Sk.misceval.objectRepr(key));
             }
@@ -114,7 +114,7 @@ var $builtinmodule = function (name) {
         };
 
         mod.Counter.prototype['elements'] = new Sk.builtin.func(function (self) {
-            Sk.builtin.pyCheckArgs('elements', arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen('elements', arguments.length, 1, 1);
             var all_elements = [];
             for (var iter = self.tp$iter(), k = iter.tp$iternext();
                 k !== undefined;
@@ -145,7 +145,7 @@ var $builtinmodule = function (name) {
         });
 
         mod.Counter.prototype['most_common'] = new Sk.builtin.func(function (self, n) {
-            Sk.builtin.pyCheckArgs('most_common', arguments, 1, 2);
+            Sk.builtin.pyCheckArgsLen('most_common', arguments.length, 1, 2);
             var length = self.mp$length();
 
             if (n === undefined) {
@@ -193,7 +193,7 @@ var $builtinmodule = function (name) {
         });
 
         mod.Counter.prototype['update'] = new Sk.builtin.func(function (self, other) {
-            Sk.builtin.pyCheckArgs('update', arguments, 1, 2);
+            Sk.builtin.pyCheckArgsLen('update', arguments.length, 1, 2);
 
             if (other instanceof Sk.builtin.dict) {
                 for (var iter = other.tp$iter(), k = iter.tp$iternext();
@@ -219,7 +219,7 @@ var $builtinmodule = function (name) {
         });
 
         mod.Counter.prototype['subtract'] = new Sk.builtin.func(function (self, other) {
-            Sk.builtin.pyCheckArgs('subtract', arguments, 1, 2);
+            Sk.builtin.pyCheckArgsLen('subtract', arguments.length, 1, 2);
 
             if (other instanceof Sk.builtin.dict) {
                 for (var iter = other.tp$iter(), k = iter.tp$iternext();
@@ -309,7 +309,7 @@ var $builtinmodule = function (name) {
         }
 
         mod.OrderedDict.prototype.__iter__ = new Sk.builtin.func(function (self) {
-            Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, false, true);
+            Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 0, 0, false, true);
 
             return mod.OrderedDict.prototype.tp$iter.call(self);
         });
@@ -418,7 +418,7 @@ var $builtinmodule = function (name) {
             var s;
             var idx;
 
-            Sk.builtin.pyCheckArgs('pop', arguments, 2, 3);
+            Sk.builtin.pyCheckArgsLen('pop', arguments.length, 2, 3);
 
             idx = self.orderedkeys.indexOf(key);
             if (idx != -1)
@@ -433,7 +433,7 @@ var $builtinmodule = function (name) {
             var key, val;
             var s;
 
-            Sk.builtin.pyCheckArgs('popitem', arguments, 1, 2);
+            Sk.builtin.pyCheckArgsLen('popitem', arguments.length, 1, 2);
 
             // Empty dictionary
             if (self.orderedkeys.length == 0)

--- a/src/lib/image.js
+++ b/src/lib/image.js
@@ -36,7 +36,7 @@ $builtinmodule = function (name) {
 
         $loc.__init__ = new Sk.builtin.func(function (self, imageId) {
             var susp;
-            Sk.builtin.pyCheckArgs("__init__", arguments, 2, 2);
+            Sk.builtin.pyCheckArgsLen("__init__", arguments.length, 2, 2);
             try {
                 self.image = document.getElementById(Sk.ffi.remapToJs(imageId));
                 initializeImage(self);
@@ -107,7 +107,7 @@ $builtinmodule = function (name) {
 
         var setdelay = function (self, delay, interval) {
             var i;
-            Sk.builtin.pyCheckArgs("setdelay", arguments, 2, 3);
+            Sk.builtin.pyCheckArgsLen("setdelay", arguments.length, 2, 3);
             self.delay = Sk.ffi.remapToJs(delay);
             i = Sk.builtin.asnum$(interval);
             if (!i) {
@@ -126,7 +126,7 @@ $builtinmodule = function (name) {
         var getpixels = function (self) {
             var arr = [];//initial array
             var i;
-            Sk.builtin.pyCheckArgs("getpixels", arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen("getpixels", arguments.length, 1, 1);
 
             for (i = 0; i < self.image.height * self.image.width; i++) {
                 arr[i] = Sk.misceval.callsim(self.getPixel, self,
@@ -148,7 +148,7 @@ $builtinmodule = function (name) {
             var green;
             var blue;
             var index;
-            Sk.builtin.pyCheckArgs("getData", arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen("getData", arguments.length, 1, 1);
 
             for (i = 0; i < self.image.height * self.image.width; i++) {
                 x = i % self.image.width;
@@ -169,7 +169,7 @@ $builtinmodule = function (name) {
             var blue;
             var green;
             var index;
-            Sk.builtin.pyCheckArgs("getpixel", arguments, 3, 3);
+            Sk.builtin.pyCheckArgsLen("getpixel", arguments.length, 3, 3);
             x = Sk.builtin.asnum$(x);
             y = Sk.builtin.asnum$(y);
             checkPixelRange(self, x, y);
@@ -225,7 +225,7 @@ $builtinmodule = function (name) {
 
         var setpixel = function (self, x, y, pix) {
             var index;
-            Sk.builtin.pyCheckArgs("setpixel", arguments, 4, 4);
+            Sk.builtin.pyCheckArgsLen("setpixel", arguments.length, 4, 4);
             x = Sk.builtin.asnum$(x);
             y = Sk.builtin.asnum$(y);
             checkPixelRange(self, x, y);
@@ -247,7 +247,7 @@ $builtinmodule = function (name) {
             var x;
             var y;
             var index;
-            Sk.builtin.pyCheckArgs("setpixelat", arguments, 3, 3);
+            Sk.builtin.pyCheckArgsLen("setpixelat", arguments.length, 3, 3);
             count = Sk.builtin.asnum$(count);
             x = count % self.image.width;
             y = Math.floor(count / self.image.width);
@@ -270,7 +270,7 @@ $builtinmodule = function (name) {
             var x;
             var y;
             var index;
-            Sk.builtin.pyCheckArgs("updatepixel", arguments, 2, 2);
+            Sk.builtin.pyCheckArgsLen("updatepixel", arguments.length, 2, 2);
             x = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getX, pixel));
             y = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getY, pixel));
             checkPixelRange(self, x, y);
@@ -288,7 +288,7 @@ $builtinmodule = function (name) {
 
 
         var getheight = function (self) {
-            Sk.builtin.pyCheckArgs("getheight", arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen("getheight", arguments.length, 1, 1);
             return new Sk.builtin.int_(self.height);
         };
 
@@ -298,7 +298,7 @@ $builtinmodule = function (name) {
 
 
         var getwidth = function (self, titlestring) {
-            Sk.builtin.pyCheckArgs("getwidth", arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen("getwidth", arguments.length, 1, 1);
             return new Sk.builtin.int_(self.width);
         };
 
@@ -329,7 +329,7 @@ $builtinmodule = function (name) {
 
         $loc.draw = new Sk.builtin.func(function (self, win, ulx, uly) {
             var susp;
-            Sk.builtin.pyCheckArgs("draw", arguments, 2, 4);
+            Sk.builtin.pyCheckArgsLen("draw", arguments.length, 2, 4);
             susp = new Sk.misceval.Suspension();
             susp.resume = function () {
                 return Sk.builtin.none.none$;
@@ -373,7 +373,7 @@ $builtinmodule = function (name) {
 
     eImage = function ($gbl, $loc) {
         $loc.__init__ = new Sk.builtin.func(function (self, width, height) {
-            Sk.builtin.pyCheckArgs("__init__", arguments, 3, 3);
+            Sk.builtin.pyCheckArgsLen("__init__", arguments.length, 3, 3);
             self.width = Sk.builtin.asnum$(width);
             self.height = Sk.builtin.asnum$(height);
             self.canvas = document.createElement("canvas");
@@ -392,7 +392,7 @@ $builtinmodule = function (name) {
 
     pixel = function ($gbl, $loc) {
         $loc.__init__ = new Sk.builtin.func(function (self, r, g, b, x, y) {
-            Sk.builtin.pyCheckArgs("__init__", arguments, 4, 6);
+            Sk.builtin.pyCheckArgsLen("__init__", arguments.length, 4, 6);
             self.red = Sk.builtin.asnum$(r);
             self.green = Sk.builtin.asnum$(g);
             self.blue = Sk.builtin.asnum$(b);
@@ -401,7 +401,7 @@ $builtinmodule = function (name) {
         });
 
         var getred = function (self) {
-            Sk.builtin.pyCheckArgs("getred", arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen("getred", arguments.length, 1, 1);
             return Sk.builtin.assk$(self.red);
         };
 
@@ -410,7 +410,7 @@ $builtinmodule = function (name) {
         $loc.getRed = new Sk.builtin.func(getred);
 
         var getgreen = function (self) {
-            Sk.builtin.pyCheckArgs("getgreen", arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen("getgreen", arguments.length, 1, 1);
             return Sk.builtin.assk$(self.green);
         };
 
@@ -419,7 +419,7 @@ $builtinmodule = function (name) {
         $loc.getGreen = new Sk.builtin.func(getgreen);
 
         var getblue = function (self) {
-            Sk.builtin.pyCheckArgs("getblue", arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen("getblue", arguments.length, 1, 1);
             return Sk.builtin.assk$(self.blue);
         };
 
@@ -428,7 +428,7 @@ $builtinmodule = function (name) {
         $loc.getBlue = new Sk.builtin.func(getblue);
 
         var getx = function (self) {
-            Sk.builtin.pyCheckArgs("getx", arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen("getx", arguments.length, 1, 1);
             return Sk.builtin.assk$(self.x);
         };
 
@@ -437,7 +437,7 @@ $builtinmodule = function (name) {
         $loc.getX = new Sk.builtin.func(getx);
 
         var gety = function (self) {
-            Sk.builtin.pyCheckArgs("gety", arguments, 1, 1);
+            Sk.builtin.pyCheckArgsLen("gety", arguments.length, 1, 1);
             return Sk.builtin.assk$(self.y);
         };
 
@@ -446,7 +446,7 @@ $builtinmodule = function (name) {
         $loc.getY = new Sk.builtin.func(gety);
 
         var setred = function (self, r) {
-            Sk.builtin.pyCheckArgs("setred", arguments, 2, 2);
+            Sk.builtin.pyCheckArgsLen("setred", arguments.length, 2, 2);
             self.red = Sk.builtin.asnum$(r);
         };
 
@@ -455,7 +455,7 @@ $builtinmodule = function (name) {
         $loc.setRed = new Sk.builtin.func(setred);
 
         var setgreen = function (self, g) {
-            Sk.builtin.pyCheckArgs("setgreen", arguments, 2, 2);
+            Sk.builtin.pyCheckArgsLen("setgreen", arguments.length, 2, 2);
             self.green = Sk.builtin.asnum$(g);
         };
 
@@ -464,7 +464,7 @@ $builtinmodule = function (name) {
         $loc.setGreen = new Sk.builtin.func(setgreen);
 
         var setblue = function (self, b) {
-            Sk.builtin.pyCheckArgs("setblue", arguments, 2, 2);
+            Sk.builtin.pyCheckArgsLen("setblue", arguments.length, 2, 2);
             self.blue = Sk.builtin.asnum$(b);
         };
 
@@ -495,7 +495,7 @@ $builtinmodule = function (name) {
 
 
         var setx = function (self, x) {
-            Sk.builtin.pyCheckArgs("setx", arguments, 2, 2);
+            Sk.builtin.pyCheckArgsLen("setx", arguments.length, 2, 2);
             self.x = Sk.builtin.asnum$(x);
         };
 
@@ -504,7 +504,7 @@ $builtinmodule = function (name) {
         $loc.setX = new Sk.builtin.func(setx);
 
         var sety = function (self, y) {
-            Sk.builtin.pyCheckArgs("sety", arguments, 2, 2);
+            Sk.builtin.pyCheckArgsLen("sety", arguments.length, 2, 2);
             self.y = Sk.builtin.asnum$(y);
         };
 
@@ -545,7 +545,7 @@ $builtinmodule = function (name) {
         $loc.__init__ = new Sk.builtin.func(function (self, width, height) {
             var currentCanvas;
             var tmpCan, tmpDiv;
-            Sk.builtin.pyCheckArgs("__init__", arguments, 1, 3);
+            Sk.builtin.pyCheckArgsLen("__init__", arguments.length, 1, 3);
             currentCanvas = ImageMod.canvasLib[Sk.canvas];
             if (currentCanvas === undefined) {
                 tmpCan = document.createElement("canvas");

--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -4,35 +4,35 @@ var $builtinmodule = function (name) {
     mod.e = new Sk.builtin.float_(Math.E);
 
     mod.fabs = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("fabs", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("fabs", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         return new Sk.builtin.float_(Math.abs(Sk.builtin.asnum$(x)));
     });
 
     mod.asin = new Sk.builtin.func(function (rad) {
-        Sk.builtin.pyCheckArgs("asin", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("asin", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.asin(Sk.builtin.asnum$(rad)));
     });
 
     mod.acos = new Sk.builtin.func(function (rad) {
-        Sk.builtin.pyCheckArgs("acos", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("acos", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.acos(Sk.builtin.asnum$(rad)));
     });
 
     mod.atan = new Sk.builtin.func(function (rad) {
-        Sk.builtin.pyCheckArgs("atan", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("atan", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.atan(Sk.builtin.asnum$(rad)));
     });
 
     mod.atan2 = new Sk.builtin.func(function (y, x) {
-        Sk.builtin.pyCheckArgs("atan2", arguments, 2, 2);
+        Sk.builtin.pyCheckArgsLen("atan2", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("y", "number", Sk.builtin.checkNumber(y));
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
@@ -40,28 +40,28 @@ var $builtinmodule = function (name) {
     });
 
     mod.sin = new Sk.builtin.func(function (rad) {
-        Sk.builtin.pyCheckArgs("sin", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("sin", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.sin(Sk.builtin.asnum$(rad)));
     });
 
     mod.cos = new Sk.builtin.func(function (rad) {
-        Sk.builtin.pyCheckArgs("cos", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("cos", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.cos(Sk.builtin.asnum$(rad)));
     });
 
     mod.tan = new Sk.builtin.func(function (rad) {
-        Sk.builtin.pyCheckArgs("tan", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("tan", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.tan(Sk.builtin.asnum$(rad)));
     });
 
     mod.asinh = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("asinh", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("asinh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Sk.builtin.asnum$(x);
@@ -72,7 +72,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.acosh = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("acosh", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("acosh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Sk.builtin.asnum$(x);
@@ -83,7 +83,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.atanh = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("atanh", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("atanh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Sk.builtin.asnum$(x);
@@ -94,7 +94,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.sinh = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("sinh", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("sinh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Sk.builtin.asnum$(x);
@@ -108,7 +108,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.cosh = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("cosh", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("cosh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Sk.builtin.asnum$(x);
@@ -122,7 +122,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.tanh = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("tanh", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("tanh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Sk.builtin.asnum$(x);
@@ -136,7 +136,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.ceil = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("ceil", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("ceil", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         if (Sk.__future__.ceil_floor_int) {
@@ -148,7 +148,7 @@ var $builtinmodule = function (name) {
 
     // returns y with the sign of x
     mod.copysign = new Sk.builtin.func(function (x, y) {
-        Sk.builtin.pyCheckArgs("ceil", arguments, 2, 2);
+        Sk.builtin.pyCheckArgsLen("ceil", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         Sk.builtin.pyCheckType("y", "number", Sk.builtin.checkNumber(y));
 
@@ -189,7 +189,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.floor = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("floor", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("floor", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         if (Sk.__future__.ceil_floor_int) {
@@ -200,21 +200,21 @@ var $builtinmodule = function (name) {
     });
 
     mod.sqrt = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("sqrt", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("sqrt", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         return new Sk.builtin.float_(Math.sqrt(Sk.builtin.asnum$(x)));
     });
 
     mod.trunc = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("trunc", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("trunc", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         return new Sk.builtin.int_(Sk.builtin.asnum$(x) | 0);
     });
 
     mod.log = new Sk.builtin.func(function (x, base) {
-        Sk.builtin.pyCheckArgs("log", arguments, 1, 2);
+        Sk.builtin.pyCheckArgsLen("log", arguments.length, 1, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         if (base === undefined) {
@@ -227,7 +227,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.log10 = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("log10", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("log10", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         var ret = Math.log(Sk.builtin.asnum$(x)) / Math.log(10);
@@ -236,7 +236,7 @@ var $builtinmodule = function (name) {
 
     /* Return True if x is infinite, and False otherwise. */
     mod.isinf = new Sk.builtin.func(function(x) {
-        Sk.builtin.pyCheckArgs("isinf", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("isinf", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         var _x = Sk.builtin.asnum$(x);
@@ -249,7 +249,7 @@ var $builtinmodule = function (name) {
 
     /* Return True if x is a NaN (not a number), and False otherwise. */
     mod.isnan = new Sk.builtin.func(function(x) {
-        Sk.builtin.pyCheckArgs("isnan", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("isnan", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "float", Sk.builtin.checkFloat(x));
 
         var _x = Sk.builtin.asnum$(x);
@@ -261,14 +261,14 @@ var $builtinmodule = function (name) {
     });
 
     mod.exp = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("exp", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("exp", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         return new Sk.builtin.float_(Math.exp(Sk.builtin.asnum$(x)));
     });
 
     mod.pow = new Sk.builtin.func(function (x, y) {
-        Sk.builtin.pyCheckArgs("pow", arguments, 2, 2);
+        Sk.builtin.pyCheckArgsLen("pow", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         Sk.builtin.pyCheckType("y", "number", Sk.builtin.checkNumber(y));
 
@@ -276,7 +276,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.radians = new Sk.builtin.func(function (deg) {
-        Sk.builtin.pyCheckArgs("radians", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("radians", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("deg", "number", Sk.builtin.checkNumber(deg));
 
         var ret = Math.PI / 180.0 * Sk.builtin.asnum$(deg);
@@ -284,7 +284,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.degrees = new Sk.builtin.func(function (rad) {
-        Sk.builtin.pyCheckArgs("degrees", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("degrees", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         var ret = 180.0 / Math.PI * Sk.builtin.asnum$(rad);
@@ -292,7 +292,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.hypot = new Sk.builtin.func(function (x, y) {
-        Sk.builtin.pyCheckArgs("hypot", arguments, 2, 2);
+        Sk.builtin.pyCheckArgsLen("hypot", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         Sk.builtin.pyCheckType("y", "number", Sk.builtin.checkNumber(y));
 
@@ -303,7 +303,7 @@ var $builtinmodule = function (name) {
 
     var MAX_SAFE_INTEGER_FACTORIAL = 18; // 19! > Number.MAX_SAFE_INTEGER
     mod.factorial = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("factorial", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("factorial", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Math.floor(Sk.builtin.asnum$(x));

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -3,23 +3,23 @@ var $builtinmodule = function(name){
     var inBrowser = (typeof window != "undefined") && (typeof window.navigator != "undefined");
 
     mod.python_implementation = new Sk.builtin.func(function() {
-        Sk.builtin.pyCheckArgs("python_implementation", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("python_implementation", arguments.length, 0, 0);
         return new Sk.builtin.str("Skulpt");
     });
 
     mod.node = new Sk.builtin.func(function() {
-        Sk.builtin.pyCheckArgs("node", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("node", arguments.length, 0, 0);
         return new Sk.builtin.str("");
     });
 
     mod.version = new Sk.builtin.func(function() {
-        Sk.builtin.pyCheckArgs("version", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("version", arguments.length, 0, 0);
         return new Sk.builtin.str("");
     });
 
     mod.python_version = new Sk.builtin.func(function() {
         var vers;
-        Sk.builtin.pyCheckArgs("python_version", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("python_version", arguments.length, 0, 0);
         if (Sk.__future__.python_version) {
             vers = "3.2.0";
         }
@@ -31,7 +31,7 @@ var $builtinmodule = function(name){
 
     mod.system = new Sk.builtin.func(function() {
         var sys;
-        Sk.builtin.pyCheckArgs("system", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("system", arguments.length, 0, 0);
         if (inBrowser) {
             sys = window.navigator.appCodeName;
         }
@@ -43,7 +43,7 @@ var $builtinmodule = function(name){
 
     mod.machine = new Sk.builtin.func(function() {
         var plat;
-        Sk.builtin.pyCheckArgs("machine", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("machine", arguments.length, 0, 0);
         if (inBrowser) {
             plat = window.navigator.platform;
         }
@@ -55,7 +55,7 @@ var $builtinmodule = function(name){
 
     mod.release = new Sk.builtin.func(function() {
         var appVers;
-        Sk.builtin.pyCheckArgs("release", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("release", arguments.length, 0, 0);
         if (inBrowser) {
             appVers = window.navigator.appVersion;
         }
@@ -66,13 +66,13 @@ var $builtinmodule = function(name){
     });
 
     mod.architecture = new Sk.builtin.func(function() {
-        Sk.builtin.pyCheckArgs("architecture", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("architecture", arguments.length, 0, 0);
         return new Sk.builtin.tuple([new Sk.builtin.str("64bit"),
                                      new Sk.builtin.str("")]);
     });
 
     mod.processor = new Sk.builtin.func(function() {
-        Sk.builtin.pyCheckArgs("processor", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("processor", arguments.length, 0, 0);
         return new Sk.builtin.str("");
     });
 

--- a/src/lib/random.js
+++ b/src/lib/random.js
@@ -227,7 +227,7 @@ var $builtinmodule = function (name) {
     var nextNormalSample = undefined;
 
     mod.seed = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("seed", arguments, 0, 1);
+        Sk.builtin.pyCheckArgsLen("seed", arguments.length, 0, 1);
         x = Sk.builtin.asnum$(x);
 
         if (arguments.length > 0) {
@@ -241,7 +241,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.random = new Sk.builtin.func(function () {
-        Sk.builtin.pyCheckArgs("random", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("random", arguments.length, 0, 0);
 
         return new Sk.builtin.float_(myGenerator.genrand_res53());
     });
@@ -315,7 +315,7 @@ var $builtinmodule = function (name) {
     };
 
     mod.randint = new Sk.builtin.func(function (a, b) {
-        Sk.builtin.pyCheckArgs("randint", arguments, 2, 2);
+        Sk.builtin.pyCheckArgsLen("randint", arguments.length, 2, 2);
 
         a = Sk.builtin.asnum$(a);
         b = Sk.builtin.asnum$(b);
@@ -323,7 +323,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.randrange = new Sk.builtin.func(function (start, stop, step) {
-        Sk.builtin.pyCheckArgs("randrange", arguments, 1, 3);
+        Sk.builtin.pyCheckArgsLen("randrange", arguments.length, 1, 3);
 
         start = Sk.builtin.asnum$(start);
         stop = Sk.builtin.asnum$(stop);
@@ -332,7 +332,7 @@ var $builtinmodule = function (name) {
     });
   
     mod.uniform = new Sk.builtin.func(function (a, b) {
-        Sk.builtin.pyCheckArgs("uniform", arguments, 2, 2);
+        Sk.builtin.pyCheckArgsLen("uniform", arguments.length, 2, 2);
 
         a = Sk.builtin.asnum$(a);
         b = Sk.builtin.asnum$(b);
@@ -342,7 +342,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.triangular = new Sk.builtin.func(function (low, high, mode) {
-        Sk.builtin.pyCheckArgs("triangular", arguments, 2, 3);
+        Sk.builtin.pyCheckArgsLen("triangular", arguments.length, 2, 3);
         Sk.builtin.pyCheckType("low", "number", Sk.builtin.checkNumber(low));
         Sk.builtin.pyCheckType("high", "number", Sk.builtin.checkNumber(high));
 
@@ -398,7 +398,7 @@ var $builtinmodule = function (name) {
     };
     
     mod.gauss = new Sk.builtin.func(function (mu, sigma) {
-        Sk.builtin.pyCheckArgs("gauss", arguments, 2, 2);
+        Sk.builtin.pyCheckArgsLen("gauss", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("mu", "number", Sk.builtin.checkNumber(mu));
         Sk.builtin.pyCheckType("sigma", "number", Sk.builtin.checkNumber(sigma));
 
@@ -414,7 +414,7 @@ var $builtinmodule = function (name) {
     mod.normalvariate = mod.gauss;
 
     mod.lognormvariate = new Sk.builtin.func(function (mu, sigma) {
-        Sk.builtin.pyCheckArgs("lognormvariate", arguments, 2, 2);
+        Sk.builtin.pyCheckArgsLen("lognormvariate", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("mu", "number", Sk.builtin.checkNumber(mu));
         Sk.builtin.pyCheckType("sigma", "number", Sk.builtin.checkNumber(sigma));
 
@@ -425,7 +425,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.expovariate = new Sk.builtin.func(function (lambd) {
-        Sk.builtin.pyCheckArgs("expovariate", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("expovariate", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("lambd", "number", Sk.builtin.checkNumber(lambd));
 
         lambd = Sk.builtin.asnum$(lambd);
@@ -435,7 +435,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.choice = new Sk.builtin.func(function (seq) {
-        Sk.builtin.pyCheckArgs("choice", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("choice", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("seq", "sequence", Sk.builtin.checkSequence(seq));
 
         if (seq.sq$length !== undefined) {
@@ -447,7 +447,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.shuffle = new Sk.builtin.func(function (x) {
-        Sk.builtin.pyCheckArgs("shuffle", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("shuffle", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "sequence", Sk.builtin.checkSequence(x));
 
         if (x.sq$length !== undefined) {
@@ -474,7 +474,7 @@ var $builtinmodule = function (name) {
     mod.sample = new Sk.builtin.func(function (population, k) {
         var i, j, iter, elem, reservoir;
 
-        Sk.builtin.pyCheckArgs("sample", arguments, 2, 2);
+        Sk.builtin.pyCheckArgsLen("sample", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("population", "iterable", Sk.builtin.checkIterable(population));
         Sk.builtin.pyCheckType("k", "integer", Sk.builtin.checkInt(k));
         k = Sk.builtin.asnum$(k);

--- a/src/lib/re.js
+++ b/src/lib/re.js
@@ -56,7 +56,7 @@ var $builtinmodule = function (name) {
         var pat, str, captured, jsflags, regex;
         var result, match, index, splits;
 
-        Sk.builtin.pyCheckArgs("split", arguments, 2, 4);
+        Sk.builtin.pyCheckArgsLen("split", arguments.length, 2, 4);
         if (!Sk.builtin.checkString(pattern)) {
             throw new Sk.builtin.TypeError("pattern must be a string");
         }
@@ -128,7 +128,7 @@ var $builtinmodule = function (name) {
     _findall = function (pattern, string, flags) {
         var pat, str, jsflags, regex, result, match;
 
-        Sk.builtin.pyCheckArgs("findall", arguments, 2, 3);
+        Sk.builtin.pyCheckArgsLen("findall", arguments.length, 2, 3);
         if (!Sk.builtin.checkString(pattern)) {
             throw new Sk.builtin.TypeError("pattern must be a string");
         }
@@ -255,7 +255,7 @@ var $builtinmodule = function (name) {
     _search = function (pattern, string, flags) {
         var mob, res;
 
-        Sk.builtin.pyCheckArgs("search", arguments, 2, 3);
+        Sk.builtin.pyCheckArgsLen("search", arguments.length, 2, 3);
         if (!Sk.builtin.checkString(pattern)) {
             throw new Sk.builtin.TypeError("pattern must be a string");
         }
@@ -284,7 +284,7 @@ var $builtinmodule = function (name) {
 
     _match = function (pattern, string, flags) {
         var mob, res;
-        Sk.builtin.pyCheckArgs("match", arguments, 2, 3);
+        Sk.builtin.pyCheckArgsLen("match", arguments.length, 2, 3);
         if (!Sk.builtin.checkString(pattern)) {
             throw new Sk.builtin.TypeError("pattern must be a string");
         }
@@ -353,7 +353,7 @@ var $builtinmodule = function (name) {
         };
 
         _re_search = function (self, string, pos, endpos) {
-            Sk.builtin.pyCheckArgs("search", arguments, 2, 4);
+            Sk.builtin.pyCheckArgsLen("search", arguments.length, 2, 4);
 
             var str = _slice(string, pos, endpos);
 
@@ -366,7 +366,7 @@ var $builtinmodule = function (name) {
         $loc.search = new Sk.builtin.func(_re_search);
 
         _re_match = function (self, string, pos, endpos) {
-            Sk.builtin.pyCheckArgs("match", arguments, 2, 4);
+            Sk.builtin.pyCheckArgsLen("match", arguments.length, 2, 4);
 
             var str = _slice(string, pos, endpos);
             // var str = string;
@@ -380,7 +380,7 @@ var $builtinmodule = function (name) {
         $loc.match = new Sk.builtin.func(_re_match);
 
         _re_split = function (self, string, maxsplit) {
-            Sk.builtin.pyCheckArgs("split", arguments, 2, 3);
+            Sk.builtin.pyCheckArgsLen("split", arguments.length, 2, 3);
 
             if (maxsplit === undefined) {
                 maxsplit = 0;
@@ -398,7 +398,7 @@ var $builtinmodule = function (name) {
         $loc.split = new Sk.builtin.func(_re_split);
 
         _re_findall = function (self, string, pos, endpos) {
-            Sk.builtin.pyCheckArgs("findall", arguments, 2, 4);
+            Sk.builtin.pyCheckArgsLen("findall", arguments.length, 2, 4);
 
             var str = _slice(string, pos, endpos);
 
@@ -415,7 +415,7 @@ var $builtinmodule = function (name) {
     mod.RegexObject = Sk.misceval.buildClass(mod, regexobj, "RegexObject", []);
     mod.compile = new Sk.builtin.func(function (pattern, flags) {
         var rob;
-        Sk.builtin.pyCheckArgs("compile", arguments, 1, 2);
+        Sk.builtin.pyCheckArgsLen("compile", arguments.length, 1, 2);
         if (!Sk.builtin.checkString(pattern)) {
             throw new Sk.builtin.TypeError("pattern must be a string");
         }

--- a/src/lib/signal.js
+++ b/src/lib/signal.js
@@ -54,7 +54,7 @@ var $builtinmodule = function (name) {
      * @returns
      */    
     mod.pause = new Sk.builtin.func(function () {
-        Sk.builtin.pyCheckArgs("pause", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("pause", arguments.length, 0, 0);
         var susp = new Sk.misceval.Suspension();
         susp.resume = function () {
             return Sk.builtin.none.none$;

--- a/src/lib/string.js
+++ b/src/lib/string.js
@@ -16,7 +16,7 @@ var $builtinmodule = function (name) {
     mod.uppercase = Sk.builtin.str('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
     mod.letters = Sk.builtin.str(mod.lowercase.v + mod.uppercase.v);
 
-    mod.digits = Sk.builtin.str('0123456789', Sk.builtin.str);
+    mod.digits = Sk.builtin.str('0123456789');
     mod.hexdigits = Sk.builtin.str('0123456789abcdefABCDEF');
     mod.octdigits = Sk.builtin.str('01234567');
 
@@ -55,7 +55,7 @@ var $builtinmodule = function (name) {
      * Note that this replaces runs of whitespace characters by a single
      * space, and removes leading and trailing whitespace. */
     mod.capwords = new Sk.builtin.func(function (s, sep) {
-        Sk.builtin.pyCheckArgs('capwords', arguments, 1, 2);
+        Sk.builtin.pyCheckArgsLen('capwords', arguments.length, 1, 2);
         if (!Sk.builtin.checkString(s)) {
             throw new Sk.builtin.TypeError("s must be a string");
         }

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -46,7 +46,7 @@ var $builtinmodule = function (name) {
     }
 
     mod.time = new Sk.builtin.func(function () {
-        Sk.builtin.pyCheckArgs("time", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("time", arguments.length, 0, 0);
         var res = Date.now();
         if (this.performance && this.performance.now)
         {
@@ -57,7 +57,7 @@ var $builtinmodule = function (name) {
 
     // This is an experimental implementation of time.sleep(), using suspensions
     mod.sleep = new Sk.builtin.func(function(delay) {
-        Sk.builtin.pyCheckArgs("sleep", arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen("sleep", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("delay", "float", Sk.builtin.checkNumber(delay));
 
         return new Sk.misceval.promiseToSuspension(new Promise(function(resolve) {
@@ -165,7 +165,7 @@ var $builtinmodule = function (name) {
     }
 
     function localtime_f(secs) {
-        Sk.builtin.pyCheckArgs("localtime", arguments, 0, 1);
+        Sk.builtin.pyCheckArgsLen("localtime", arguments.length, 0, 1);
         var d = new Date();
         if (secs) {
             Sk.builtin.pyCheckType("secs", "number", Sk.builtin.checkNumber(secs));
@@ -178,7 +178,7 @@ var $builtinmodule = function (name) {
     mod.localtime = new Sk.builtin.func(localtime_f);
 
     mod.gmtime = new Sk.builtin.func(function(secs) {
-        Sk.builtin.pyCheckArgs("localtime", arguments, 0, 1);
+        Sk.builtin.pyCheckArgsLen("localtime", arguments.length, 0, 1);
         var d = new Date();
         if (secs) {
             Sk.builtin.pyCheckType("secs", "number", Sk.builtin.checkNumber(secs));
@@ -278,7 +278,7 @@ var $builtinmodule = function (name) {
     function strftime_f(format, t) {
         var jsFormat;
 
-        Sk.builtin.pyCheckArgs("strftime", arguments, 1, 2);
+        Sk.builtin.pyCheckArgsLen("strftime", arguments.length, 1, 2);
         if (!Sk.builtin.checkString(format)) {
             throw new Sk.builtin.TypeError("format must be a string");
         }
@@ -301,14 +301,14 @@ var $builtinmodule = function (name) {
     function tzset_f()
     {
         throw new Sk.builtin.NotImplementedError("time.tzset() is not yet implemented");
-        Sk.builtin.pyCheckArgs("tzset", arguments, 0, 0);
+        Sk.builtin.pyCheckArgsLen("tzset", arguments.length, 0, 0);
     }
 
     mod.tzset = new Sk.builtin.func(tzset_f);
 
     function strptime_f(s, format)
     {
-        Sk.builtin.pyCheckArgs("strptime", arguments, 1, 2);
+        Sk.builtin.pyCheckArgsLen("strptime", arguments.length, 1, 2);
         Sk.builtin.pyCheckType("string", "string", Sk.builtin.checkString(s));
         if (format !== undefined) {
             Sk.builtin.pyCheckType("format", "string", Sk.builtin.checkString(format));

--- a/src/list.js
+++ b/src/list.js
@@ -222,7 +222,7 @@ Sk.builtin.list.prototype.tp$richcompare = function (w, op) {
 };
 
 Sk.builtin.list.prototype.__iter__ = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, true, false);
+    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 0, 0, true, false);
     return new Sk.builtin.list_iter_(self);
 });
 
@@ -295,7 +295,7 @@ Sk.builtin.list.prototype.sq$contains = function (item) {
 };
 
 Sk.builtin.list.prototype.__contains__ = new Sk.builtin.func(function(self, item) {
-    Sk.builtin.pyCheckArgs("__contains__", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("__contains__", arguments.length, 2, 2);
     return new Sk.builtin.bool(self.sq$contains(item));
 });
 
@@ -509,7 +509,7 @@ Sk.builtin.list.prototype.list_reverse_ = function (self) {
     var newarr;
     var old;
     var len;
-    Sk.builtin.pyCheckArgs("reverse", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("reverse", arguments.length, 1, 1);
 
     len = self.v.length;
     old = self.v;
@@ -524,14 +524,14 @@ Sk.builtin.list.prototype.list_reverse_ = function (self) {
 //Sk.builtin.list.prototype.__reversed__ = todo;
 
 Sk.builtin.list.prototype["append"] = new Sk.builtin.func(function (self, item) {
-    Sk.builtin.pyCheckArgs("append", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("append", arguments.length, 2, 2);
 
     self.v.push(item);
     return Sk.builtin.none.none$;
 });
 
 Sk.builtin.list.prototype["insert"] = new Sk.builtin.func(function (self, i, x) {
-    Sk.builtin.pyCheckArgs("insert", arguments, 3, 3);
+    Sk.builtin.pyCheckArgsLen("insert", arguments.length, 3, 3);
     if (!Sk.builtin.checkNumber(i)) {
         throw new Sk.builtin.TypeError("an integer is required");
     }
@@ -550,14 +550,14 @@ Sk.builtin.list.prototype["insert"] = new Sk.builtin.func(function (self, i, x) 
 });
 
 Sk.builtin.list.prototype["extend"] = new Sk.builtin.func(function (self, b) {
-    Sk.builtin.pyCheckArgs("extend", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("extend", arguments.length, 2, 2);
     self.list_extend_(b);
     return Sk.builtin.none.none$;
 });
 
 Sk.builtin.list.prototype["pop"] = new Sk.builtin.func(function (self, i) {
     var ret;
-    Sk.builtin.pyCheckArgs("pop", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("pop", arguments.length, 1, 2);
     if (i === undefined) {
         i = self.v.length - 1;
     }
@@ -580,7 +580,7 @@ Sk.builtin.list.prototype["pop"] = new Sk.builtin.func(function (self, i) {
 
 Sk.builtin.list.prototype["remove"] = new Sk.builtin.func(function (self, item) {
     var idx;
-    Sk.builtin.pyCheckArgs("remove", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("remove", arguments.length, 2, 2);
 
     idx = Sk.builtin.list.prototype["index"].func_code(self, item);
     self.v.splice(Sk.builtin.asnum$(idx), 1);
@@ -591,7 +591,7 @@ Sk.builtin.list.prototype["index"] = new Sk.builtin.func(function (self, item, s
     var i;
     var obj;
     var len;
-    Sk.builtin.pyCheckArgs("index", arguments, 2, 4);
+    Sk.builtin.pyCheckArgsLen("index", arguments.length, 2, 4);
     if (start !== undefined && !Sk.builtin.checkInt(start)) {
         throw new Sk.builtin.TypeError("slice indices must be integers");
     }
@@ -625,7 +625,7 @@ Sk.builtin.list.prototype["count"] = new Sk.builtin.func(function (self, item) {
     var count;
     var obj;
     var len;
-    Sk.builtin.pyCheckArgs("count", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("count", arguments.length, 2, 2);
 
     len = self.v.length;
     obj = self.v;

--- a/src/long.js
+++ b/src/long.js
@@ -79,7 +79,7 @@ Sk.builtin.lng.prototype.nb$int_ = function() {
 
 Sk.builtin.lng.prototype.__format__= function (obj, format_spec) {
     var formatstr;
-    Sk.builtin.pyCheckArgs("__format__", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
 
     if (!Sk.builtin.checkString(format_spec)) {
         if (Sk.__future__.exceptions) {
@@ -98,7 +98,7 @@ Sk.builtin.lng.prototype.__format__= function (obj, format_spec) {
 };
 
 Sk.builtin.lng.prototype.round$ = function (self, ndigits) {
-    Sk.builtin.pyCheckArgs("__round__", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("__round__", arguments.length, 1, 2);
 
     var result, multiplier, number, num10, rounded, bankRound, ndigs;
 

--- a/src/method.js
+++ b/src/method.js
@@ -10,7 +10,7 @@
  */
 Sk.builtin.method = function (func, self, klass, builtin) {
     if (!(this instanceof Sk.builtin.method)) {
-        Sk.builtin.pyCheckArgs("method", arguments, 3, 3);
+        Sk.builtin.pyCheckArgsLen("method", arguments.length, 3, 3);
         if (!Sk.builtin.checkCallable(func)) {
             throw new Sk.builtin.TypeError("First argument must be callable");
         }
@@ -76,7 +76,7 @@ Sk.builtin.method.prototype.tp$descr_get = function (obj, objtype) {
 Sk.builtin.method.pythonFunctions = ["__get__"];
 
 Sk.builtin.method.prototype.__get__ = function __get__(self, instance, owner) {
-    Sk.builtin.pyCheckArgs("__get__", arguments, 1, 2, false, true);
+    Sk.builtin.pyCheckArgsLen("__get__", arguments.length, 1, 2, false, true);
     if (instance === Sk.builtin.none.none$ && owner === Sk.builtin.none.none$) {
         throw new Sk.builtin.TypeError("__get__(None, None) is invalid");
     }

--- a/src/numtype.js
+++ b/src/numtype.js
@@ -32,7 +32,7 @@ Sk.builtin.numtype.prototype["__abs__"] = new Sk.builtin.func(function (self) {
         throw new Sk.builtin.NotImplementedError("__abs__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__abs__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__abs__", arguments.length, 0, 0, false, true);
     return self.nb$abs();
 
 });
@@ -50,7 +50,7 @@ Sk.builtin.numtype.prototype["__neg__"] = new Sk.builtin.func(function (self) {
         throw new Sk.builtin.NotImplementedError("__neg__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__neg__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__neg__", arguments.length, 0, 0, false, true);
     return self.nb$negative();
 
 });
@@ -68,7 +68,7 @@ Sk.builtin.numtype.prototype["__pos__"] = new Sk.builtin.func(function (self) {
         throw new Sk.builtin.NotImplementedError("__pos__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__pos__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__pos__", arguments.length, 0, 0, false, true);
     return self.nb$positive();
 
 });
@@ -86,7 +86,7 @@ Sk.builtin.numtype.prototype["__int__"] = new Sk.builtin.func(function (self) {
         throw new Sk.builtin.NotImplementedError("__int__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__int__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__int__", arguments.length, 0, 0, false, true);
     return self.nb$int_();
 
 });
@@ -104,7 +104,7 @@ Sk.builtin.numtype.prototype["__long__"] = new Sk.builtin.func(function (self) {
         throw new Sk.builtin.NotImplementedError("__long__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__long__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__long__", arguments.length, 0, 0, false, true);
     return self.nb$lng();
 
 });
@@ -122,7 +122,7 @@ Sk.builtin.numtype.prototype["__float__"] = new Sk.builtin.func(function (self) 
         throw new Sk.builtin.NotImplementedError("__float__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__float__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__float__", arguments.length, 0, 0, false, true);
     return self.nb$float_();
 
 });
@@ -140,7 +140,7 @@ Sk.builtin.numtype.prototype["__add__"] = new Sk.builtin.func(function (self, ot
         throw new Sk.builtin.NotImplementedError("__add__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__add__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__add__", arguments.length, 1, 1, false, true);
     return self.nb$add(other);
 
 });
@@ -158,7 +158,7 @@ Sk.builtin.numtype.prototype["__radd__"] = new Sk.builtin.func(function (self, o
         throw new Sk.builtin.NotImplementedError("__radd__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__radd__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__radd__", arguments.length, 1, 1, false, true);
     return self.nb$reflected_add(other);
 
 });
@@ -176,7 +176,7 @@ Sk.builtin.numtype.prototype["__sub__"] = new Sk.builtin.func(function (self, ot
         throw new Sk.builtin.NotImplementedError("__sub__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__sub__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__sub__", arguments.length, 1, 1, false, true);
     return self.nb$subtract(other);
 
 });
@@ -194,7 +194,7 @@ Sk.builtin.numtype.prototype["__rsub__"] = new Sk.builtin.func(function (self, o
         throw new Sk.builtin.NotImplementedError("__rsub__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__rsub__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__rsub__", arguments.length, 1, 1, false, true);
     return self.nb$reflected_subtract(other);
 
 });
@@ -212,7 +212,7 @@ Sk.builtin.numtype.prototype["__mul__"] = new Sk.builtin.func(function (self, ot
         throw new Sk.builtin.NotImplementedError("__mul__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__mul__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__mul__", arguments.length, 1, 1, false, true);
     return self.nb$multiply(other);
 
 });
@@ -230,7 +230,7 @@ Sk.builtin.numtype.prototype["__rmul__"] = new Sk.builtin.func(function (self, o
         throw new Sk.builtin.NotImplementedError("__rmul__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__rmul__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__rmul__", arguments.length, 1, 1, false, true);
     return self.nb$reflected_multiply(other);
 
 });
@@ -248,7 +248,7 @@ Sk.builtin.numtype.prototype["__div__"] = new Sk.builtin.func(function (self, ot
         throw new Sk.builtin.NotImplementedError("__div__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__div__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__div__", arguments.length, 1, 1, false, true);
     return self.nb$divide(other);
 
 });
@@ -266,7 +266,7 @@ Sk.builtin.numtype.prototype["__rdiv__"] = new Sk.builtin.func(function (self, o
         throw new Sk.builtin.NotImplementedError("__rdiv__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__rdiv__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__rdiv__", arguments.length, 1, 1, false, true);
     return self.nb$reflected_divide(other);
 
 });
@@ -284,7 +284,7 @@ Sk.builtin.numtype.prototype["__floordiv__"] = new Sk.builtin.func(function (sel
         throw new Sk.builtin.NotImplementedError("__floordiv__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__floordiv__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__floordiv__", arguments.length, 1, 1, false, true);
     return self.nb$floor_divide(other);
 
 });
@@ -302,7 +302,7 @@ Sk.builtin.numtype.prototype["__rfloordiv__"] = new Sk.builtin.func(function (se
         throw new Sk.builtin.NotImplementedError("__rfloordiv__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__rfloordiv__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__rfloordiv__", arguments.length, 1, 1, false, true);
     return self.nb$reflected_floor_divide(other);
 
 });
@@ -320,7 +320,7 @@ Sk.builtin.numtype.prototype["__mod__"] = new Sk.builtin.func(function (self, ot
         throw new Sk.builtin.NotImplementedError("__mod__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__mod__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__mod__", arguments.length, 1, 1, false, true);
     return self.nb$remainder(other);
 
 });
@@ -338,7 +338,7 @@ Sk.builtin.numtype.prototype["__rmod__"] = new Sk.builtin.func(function (self, o
         throw new Sk.builtin.NotImplementedError("__rmod__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__rmod__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__rmod__", arguments.length, 1, 1, false, true);
     return self.nb$reflected_remainder(other);
 
 });
@@ -356,7 +356,7 @@ Sk.builtin.numtype.prototype["__divmod__"] = new Sk.builtin.func(function (self,
         throw new Sk.builtin.NotImplementedError("__divmod__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__divmod__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__divmod__", arguments.length, 1, 1, false, true);
     return self.nb$divmod(other);
 
 });
@@ -374,7 +374,7 @@ Sk.builtin.numtype.prototype["__rdivmod__"] = new Sk.builtin.func(function (self
         throw new Sk.builtin.NotImplementedError("__rdivmod__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__rdivmod__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__rdivmod__", arguments.length, 1, 1, false, true);
     return self.nb$reflected_divmod(other);
 
 });
@@ -392,7 +392,7 @@ Sk.builtin.numtype.prototype["__pow__"] = new Sk.builtin.func(function (self, ot
         throw new Sk.builtin.NotImplementedError("__pow__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__pow__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__pow__", arguments.length, 1, 1, false, true);
     return self.nb$power(other);
 
 });
@@ -410,7 +410,7 @@ Sk.builtin.numtype.prototype["__rpow__"] = new Sk.builtin.func(function (self, o
         throw new Sk.builtin.NotImplementedError("__rpow__ is not yet implemented");
     }
 
-    Sk.builtin.pyCheckArgs("__rpow__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__rpow__", arguments.length, 1, 1, false, true);
     return self.nb$reflected_power(other);
 
 });

--- a/src/object.js
+++ b/src/object.js
@@ -216,7 +216,7 @@ Sk.builtin.object.prototype.tp$descr_set = undefined;   // Nonsense for closure 
  * @instance
  */
 Sk.builtin.object.prototype["__new__"] = function (cls) {
-    Sk.builtin.pyCheckArgs("__new__", arguments, 1, 1, false, false);
+    Sk.builtin.pyCheckArgsLen("__new__", arguments.length, 1, 1, false, false);
 
     return new cls([], []);
 };
@@ -228,7 +228,7 @@ Sk.builtin.object.prototype["__new__"] = function (cls) {
  * @instance
  */
 Sk.builtin.object.prototype["__repr__"] = function (self) {
-    Sk.builtin.pyCheckArgs("__repr__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__repr__", arguments.length, 0, 0, false, true);
 
     return self["$r"]();
 };
@@ -236,7 +236,7 @@ Sk.builtin.object.prototype["__repr__"] = function (self) {
 
 Sk.builtin.object.prototype["__format__"] = function (self, format_spec) {
     var formatstr;
-    Sk.builtin.pyCheckArgs("__format__", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
 
     if (!Sk.builtin.checkString(format_spec)) {
         if (Sk.__future__.exceptions) {
@@ -262,7 +262,7 @@ Sk.builtin.object.prototype["__format__"] = function (self, format_spec) {
  * @instance
  */
 Sk.builtin.object.prototype["__str__"] = function (self) {
-    Sk.builtin.pyCheckArgs("__str__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__str__", arguments.length, 0, 0, false, true);
 
     return self["$r"]();
 };
@@ -274,7 +274,7 @@ Sk.builtin.object.prototype["__str__"] = function (self) {
  * @instance
  */
 Sk.builtin.object.prototype["__hash__"] = function (self) {
-    Sk.builtin.pyCheckArgs("__hash__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__hash__", arguments.length, 0, 0, false, true);
 
     return self.tp$hash();
 };
@@ -286,7 +286,7 @@ Sk.builtin.object.prototype["__hash__"] = function (self) {
  * @instance
  */
 Sk.builtin.object.prototype["__eq__"] = function (self, other) {
-    Sk.builtin.pyCheckArgs("__eq__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__eq__", arguments.length, 1, 1, false, true);
 
     return self.ob$eq(other);
 };
@@ -298,7 +298,7 @@ Sk.builtin.object.prototype["__eq__"] = function (self, other) {
  * @instance
  */
 Sk.builtin.object.prototype["__ne__"] = function (self, other) {
-    Sk.builtin.pyCheckArgs("__ne__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__ne__", arguments.length, 1, 1, false, true);
 
     return self.ob$ne(other);
 };
@@ -310,7 +310,7 @@ Sk.builtin.object.prototype["__ne__"] = function (self, other) {
  * @instance
  */
 Sk.builtin.object.prototype["__lt__"] = function (self, other) {
-    Sk.builtin.pyCheckArgs("__lt__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__lt__", arguments.length, 1, 1, false, true);
 
     return self.ob$lt(other);
 };
@@ -322,7 +322,7 @@ Sk.builtin.object.prototype["__lt__"] = function (self, other) {
  * @instance
  */
 Sk.builtin.object.prototype["__le__"] = function (self, other) {
-    Sk.builtin.pyCheckArgs("__le__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__le__", arguments.length, 1, 1, false, true);
 
     return self.ob$le(other);
 };
@@ -334,7 +334,7 @@ Sk.builtin.object.prototype["__le__"] = function (self, other) {
  * @instance
  */
 Sk.builtin.object.prototype["__gt__"] = function (self, other) {
-    Sk.builtin.pyCheckArgs("__gt__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__gt__", arguments.length, 1, 1, false, true);
 
     return self.ob$gt(other);
 };
@@ -346,7 +346,7 @@ Sk.builtin.object.prototype["__gt__"] = function (self, other) {
  * @instance
  */
 Sk.builtin.object.prototype["__ge__"] = function (self, other) {
-    Sk.builtin.pyCheckArgs("__ge__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__ge__", arguments.length, 1, 1, false, true);
 
     return self.ob$ge(other);
 };

--- a/src/print.js
+++ b/src/print.js
@@ -5,7 +5,7 @@
 
 */
 var print_f = function function_print(kwa) {
-    Sk.builtin.pyCheckArgs("print", arguments, 0, Infinity, true, false);
+    Sk.builtin.pyCheckArgsLen("print", arguments.length, 0, Infinity, true, false);
     var args = Array.prototype.slice.call(arguments, 1);
     var kwargs = new Sk.builtins.dict(kwa);
     var _kwargs = Sk.ffi.remapToJs(kwargs);

--- a/src/seqtype.js
+++ b/src/seqtype.js
@@ -28,7 +28,7 @@ Sk.builtin.seqtype.sk$abstract = true;
  */
 Sk.builtin.seqtype.prototype["__len__"] = new Sk.builtin.func(function (self) {
 
-    Sk.builtin.pyCheckArgs("__len__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__len__", arguments.length, 0, 0, false, true);
 
     return new Sk.builtin.int_(self.sq$length());    
 
@@ -43,7 +43,7 @@ Sk.builtin.seqtype.prototype["__len__"] = new Sk.builtin.func(function (self) {
  */
 Sk.builtin.seqtype.prototype["__iter__"] = new Sk.builtin.func(function (self) {
 
-    Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 0, 0, false, true);
 
     return self.tp$iter();
 
@@ -58,7 +58,7 @@ Sk.builtin.seqtype.prototype["__iter__"] = new Sk.builtin.func(function (self) {
  */
 Sk.builtin.seqtype.prototype["__contains__"] = new Sk.builtin.func(function (self, item) {
 
-    Sk.builtin.pyCheckArgs("__contains__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__contains__", arguments.length, 1, 1, false, true);
 
     if (self.sq$contains(item)) {
         return Sk.builtin.bool.true$;
@@ -77,7 +77,7 @@ Sk.builtin.seqtype.prototype["__contains__"] = new Sk.builtin.func(function (sel
  */
 Sk.builtin.seqtype.prototype["__getitem__"] = new Sk.builtin.func(function (self, key) {
 
-    Sk.builtin.pyCheckArgs("__getitem__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__getitem__", arguments.length, 1, 1, false, true);
 
     return self.mp$subscript(key);
 
@@ -92,7 +92,7 @@ Sk.builtin.seqtype.prototype["__getitem__"] = new Sk.builtin.func(function (self
  */
 Sk.builtin.seqtype.prototype["__add__"] = new Sk.builtin.func(function (self, other) {
 
-    Sk.builtin.pyCheckArgs("__add__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__add__", arguments.length, 1, 1, false, true);
 
     return self.sq$concat(other);
 
@@ -107,7 +107,7 @@ Sk.builtin.seqtype.prototype["__add__"] = new Sk.builtin.func(function (self, ot
  */
 Sk.builtin.seqtype.prototype["__mul__"] = new Sk.builtin.func(function (self, n) {
 
-    Sk.builtin.pyCheckArgs("__mul__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__mul__", arguments.length, 1, 1, false, true);
 
     if (!Sk.misceval.isIndex(n)) {
         throw new Sk.builtin.TypeError("can't multiply sequence by non-int of type '" + Sk.abstr.typeName(n) + "'");
@@ -126,7 +126,7 @@ Sk.builtin.seqtype.prototype["__mul__"] = new Sk.builtin.func(function (self, n)
  */
 Sk.builtin.seqtype.prototype["__rmul__"] = new Sk.builtin.func(function (self, n) {
 
-    Sk.builtin.pyCheckArgs("__rmul__", arguments, 1, 1, false, true);
+    Sk.builtin.pyCheckArgsLen("__rmul__", arguments.length, 1, 1, false, true);
 
     return self.sq$repeat(n);    
 

--- a/src/set.js
+++ b/src/set.js
@@ -6,6 +6,7 @@ Sk.builtin.set = function (S) {
     var it, i;
     var S_list;
     if (!(this instanceof Sk.builtin.set)) {
+        Sk.builtin.pyCheckArgsLen("set", arguments.length, 0, 1);
         return new Sk.builtin.set(S);
     }
 
@@ -162,7 +163,7 @@ Sk.builtin.set.prototype.nb$subtract = function(other){
 };
 
 Sk.builtin.set.prototype["__iter__"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, false, true);
+    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 0, 0, false, true);
     return new Sk.builtin.set_iter_(self);
 });
 
@@ -183,7 +184,7 @@ Sk.builtin.set.prototype["isdisjoint"] = new Sk.builtin.func(function (self, oth
     var isIn;
     var it, item;
 
-    Sk.builtin.pyCheckArgs("isdisjoint", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("isdisjoint", arguments.length, 2, 2);
     if (!Sk.builtin.checkIterable(other)) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(other) + "' object is not iterable");
     }
@@ -202,7 +203,7 @@ Sk.builtin.set.prototype["issubset"] = new Sk.builtin.func(function (self, other
     var it, item;
     var selfLength, otherLength;
 
-    Sk.builtin.pyCheckArgs("issubset", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("issubset", arguments.length, 2, 2);
     if (!Sk.builtin.checkIterable(other)) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(other) + "' object is not iterable");
     }
@@ -224,14 +225,14 @@ Sk.builtin.set.prototype["issubset"] = new Sk.builtin.func(function (self, other
 });
 
 Sk.builtin.set.prototype["issuperset"] = new Sk.builtin.func(function (self, other) {
-    Sk.builtin.pyCheckArgs("issuperset", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("issuperset", arguments.length, 2, 2);
     return Sk.builtin.set.prototype["issubset"].func_code(other, self);
 });
 
 Sk.builtin.set.prototype["union"] = new Sk.builtin.func(function (self) {
     var S, i, new_args;
 
-    Sk.builtin.pyCheckArgs("union", arguments, 1);
+    Sk.builtin.pyCheckArgsLen("union", arguments.length, 1);
 
     S = Sk.builtin.set.prototype["copy"].func_code(self);
     new_args = [S];
@@ -246,7 +247,7 @@ Sk.builtin.set.prototype["union"] = new Sk.builtin.func(function (self) {
 Sk.builtin.set.prototype["intersection"] = new Sk.builtin.func(function (self) {
     var S, i, new_args;
 
-    Sk.builtin.pyCheckArgs("intersection", arguments, 1);
+    Sk.builtin.pyCheckArgsLen("intersection", arguments.length, 1);
 
     S = Sk.builtin.set.prototype["copy"].func_code(self);
     new_args = [S];
@@ -261,7 +262,7 @@ Sk.builtin.set.prototype["intersection"] = new Sk.builtin.func(function (self) {
 Sk.builtin.set.prototype["difference"] = new Sk.builtin.func(function (self, other) {
     var S, i, new_args;
 
-    Sk.builtin.pyCheckArgs("difference", arguments, 2);
+    Sk.builtin.pyCheckArgsLen("difference", arguments.length, 2);
 
     S = Sk.builtin.set.prototype["copy"].func_code(self);
     new_args = [S];
@@ -276,7 +277,7 @@ Sk.builtin.set.prototype["difference"] = new Sk.builtin.func(function (self, oth
 Sk.builtin.set.prototype["symmetric_difference"] = new Sk.builtin.func(function (self, other) {
     var it, item, S;
 
-    Sk.builtin.pyCheckArgs("symmetric_difference", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("symmetric_difference", arguments.length, 2, 2);
 
     S = Sk.builtin.set.prototype["union"].func_code(self, other);
     for (it = Sk.abstr.iter(S), item = it.tp$iternext(); item !== undefined; item = it.tp$iternext()) {
@@ -288,14 +289,14 @@ Sk.builtin.set.prototype["symmetric_difference"] = new Sk.builtin.func(function 
 });
 
 Sk.builtin.set.prototype["copy"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("copy", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("copy", arguments.length, 1, 1);
     return new Sk.builtin.set(self);
 });
 
 Sk.builtin.set.prototype["update"] = new Sk.builtin.func(function (self, other) {
     var i, it, item, arg;
 
-    Sk.builtin.pyCheckArgs("update", arguments, 2);
+    Sk.builtin.pyCheckArgsLen("update", arguments.length, 2);
 
     for (i = 1; i < arguments.length; i++) {
         arg = arguments[i];
@@ -315,7 +316,7 @@ Sk.builtin.set.prototype["update"] = new Sk.builtin.func(function (self, other) 
 Sk.builtin.set.prototype["intersection_update"] = new Sk.builtin.func(function (self, other) {
     var i, it, item;
 
-    Sk.builtin.pyCheckArgs("intersection_update", arguments, 2);
+    Sk.builtin.pyCheckArgsLen("intersection_update", arguments.length, 2);
     for (i = 1; i < arguments.length; i++) {
         if (!Sk.builtin.checkIterable(arguments[i])) {
             throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(arguments[i]) +
@@ -337,7 +338,7 @@ Sk.builtin.set.prototype["intersection_update"] = new Sk.builtin.func(function (
 Sk.builtin.set.prototype["difference_update"] = new Sk.builtin.func(function (self, other) {
     var i, it, item;
 
-    Sk.builtin.pyCheckArgs("difference_update", arguments, 2);
+    Sk.builtin.pyCheckArgsLen("difference_update", arguments.length, 2);
     for (i = 1; i < arguments.length; i++) {
         if (!Sk.builtin.checkIterable(arguments[i])) {
             throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(arguments[i]) +
@@ -357,7 +358,7 @@ Sk.builtin.set.prototype["difference_update"] = new Sk.builtin.func(function (se
 });
 
 Sk.builtin.set.prototype["symmetric_difference_update"] = new Sk.builtin.func(function (self, other) {
-    Sk.builtin.pyCheckArgs("symmetric_difference_update", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("symmetric_difference_update", arguments.length, 2, 2);
 
     var sd = Sk.builtin.set.prototype["symmetric_difference"].func_code(self, other);
     self.set_reset_();
@@ -367,14 +368,14 @@ Sk.builtin.set.prototype["symmetric_difference_update"] = new Sk.builtin.func(fu
 
 
 Sk.builtin.set.prototype["add"] = new Sk.builtin.func(function (self, item) {
-    Sk.builtin.pyCheckArgs("add", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("add", arguments.length, 2, 2);
 
     self.v.mp$ass_subscript(item, true);
     return Sk.builtin.none.none$;
 });
 
 Sk.builtin.set.prototype["discard"] = new Sk.builtin.func(function (self, item) {
-    Sk.builtin.pyCheckArgs("discard", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("discard", arguments.length, 2, 2);
 
     Sk.builtin.dict.prototype["pop"].func_code(self.v, item,
         Sk.builtin.none.none$);
@@ -384,7 +385,7 @@ Sk.builtin.set.prototype["discard"] = new Sk.builtin.func(function (self, item) 
 Sk.builtin.set.prototype["pop"] = new Sk.builtin.func(function (self) {
     var it, item;
 
-    Sk.builtin.pyCheckArgs("pop", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("pop", arguments.length, 1, 1);
 
     if (self.sq$length() === 0) {
         throw new Sk.builtin.KeyError("pop from an empty set");
@@ -397,7 +398,7 @@ Sk.builtin.set.prototype["pop"] = new Sk.builtin.func(function (self) {
 });
 
 Sk.builtin.set.prototype["remove"] = new Sk.builtin.func(function (self, item) {
-    Sk.builtin.pyCheckArgs("remove", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("remove", arguments.length, 2, 2);
 
     self.v.mp$del_subscript(item);
     return Sk.builtin.none.none$;
@@ -448,7 +449,7 @@ Sk.abstr.setUpInheritance("setiterator", Sk.builtin.set_iter_, Sk.builtin.object
 Sk.builtin.set_iter_.prototype.__class__ = Sk.builtin.set_iter_;
 
 Sk.builtin.set_iter_.prototype.__iter__ = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, true, false);
+    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 0, 0, true, false);
     return self;
 });
 

--- a/src/slice.js
+++ b/src/slice.js
@@ -5,7 +5,7 @@
  * @param {Object=} step
  */
 Sk.builtin.slice = function slice (start, stop, step) {
-    Sk.builtin.pyCheckArgs("slice", arguments, 1, 3, false, false);
+    Sk.builtin.pyCheckArgsLen("slice", arguments.length, 1, 3, false, false);
 
     if ((step !== undefined) && Sk.misceval.isIndex(step) && (Sk.misceval.asIndex(step) === 0)) {
         throw new Sk.builtin.ValueError("slice step cannot be zero");
@@ -146,7 +146,7 @@ Sk.builtin.slice.prototype.slice_indices_ = function (length) {
 };
 
 Sk.builtin.slice.prototype["indices"] = new Sk.builtin.func(function (self, length) {
-    Sk.builtin.pyCheckArgs("indices", arguments, 2, 2, false, false);
+    Sk.builtin.pyCheckArgsLen("indices", arguments.length, 2, 2, false, false);
 
     length = Sk.builtin.asnum$(length);
     var sss = self.slice_indices_(length);

--- a/src/str.js
+++ b/src/str.js
@@ -7,6 +7,9 @@ Sk.builtin.interned = {};
  */
 Sk.builtin.str = function (x) {
     var ret;
+
+    Sk.builtin.pyCheckArgsLen("str", arguments.length, 0, 1);
+
     if (x === undefined) {
         x = "";
     }
@@ -232,12 +235,12 @@ Sk.builtin.str.re_escape_ = function (s) {
 };
 
 Sk.builtin.str.prototype["lower"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("lower", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("lower", arguments.length, 1, 1);
     return new Sk.builtin.str(self.v.toLowerCase());
 });
 
 Sk.builtin.str.prototype["upper"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("upper", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("upper", arguments.length, 1, 1);
     return new Sk.builtin.str(self.v.toUpperCase());
 });
 
@@ -245,7 +248,7 @@ Sk.builtin.str.prototype["capitalize"] = new Sk.builtin.func(function (self) {
     var i;
     var cap;
     var orig;
-    Sk.builtin.pyCheckArgs("capitalize", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("capitalize", arguments.length, 1, 1);
     orig = self.v;
 
     if (orig.length === 0) {
@@ -262,7 +265,7 @@ Sk.builtin.str.prototype["capitalize"] = new Sk.builtin.func(function (self) {
 Sk.builtin.str.prototype["join"] = new Sk.builtin.func(function (self, seq) {
     var it, i;
     var arrOfStrs;
-    Sk.builtin.pyCheckArgs("join", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("join", arguments.length, 2, 2);
     Sk.builtin.pyCheckType("seq", "iterable", Sk.builtin.checkIterable(seq));
     arrOfStrs = [];
     for (it = seq.tp$iter(), i = it.tp$iternext(); i !== undefined; i = it.tp$iternext()) {
@@ -282,7 +285,7 @@ Sk.builtin.str.prototype["split"] = new Sk.builtin.func(function (self, on, howm
     var s;
     var str;
     var regex;
-    Sk.builtin.pyCheckArgs("split", arguments, 1, 3);
+    Sk.builtin.pyCheckArgsLen("split", arguments.length, 1, 3);
     if ((on === undefined) || (on instanceof Sk.builtin.none)) {
         on = null;
     }
@@ -336,7 +339,7 @@ Sk.builtin.str.prototype["split"] = new Sk.builtin.func(function (self, on, howm
 Sk.builtin.str.prototype["strip"] = new Sk.builtin.func(function (self, chars) {
     var regex;
     var pattern;
-    Sk.builtin.pyCheckArgs("strip", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("strip", arguments.length, 1, 2);
     if ((chars !== undefined) && !Sk.builtin.checkString(chars)) {
         throw new Sk.builtin.TypeError("strip arg must be None or str");
     }
@@ -352,7 +355,7 @@ Sk.builtin.str.prototype["strip"] = new Sk.builtin.func(function (self, chars) {
 Sk.builtin.str.prototype["lstrip"] = new Sk.builtin.func(function (self, chars) {
     var regex;
     var pattern;
-    Sk.builtin.pyCheckArgs("lstrip", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("lstrip", arguments.length, 1, 2);
     if ((chars !== undefined) && !Sk.builtin.checkString(chars)) {
         throw new Sk.builtin.TypeError("lstrip arg must be None or str");
     }
@@ -368,7 +371,7 @@ Sk.builtin.str.prototype["lstrip"] = new Sk.builtin.func(function (self, chars) 
 Sk.builtin.str.prototype["rstrip"] = new Sk.builtin.func(function (self, chars) {
     var regex;
     var pattern;
-    Sk.builtin.pyCheckArgs("rstrip", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("rstrip", arguments.length, 1, 2);
     if ((chars !== undefined) && !Sk.builtin.checkString(chars)) {
         throw new Sk.builtin.TypeError("rstrip arg must be None or str");
     }
@@ -383,7 +386,7 @@ Sk.builtin.str.prototype["rstrip"] = new Sk.builtin.func(function (self, chars) 
 
 Sk.builtin.str.prototype["__format__"] = new Sk.builtin.func(function (self, format_spec) {
     var formatstr;
-    Sk.builtin.pyCheckArgs("__format__", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
 
     if (!Sk.builtin.checkString(format_spec)) {
         if (Sk.__future__.exceptions) {
@@ -404,7 +407,7 @@ Sk.builtin.str.prototype["__format__"] = new Sk.builtin.func(function (self, for
 Sk.builtin.str.prototype["partition"] = new Sk.builtin.func(function (self, sep) {
     var pos;
     var sepStr;
-    Sk.builtin.pyCheckArgs("partition", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("partition", arguments.length, 2, 2);
     Sk.builtin.pyCheckType("sep", "string", Sk.builtin.checkString(sep));
     sepStr = new Sk.builtin.str(sep);
     pos = self.v.indexOf(sepStr.v);
@@ -421,7 +424,7 @@ Sk.builtin.str.prototype["partition"] = new Sk.builtin.func(function (self, sep)
 Sk.builtin.str.prototype["rpartition"] = new Sk.builtin.func(function (self, sep) {
     var pos;
     var sepStr;
-    Sk.builtin.pyCheckArgs("rpartition", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("rpartition", arguments.length, 2, 2);
     Sk.builtin.pyCheckType("sep", "string", Sk.builtin.checkString(sep));
     sepStr = new Sk.builtin.str(sep);
     pos = self.v.lastIndexOf(sepStr.v);
@@ -440,7 +443,7 @@ Sk.builtin.str.prototype["count"] = new Sk.builtin.func(function (self, pat, sta
     var ctl;
     var slice;
     var m;
-    Sk.builtin.pyCheckArgs("count", arguments, 2, 4);
+    Sk.builtin.pyCheckArgsLen("count", arguments.length, 2, 4);
     if (!Sk.builtin.checkString(pat)) {
         throw new Sk.builtin.TypeError("expected a character buffer object");
     }
@@ -479,7 +482,7 @@ Sk.builtin.str.prototype["count"] = new Sk.builtin.func(function (self, pat, sta
 
 Sk.builtin.str.prototype["ljust"] = new Sk.builtin.func(function (self, len, fillchar) {
     var newstr;
-    Sk.builtin.pyCheckArgs("ljust", arguments, 2, 3);
+    Sk.builtin.pyCheckArgsLen("ljust", arguments.length, 2, 3);
     if (!Sk.builtin.checkInt(len)) {
         throw new Sk.builtin.TypeError("integer argument exepcted, got " + Sk.abstr.typeName(len));
     }
@@ -502,7 +505,7 @@ Sk.builtin.str.prototype["ljust"] = new Sk.builtin.func(function (self, len, fil
 
 Sk.builtin.str.prototype["rjust"] = new Sk.builtin.func(function (self, len, fillchar) {
     var newstr;
-    Sk.builtin.pyCheckArgs("rjust", arguments, 2, 3);
+    Sk.builtin.pyCheckArgsLen("rjust", arguments.length, 2, 3);
     if (!Sk.builtin.checkInt(len)) {
         throw new Sk.builtin.TypeError("integer argument exepcted, got " + Sk.abstr.typeName(len));
     }
@@ -527,7 +530,7 @@ Sk.builtin.str.prototype["rjust"] = new Sk.builtin.func(function (self, len, fil
 Sk.builtin.str.prototype["center"] = new Sk.builtin.func(function (self, len, fillchar) {
     var newstr;
     var newstr1;
-    Sk.builtin.pyCheckArgs("center", arguments, 2, 3);
+    Sk.builtin.pyCheckArgsLen("center", arguments.length, 2, 3);
     if (!Sk.builtin.checkInt(len)) {
         throw new Sk.builtin.TypeError("integer argument exepcted, got " + Sk.abstr.typeName(len));
     }
@@ -555,7 +558,7 @@ Sk.builtin.str.prototype["center"] = new Sk.builtin.func(function (self, len, fi
 
 Sk.builtin.str.prototype["find"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
-    Sk.builtin.pyCheckArgs("find", arguments, 2, 4);
+    Sk.builtin.pyCheckArgsLen("find", arguments.length, 2, 4);
     if (!Sk.builtin.checkString(tgt)) {
         throw new Sk.builtin.TypeError("expected a character buffer object");
     }
@@ -588,7 +591,7 @@ Sk.builtin.str.prototype["find"] = new Sk.builtin.func(function (self, tgt, star
 
 Sk.builtin.str.prototype["index"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
-    Sk.builtin.pyCheckArgs("index", arguments, 2, 4);
+    Sk.builtin.pyCheckArgsLen("index", arguments.length, 2, 4);
     idx = Sk.misceval.callsim(self["find"], self, tgt, start, end);
     if (Sk.builtin.asnum$(idx) === -1) {
         throw new Sk.builtin.ValueError("substring not found");
@@ -598,7 +601,7 @@ Sk.builtin.str.prototype["index"] = new Sk.builtin.func(function (self, tgt, sta
 
 Sk.builtin.str.prototype["rfind"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
-    Sk.builtin.pyCheckArgs("rfind", arguments, 2, 4);
+    Sk.builtin.pyCheckArgsLen("rfind", arguments.length, 2, 4);
     if (!Sk.builtin.checkString(tgt)) {
         throw new Sk.builtin.TypeError("expected a character buffer object");
     }
@@ -632,7 +635,7 @@ Sk.builtin.str.prototype["rfind"] = new Sk.builtin.func(function (self, tgt, sta
 
 Sk.builtin.str.prototype["rindex"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
-    Sk.builtin.pyCheckArgs("rindex", arguments, 2, 4);
+    Sk.builtin.pyCheckArgsLen("rindex", arguments.length, 2, 4);
     idx = Sk.misceval.callsim(self["rfind"], self, tgt, start, end);
     if (Sk.builtin.asnum$(idx) === -1) {
         throw new Sk.builtin.ValueError("substring not found");
@@ -641,14 +644,14 @@ Sk.builtin.str.prototype["rindex"] = new Sk.builtin.func(function (self, tgt, st
 });
 
 Sk.builtin.str.prototype["startswith"] = new Sk.builtin.func(function (self, tgt) {
-    Sk.builtin.pyCheckArgs("startswith", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("startswith", arguments.length, 2, 2);
     Sk.builtin.pyCheckType("tgt", "string", Sk.builtin.checkString(tgt));
     return new Sk.builtin.bool( self.v.indexOf(tgt.v) === 0);
 });
 
 // http://stackoverflow.com/questions/280634/endswith-in-javascript
 Sk.builtin.str.prototype["endswith"] = new Sk.builtin.func(function (self, tgt) {
-    Sk.builtin.pyCheckArgs("endswith", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("endswith", arguments.length, 2, 2);
     Sk.builtin.pyCheckType("tgt", "string", Sk.builtin.checkString(tgt));
     return new Sk.builtin.bool( self.v.indexOf(tgt.v, self.v.length - tgt.v.length) !== -1);
 });
@@ -656,7 +659,7 @@ Sk.builtin.str.prototype["endswith"] = new Sk.builtin.func(function (self, tgt) 
 Sk.builtin.str.prototype["replace"] = new Sk.builtin.func(function (self, oldS, newS, count) {
     var c;
     var patt;
-    Sk.builtin.pyCheckArgs("replace", arguments, 3, 4);
+    Sk.builtin.pyCheckArgsLen("replace", arguments.length, 3, 4);
     Sk.builtin.pyCheckType("oldS", "string", Sk.builtin.checkString(oldS));
     Sk.builtin.pyCheckType("newS", "string", Sk.builtin.checkString(newS));
     if ((count !== undefined) && !Sk.builtin.checkInt(count)) {
@@ -690,7 +693,7 @@ Sk.builtin.str.prototype["zfill"] = new Sk.builtin.func(function (self, len) {
     var offset;
     var pad = "";
 
-    Sk.builtin.pyCheckArgs("zfill", arguments, 2, 2);
+    Sk.builtin.pyCheckArgsLen("zfill", arguments.length, 2, 2);
     if (! Sk.builtin.checkInt(len)) {
         throw new Sk.builtin.TypeError("integer argument exepected, got " + Sk.abstr.typeName(len));
     }
@@ -710,12 +713,12 @@ Sk.builtin.str.prototype["zfill"] = new Sk.builtin.func(function (self, len) {
 });
 
 Sk.builtin.str.prototype["isdigit"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("isdigit", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("isdigit", arguments.length, 1, 1);
     return new Sk.builtin.bool( /^\d+$/.test(self.v));
 });
 
 Sk.builtin.str.prototype["isspace"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("isspace", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("isspace", arguments.length, 1, 1);
     return new Sk.builtin.bool( /^\s+$/.test(self.v));
 });
 
@@ -731,7 +734,7 @@ Sk.builtin.str.prototype["expandtabs"] = new Sk.builtin.func(function (self, tab
     var spaces;
     var expanded;
 
-    Sk.builtin.pyCheckArgs("expandtabs", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("expandtabs", arguments.length, 1, 2);
 
 
     if ((tabsize !== undefined) && ! Sk.builtin.checkInt(tabsize)) {
@@ -752,7 +755,7 @@ Sk.builtin.str.prototype["expandtabs"] = new Sk.builtin.func(function (self, tab
 
 Sk.builtin.str.prototype["swapcase"] = new Sk.builtin.func(function (self) {
     var ret;
-    Sk.builtin.pyCheckArgs("swapcase", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("swapcase", arguments.length, 1, 1);
 
 
     ret = self.v.replace(/[a-z]/gi, function(c) {
@@ -773,7 +776,7 @@ Sk.builtin.str.prototype["splitlines"] = new Sk.builtin.func(function (self, kee
     var eol;
     var sol = 0;
     var slice;
-    Sk.builtin.pyCheckArgs("splitlines", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("splitlines", arguments.length, 1, 2);
     if ((keepends !== undefined) && ! Sk.builtin.checkBool(keepends)) {
         throw new Sk.builtin.TypeError("boolean argument expected, got " + Sk.abstr.typeName(keepends));
     }
@@ -819,7 +822,7 @@ Sk.builtin.str.prototype["splitlines"] = new Sk.builtin.func(function (self, kee
 Sk.builtin.str.prototype["title"] = new Sk.builtin.func(function (self) {
     var ret;
 
-    Sk.builtin.pyCheckArgs("title", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("title", arguments.length, 1, 1);
 
     ret = self.v.replace(/[a-z][a-z]*/gi, function(str) {
         return str[0].toUpperCase() + str.substr(1).toLowerCase();
@@ -829,28 +832,28 @@ Sk.builtin.str.prototype["title"] = new Sk.builtin.func(function (self) {
 });
 
 Sk.builtin.str.prototype["isalpha"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("isalpha", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("isalpha", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && goog.string.isAlpha(self.v));
 });
 
 Sk.builtin.str.prototype["isalnum"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("isalnum", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("isalnum", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && goog.string.isAlphaNumeric(self.v));
 });
 
 // does not account for unicode numeric values
 Sk.builtin.str.prototype["isnumeric"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("isnumeric", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("isnumeric", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && goog.string.isNumeric(self.v));
 });
 
 Sk.builtin.str.prototype["islower"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("islower", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("islower", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && /[a-z]/.test(self.v) && !/[A-Z]/.test(self.v));
 });
 
 Sk.builtin.str.prototype["isupper"] = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("isupper", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("isupper", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && !/[a-z]/.test(self.v) && /[A-Z]/.test(self.v));
 });
 
@@ -862,7 +865,7 @@ Sk.builtin.str.prototype["istitle"] = new Sk.builtin.func(function (self) {
     var previous_is_cased = false;
     var pos;
     var ch;
-    Sk.builtin.pyCheckArgs("istitle", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("istitle", arguments.length, 1, 1);
     for (pos = 0; pos < input.length; pos ++) {
         ch = input.charAt(pos);
         if (! /[a-z]/.test(ch) && /[A-Z]/.test(ch)) {
@@ -1175,7 +1178,7 @@ Sk.abstr.setUpInheritance("iterator", Sk.builtin.str_iter_, Sk.builtin.object);
 Sk.builtin.str_iter_.prototype.__class__ = Sk.builtin.str_iter_;
 
 Sk.builtin.str_iter_.prototype.__iter__ = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__iter__", arguments, 0, 0, true, false);
+    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 0, 0, true, false);
     return self;
 });
 

--- a/src/structseq.js
+++ b/src/structseq.js
@@ -11,7 +11,7 @@ Sk.builtin.make_structseq = function (module, name, fields, doc) {
     }
 
     var cons = function structseq_constructor(arg) {
-        Sk.builtin.pyCheckArgs(nm, arguments, 1, 1);
+        Sk.builtin.pyCheckArgsLen(nm, arguments.length, 1, 1);
         var o;
         var it, i, v;
         if (!(this instanceof Sk.builtin.structseq_types[nm])) {

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -5,6 +5,7 @@
 Sk.builtin.tuple = function (L) {
     var it, i;
     if (!(this instanceof Sk.builtin.tuple)) {
+        Sk.builtin.pyCheckArgsLen("tuple", arguments.length, 0, 1);
         return new Sk.builtin.tuple(L);
     }
 
@@ -120,7 +121,7 @@ Sk.builtin.tuple.prototype.nb$multiply = Sk.builtin.tuple.prototype.sq$repeat;
 Sk.builtin.tuple.prototype.nb$inplace_multiply = Sk.builtin.tuple.prototype.sq$repeat;
 
 Sk.builtin.tuple.prototype.__iter__ = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgs("__iter__", arguments, 1, 1);
+    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 1, 1);
     return new Sk.builtin.tuple_iter_(self);
 });
 

--- a/src/type.js
+++ b/src/type.js
@@ -690,7 +690,7 @@ Sk.builtin.type.prototype.tp$richcompare = function (other, op) {
 };
 
 Sk.builtin.type.prototype["__format__"] = function(self, format_spec) {
-    Sk.builtin.pyCheckArgs("__format__", arguments, 1, 2);
+    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 1, 2);
     return new Sk.builtin.str(self);
 };
 

--- a/src/typeobject.js
+++ b/src/typeobject.js
@@ -32,7 +32,7 @@ Sk.builtin.PyType_IsSubtype = function PyType_IsSubtype(a, b) {
  * Sk.builtin.super_
  */
 Sk.builtin.super_ = function super_ (a_type, self) {
-    Sk.builtin.pyCheckArgs("super", arguments, 1);
+    Sk.builtin.pyCheckArgsLen("super", arguments.length, 1);
 
     if (!(this instanceof Sk.builtin.super_)) {
         return new Sk.builtin.super_(a_type, self);


### PR DESCRIPTION
This introduces pyCheckArgsLen which just takes the number of arguments passed to a function, instead of taking "arguments", as pyCheckArgs does.  I changed the name and left in pyCheckArgs in case there are other modules out there using it.  Although I'd like to just delete pyCheckArgs so that people use the new version going forward.

This gives the optimizer a better chance at optimizing functions (see #295).