### PR TITLE
Fix string formatting

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -110,7 +110,7 @@ Sk.ffi.remapToJs = function (obj) {
         return Sk.builtin.asnum$(obj);
     } else if (obj instanceof Sk.builtin.lng) {
         return Sk.builtin.asnum$(obj);
-    } else if (typeof obj === "number" || typeof obj === "boolean") {
+    } else if (typeof obj === "number" || typeof obj === "boolean" || typeof obj === "string") {
         return obj;
     } else if (obj === undefined) {
         return undefined;

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -86,7 +86,7 @@ var format = function (kwa) {
                 if (container instanceof Sk.builtin.dict) {
                     value = Sk.abstr.objectGetItem(container, new Sk.builtin.str(element_index), false);
                 } else {
-                    value = Sk.abstr.objectGetItem(container, new Sk.builtin.int_(new Sk.builtin.str(element_index)), false);
+                    value = Sk.abstr.objectGetItem(container, new Sk.builtin.int_(parseInt(element_index, 10)), false);
                 }
             }
             index++;

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -563,6 +563,8 @@ Sk.misceval.objectRepr = function (v) {
         return new Sk.builtin.str("False");
     } else if (typeof v === "number") {
         return new Sk.builtin.str("" + v);
+    } else if (typeof v === "string") {
+        return new Sk.builtin.str(v);
     } else if (!v["$r"]) {
         if (v.tp$name) {
             return new Sk.builtin.str("<" + v.tp$name + " object>");

--- a/test/unit/test_strformat.py
+++ b/test/unit/test_strformat.py
@@ -32,7 +32,7 @@ class string_format(unittest.TestCase):
     def test_arg_items(self):
         coord = (3, 5)
         self.assertEqual('X: 3;  Y: 5','X: {0[0]};  Y: {0[1]}'.format(coord))
-#        self.assertEqual('My name is Fred',"My name is {0[name]}".format({'name':'Fred'}))
+        self.assertEqual('My name is Fred',"My name is {0[name]}".format({'name':'Fred'}))
 
 # TODO:  make these pass
 #    def test_width(self):

--- a/test/unit/test_strformat.py
+++ b/test/unit/test_strformat.py
@@ -66,6 +66,10 @@ class string_format(unittest.TestCase):
         total = 22
         self.assertEqual('Correct answers: 88.64%', 'Correct answers: {:.2%}'.format(points/total))
 
+    def test_sequence(self):
+        self.assertEqual('(1, 2, 3)', '{}'.format((1, 2, 3)))
+        self.assertEqual('[1, 2, 3]', '{}'.format([1, 2, 3]))
+
     ## Datetime requires more work.
     
     # def test_datetome(self):


### PR DESCRIPTION
This addresses #834 but I'm not sure it's the best solution.  The string formatting code is fast and loose with Python vs. Javascript types, making it a bit messy.  I think I did manage to fix the reported bug (and a few related bugs) without breaking anything else, though.  But I'm not happy with the back and forth conversions that were needed.

This would benefit from others running more code through it before accepting it, though, to make sure that I did not introduce any regressions that are not captured by the somewhat limited test suite.