### PR TITLE
Convert callsim to not mess with arguments.

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -180,7 +180,7 @@ Sk.abstr.binary_op_ = function (v, w, opname) {
             if (wop.call) {
                 ret = wop.call(w, v);
             } else {
-                ret = Sk.misceval.callsim(wop, w, v);
+                ret = Sk.misceval.callsimArray(wop, [w, v]);
             }
             if (ret !== undefined && ret !== Sk.builtin.NotImplemented.NotImplemented$) {
                 return ret;
@@ -193,7 +193,7 @@ Sk.abstr.binary_op_ = function (v, w, opname) {
         if (vop.call) {
             ret = vop.call(v, w);
         } else {
-            ret = Sk.misceval.callsim(vop, v, w);
+            ret = Sk.misceval.callsimArray(vop, [v, w]);
         }
         if (ret !== undefined && ret !== Sk.builtin.NotImplemented.NotImplemented$) {
             return ret;
@@ -206,7 +206,7 @@ Sk.abstr.binary_op_ = function (v, w, opname) {
             if (wop.call) {
                 ret = wop.call(w, v);
             } else {
-                ret = Sk.misceval.callsim(wop, w, v);
+                ret = Sk.misceval.callsimArray(wop, [w, v]);
             }
             if (ret !== undefined && ret !== Sk.builtin.NotImplemented.NotImplemented$) {
                 return ret;
@@ -224,7 +224,7 @@ Sk.abstr.binary_iop_ = function (v, w, opname) {
         if (vop.call) {
             ret = vop.call(v, w);
         } else {  // assume that vop is an __xxx__ type method
-            ret = Sk.misceval.callsim(vop, v, w);
+            ret = Sk.misceval.callsimArray(vop, [v, w]);
         }
         if (ret !== undefined && ret !== Sk.builtin.NotImplemented.NotImplemented$) {
             return ret;
@@ -240,7 +240,7 @@ Sk.abstr.unary_op_ = function (v, opname) {
         if (vop.call) {
             ret = vop.call(v);
         } else {  // assume that vop is an __xxx__ type method
-            ret = Sk.misceval.callsim(vop, v); //  added to be like not-in-place... is this okay?
+            ret = Sk.misceval.callsimArray(vop, [v]); //  added to be like not-in-place... is this okay?
         }
         if (ret !== undefined) {
             return ret;
@@ -482,7 +482,7 @@ Sk.abstr.sequenceContains = function (seq, ob, canSuspend) {
     special = Sk.abstr.lookupSpecial(seq, "__contains__");
     if (special != null) {
         // method on builtin, provide this arg
-        return Sk.misceval.isTrue(Sk.misceval.callsim(special, seq, ob));
+        return Sk.misceval.isTrue(Sk.misceval.callsimArray(special, [seq, ob]));
     }
 
     if (!Sk.builtin.checkIterable(seq)) {
@@ -515,7 +515,7 @@ Sk.abstr.sequenceGetIndexOf = function (seq, ob) {
     var i, it;
     var index;
     if (seq.index) {
-        return Sk.misceval.callsim(seq.index, seq, ob);
+        return Sk.misceval.callsimArray(seq.index, [seq, ob]);
     }
     if (Sk.builtin.checkIterable(seq)) {
         index = 0;
@@ -538,7 +538,7 @@ Sk.abstr.sequenceGetCountOf = function (seq, ob) {
     var i, it;
     var count;
     if (seq.count) {
-        return Sk.misceval.callsim(seq.count, seq, ob);
+        return Sk.misceval.callsimArray(seq.count, [seq, ob]);
     }
     if (Sk.builtin.checkIterable(seq)) {
         count = 0;
@@ -682,7 +682,7 @@ Sk.abstr.objectFormat = function (obj, format_spec) {
     }
 
     // And call it
-    result = Sk.misceval.callsim(meth, obj, format_spec);
+    result = Sk.misceval.callsimArray(meth, [obj, format_spec]);
     if (!Sk.builtin.checkString(result)) {
         throw new Sk.builtin.TypeError("__format__ must return a str, not " + Sk.abstr.typeName(result));
     }
@@ -874,7 +874,7 @@ Sk.abstr.iter = function(obj) {
         this.tp$iternext = function () {
             var ret;
             try {
-                ret = Sk.misceval.callsim(this.getitem, this.myobj, Sk.ffi.remapToPy(this.idx));
+                ret = Sk.misceval.callsimArray(this.getitem, [this.myobj, Sk.ffi.remapToPy(this.idx)]);
             } catch (e) {
                 if (e instanceof Sk.builtin.IndexError || e instanceof Sk.builtin.StopIteration) {
                     return undefined;
@@ -890,7 +890,7 @@ Sk.abstr.iter = function(obj) {
     if (obj.tp$getattr) {
         iter =  Sk.abstr.lookupSpecial(obj,"__iter__");
         if (iter) {
-            ret = Sk.misceval.callsim(iter, obj);
+            ret = Sk.misceval.callsimArray(iter, [obj]);
             if (ret.tp$iternext) {
                 return ret;
             }

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -237,9 +237,9 @@ Sk.builtin.round = function round (number, ndigits) {
     if (special != null) {
         // method on builtin, provide this arg
         if (!Sk.builtin.checkFunction(number)) {
-            return Sk.misceval.callsim(special, number, ndigits);
+            return Sk.misceval.callsimArray(special, [number, ndigits]);
         } else {
-            return Sk.misceval.callsim(special, number);
+            return Sk.misceval.callsimArray(special, [number]);
         }
     } else {
         throw new Sk.builtin.TypeError("a float is required");
@@ -276,7 +276,7 @@ Sk.builtin.len = function len (item) {
         if (Sk.builtin.checkFunction(item)) {
             special = Sk.abstr.lookupSpecial(item, "__len__");
             if (special != null) {
-                return Sk.misceval.callsim(special, item);
+                return Sk.misceval.callsimArray(special, [item]);
             } else {
                 if (Sk.__future__.exceptions) {
                     throw new Sk.builtin.TypeError("object of type '" + Sk.abstr.typeName(item) + "' has no len()");
@@ -470,13 +470,13 @@ Sk.builtin.abs = function abs (x) {
     if (Sk.builtin.checkNumber(x)) {
         return Sk.builtin.assk$(Math.abs(Sk.builtin.asnum$(x)));
     } else if (Sk.builtin.checkComplex(x)) {
-        return Sk.misceval.callsim(x.__abs__, x);
+        return Sk.misceval.callsimArray(x.__abs__, [x]);
     }
 
     // call custom __abs__ methods
     if (x.tp$getattr) {
         var f = x.tp$getattr("__abs__");
-        return Sk.misceval.callsim(f);
+        return Sk.misceval.callsimArray(f);
     }
 
     throw new TypeError("bad operand type for abs(): '" + Sk.abstr.typeName(x) + "'");
@@ -625,7 +625,7 @@ Sk.builtin.dir = function dir (x) {
     var special = Sk.abstr.lookupSpecial(x, "__dir__");
     if(special != null) {
         // method on builtin, provide this arg
-        _seq = Sk.misceval.callsim(special, x);
+        _seq = Sk.misceval.callsimArray(special, [x]);
 
         if (!Sk.builtin.checkSequence(_seq)) {
             throw new Sk.builtin.TypeError("__dir__ must return sequence.");
@@ -991,7 +991,7 @@ Sk.builtin.reduce = function reduce (fun, seq, initializer) {
     for (item = iter.tp$iternext();
          item !== undefined;
          item = iter.tp$iternext()) {
-        accum_value = Sk.misceval.callsim(fun, accum_value, item);
+        accum_value = Sk.misceval.callsimArray(fun, [accum_value, item]);
     }
 
     return accum_value;
@@ -1045,7 +1045,7 @@ Sk.builtin.filter = function filter (fun, iterable) {
         if (fun === Sk.builtin.none.none$) {
             result = new Sk.builtin.bool( item);
         } else {
-            result = Sk.misceval.callsim(fun, item);
+            result = Sk.misceval.callsimArray(fun, [item]);
         }
 
         if (Sk.misceval.isTrue(result)) {
@@ -1248,7 +1248,7 @@ Sk.builtin.reversed = function reversed (seq) {
 
     var special = Sk.abstr.lookupSpecial(seq, "__reversed__");
     if (special != null) {
-        return Sk.misceval.callsim(special, seq);
+        return Sk.misceval.callsimArray(special, [seq]);
     } else {
         if (!Sk.builtin.checkSequence(seq)) {
             throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(seq) + "' object is not a sequence");
@@ -1274,7 +1274,7 @@ Sk.builtin.reversed = function reversed (seq) {
                 }
 
                 try {
-                    ret = Sk.misceval.callsim(this.getitem, this.myobj, Sk.ffi.remapToPy(this.idx));
+                    ret = Sk.misceval.callsimArray(this.getitem, [this.myobj, Sk.ffi.remapToPy(this.idx)]);
                 } catch (e) {
                     if (e instanceof Sk.builtin.IndexError) {
                         return undefined;

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -861,12 +861,12 @@ Sk.builtin.raw_input = function (prompt) {
 
     return Sk.misceval.chain(Sk.importModule("sys", false, true), function (sys) {
         if (Sk.inputfunTakesPrompt) {
-            return Sk.misceval.callsimOrSuspend(Sk.builtin.file.$readline, sys["$d"]["stdin"], null, lprompt);
+            return Sk.misceval.callsimOrSuspendArray(Sk.builtin.file.$readline, [sys["$d"]["stdin"], null, lprompt]);
         } else {
             return Sk.misceval.chain(undefined, function() {
-                return Sk.misceval.callsimOrSuspend(sys["$d"]["stdout"]["write"], sys["$d"]["stdout"], new Sk.builtin.str(lprompt));
+                return Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdout"]["write"], [sys["$d"]["stdout"], new Sk.builtin.str(lprompt)]);
             }, function () {
-                return Sk.misceval.callsimOrSuspend(sys["$d"]["stdin"]["readline"], sys["$d"]["stdin"]);
+                return Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdin"]["readline"], [sys["$d"]["stdin"]]);
             });
         }
     });

--- a/src/compile.js
+++ b/src/compile.js
@@ -1235,7 +1235,7 @@ Compiler.prototype.craise = function (s) {
             // handles: raise Error OR raise someinstance
             exc = this._gr("err", this.vexpr(s.type));
             out("if(",exc," instanceof Sk.builtin.type) {",
-                "throw Sk.misceval.callsim(", exc, ");",
+                "throw Sk.misceval.callsimArray(", exc, ");",
                 "} else if(typeof(",exc,") === 'function') {",
                 "throw ",exc,"();",
                 "} else {",
@@ -1288,7 +1288,7 @@ Compiler.prototype.ctryexcept = function (s) {
             next = (i == n - 1) ? unhandled : handlers[i + 1];
 
             // var isinstance = this.nameop(new Sk.builtin.str("isinstance"), Load));
-            // var check = this._gr('call', "Sk.misceval.callsim(", isinstance, ", $err, ", handlertype, ")");
+            // var check = this._gr('call', "Sk.misceval.callsimArray(", isinstance, ", [$err, ", handlertype, "])");
 
             check = this._gr("instance", "Sk.misceval.isTrue(Sk.builtin.isinstance($err, ", handlertype, "))");
             this._jumpfalse(check, next);
@@ -2027,7 +2027,7 @@ Compiler.prototype.cgenexp = function (e) {
     // but the code builder builds a wrapper that makes generators for normal
     // function generators, so we just do it outside (even just new'ing it
     // inline would be fine).
-    var gener = this._gr("gener", "Sk.misceval.callsim(", gen, ");");
+    var gener = this._gr("gener", "Sk.misceval.callsimArray(", gen, ");");
     // stuff the outermost iterator into the generator after evaluating it
     // outside of the function. it's retrieved by the fixed name above.
     out(gener, ".gi$locals.$iter0=Sk.abstr.iter(", this.vexpr(e.generators[0].iter), ");");

--- a/src/compile.js
+++ b/src/compile.js
@@ -539,7 +539,11 @@ Compiler.prototype.ccall = function (e) {
             args.push("$gbl.__class__");
             args.push("self");
         }
-        out ("$ret = Sk.misceval.callsimOrSuspend(", func, args.length > 0 ? "," : "", args, ");");
+        if (args.length > 0) {
+            out ("$ret = Sk.misceval.callsimOrSuspendArray(", func, ", [", args, "]);");
+        } else {
+            out ("$ret = Sk.misceval.callsimOrSuspendArray(", func, ");");
+        }
     }
 
     this._checkSuspension(e);
@@ -1416,7 +1420,7 @@ Compiler.prototype.cwith = function (s) {
     // value = mgr.__enter__()
     out("$ret = Sk.abstr.gattr(",mgr,",'__enter__', true);");
     this._checkSuspension(s);
-    out("$ret = Sk.misceval.callsimOrSuspend($ret);");
+    out("$ret = Sk.misceval.callsimOrSuspendArray($ret);");
     this._checkSuspension(s);
     value = this._gr("value", "$ret");
 
@@ -1451,7 +1455,7 @@ Compiler.prototype.cwith = function (s) {
     this.popFinallyBlock();
 
     //   exit(None, None, None)
-    out("$ret = Sk.misceval.callsimOrSuspend(",exit,",Sk.builtin.none.none$,Sk.builtin.none.none$,Sk.builtin.none.none$);");
+    out("$ret = Sk.misceval.callsimOrSuspendArray(",exit,",[Sk.builtin.none.none$,Sk.builtin.none.none$,Sk.builtin.none.none$]);");
     this._checkSuspension(s);
     // Ignore $ret.
 
@@ -1900,7 +1904,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     else {
         var res;
         if (decos.length > 0) {
-            out("$ret = Sk.misceval.callsimOrSuspend(", scopename, ".$decorators[0], new Sk.builtins['function'](", scopename, ",$gbl", frees, "));");
+            out("$ret = Sk.misceval.callsimOrSuspendArray(", scopename, ".$decorators[0], [new Sk.builtins['function'](", scopename, ",$gbl", frees, ")]);");
             this._checkSuspension();
             return this._gr("funcobj", "$ret");
         }

--- a/src/complex.js
+++ b/src/complex.js
@@ -218,7 +218,7 @@ Sk.builtin.complex.try_complex_special_method = function (op) {
 
     if (f != null) {
         // method on builtin, provide this arg
-        res = Sk.misceval.callsim(f, op);
+        res = Sk.misceval.callsimArray(f, [op]);
 
         return res;
     }

--- a/src/dict.js
+++ b/src/dict.js
@@ -357,7 +357,7 @@ Sk.builtin.dict.prototype.dict_merge = function(b) {
         }
     } else {
         // generic slower way
-        var keys = Sk.misceval.callsim(b["keys"], b);
+        var keys = Sk.misceval.callsimArray(b["keys"], [b]);
         for (iter = Sk.abstr.iter(keys), k = iter.tp$iternext(); k !== undefined; k = iter.tp$iternext()) {
             v = b.tp$getitem(k); // get value
             if (v === undefined) {

--- a/src/file.js
+++ b/src/file.js
@@ -81,7 +81,7 @@ Sk.builtin.file.prototype["__enter__"] = new Sk.builtin.func(function __enter__(
 });
 
 Sk.builtin.file.prototype["__exit__"] = new Sk.builtin.func(function __exit__(self) {
-    return Sk.misceval.callsim(Sk.builtin.file.prototype["close"], self);
+    return Sk.misceval.callsimArray(Sk.builtin.file.prototype["close"], [self]);
 });
 
 Sk.builtin.file.prototype.tp$iter = function () {

--- a/src/float.js
+++ b/src/float.js
@@ -60,7 +60,7 @@ Sk.builtin.float_ = function (x) {
     var special = Sk.abstr.lookupSpecial(x, "__float__");
     if (special != null) {
         // method on builtin, provide this arg
-        return Sk.misceval.callsim(special, x);
+        return Sk.misceval.callsimArray(special, [x]);
     }
 
     throw new Sk.builtin.TypeError("float() argument must be a string or a number");
@@ -170,7 +170,7 @@ Sk.builtin.float_.PyFloat_AsDouble = function (op) {
     }
 
     // call internal float method
-    fo = Sk.misceval.callsim(f, op);
+    fo = Sk.misceval.callsimArray(f, [op]);
 
     // return value of __float__ must be a python float
     if (!Sk.builtin.float_.PyFloat_Check(fo)) {

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -45,7 +45,7 @@ var format = function (kwa) {
 
     if(kwargs.size !== 0){
 
-        var kwItems = Sk.misceval.callsim(Sk.builtin.dict.prototype["items"], kwargs);
+        var kwItems = Sk.misceval.callsimArray(Sk.builtin.dict.prototype["items"], [kwargs]);
 
         for (var n in kwItems.v){
 

--- a/src/int.js
+++ b/src/int.js
@@ -48,9 +48,9 @@ Sk.builtin.int_ = function (x, base) {
         if (Sk.builtin.checkFloat(base)) {
             throw new Sk.builtin.TypeError("integer argument expected, got " + Sk.abstr.typeName(base));
         } else if (base.__index__) {
-            base = Sk.misceval.callsim(base.__index__, base);
+            base = Sk.misceval.callsimArray(base.__index__, [base]);
         } else if(base.__int__) {
-            base = Sk.misceval.callsim(base.__int__, base);
+            base = Sk.misceval.callsimArray(base.__int__, [base]);
         } else {
             throw new Sk.builtin.AttributeError(Sk.abstr.typeName(base) + " instance has no attribute '__index__' or '__int__'");
         }
@@ -91,18 +91,18 @@ Sk.builtin.int_ = function (x, base) {
     if(x !== undefined && (x.tp$getattr && x.tp$getattr("__int__"))) {
         // calling a method which contains im_self and im_func
         // causes skulpt to automatically map the im_self as first argument
-        ret = Sk.misceval.callsim(x.tp$getattr("__int__"));
+        ret = Sk.misceval.callsimArray(x.tp$getattr("__int__"));
         magicName = "__int__";
     } else if(x !== undefined && x.__int__) {
         // required for internal types
         // __int__ method is on prototype
-        ret = Sk.misceval.callsim(x.__int__, x);
+        ret = Sk.misceval.callsimArray(x.__int__, [x]);
         magicName = "__int__";
     } else if(x !== undefined && (x.tp$getattr && x.tp$getattr("__trunc__"))) {
-        ret = Sk.misceval.callsim(x.tp$getattr("__trunc__"));
+        ret = Sk.misceval.callsimArray(x.tp$getattr("__trunc__"));
         magicName = "__trunc__";
     } else if(x !== undefined && x.__trunc__) {
-        ret = Sk.misceval.callsim(x.__trunc__, x);
+        ret = Sk.misceval.callsimArray(x.__trunc__, [x]);
         magicName = "__trunc__";
     }
 

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -61,7 +61,7 @@ Sk.builtin.iterator.prototype.tp$iternext = function (canSuspend) {
 
     if (this.getitem) {
         r = Sk.misceval.tryCatch(function() {
-            return Sk.misceval.callsimOrSuspend(self.getitem, self.obj, Sk.ffi.remapToPy(self.idx++));
+            return Sk.misceval.callsimOrSuspendArray(self.getitem, [self.obj, Sk.ffi.remapToPy(self.idx++)]);
         }, function(e) {
             if (e instanceof Sk.builtin.StopIteration || e instanceof Sk.builtin.IndexError) {
                 return undefined;
@@ -82,10 +82,10 @@ Sk.builtin.iterator.prototype.tp$iternext = function (canSuspend) {
     };
 
     if (this.call) {
-        r = Sk.misceval.chain(Sk.misceval.callsimOrSuspend(this.call, this.obj), checkSentinel);
+        r = Sk.misceval.chain(Sk.misceval.callsimOrSuspendArray(this.call, [this.obj]), checkSentinel);
     } else {
         var obj = /** @type {Object} */ (this.obj);
-        r = Sk.misceval.chain(Sk.misceval.callsimOrSuspend(obj), checkSentinel);
+        r = Sk.misceval.chain(Sk.misceval.callsimOrSuspendArray(obj), checkSentinel);
     }
 
     return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -18,7 +18,7 @@ Sk.builtin.iterator = function (obj, sentinel) {
     }
     objit = Sk.abstr.lookupSpecial(obj, "__iter__");
     if (objit) {
-        return Sk.misceval.callsim(objit, obj);
+        return Sk.misceval.callsimArray(objit, [obj]);
     }
     this.sentinel = sentinel;
     this.flag = false;

--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -106,7 +106,7 @@ $builtinmodule = function (name) {
                      item !== undefined;
                      item = iter.tp$iternext()) {
 
-                    Sk.misceval.callsim(self.internalIterable.append, self.internalIterable, item);
+                    Sk.misceval.callsimArray(self.internalIterable.append, [self.internalIterable, item]);
                 }
             }
         });
@@ -118,7 +118,7 @@ $builtinmodule = function (name) {
                 if (Sk.ffi.remapToJs(self.typecode) == "c") {
                     iterableJs = ", '" + Sk.ffi.remapToJs(self.internalIterable).join("") + "'";
                 } else {
-                    iterableJs = ", " + Sk.ffi.remapToJs(Sk.misceval.callsim(self.internalIterable.__repr__,  self.internalIterable));
+                    iterableJs = ", " + Sk.ffi.remapToJs(Sk.misceval.callsimArray(self.internalIterable.__repr__,  [self.internalIterable]));
                 }
             }
 
@@ -132,7 +132,7 @@ $builtinmodule = function (name) {
         });
 
         $loc.append = new Sk.builtin.func(function (self, item) {
-            Sk.misceval.callsim(self.internalIterable.append, self.internalIterable, item);
+            Sk.misceval.callsimArray(self.internalIterable.append, [self.internalIterable, item]);
             return Sk.builtin.none.none$;
         });
 
@@ -147,7 +147,7 @@ $builtinmodule = function (name) {
                  item !== undefined;
                  item = iter.tp$iternext()) {
 
-                Sk.misceval.callsim(self.internalIterable.append, self.internalIterable, item);
+                Sk.misceval.callsimArray(self.internalIterable.append, [self.internalIterable, item]);
             }
         });
     };

--- a/src/lib/collections.js
+++ b/src/lib/collections.js
@@ -45,7 +45,7 @@ var $builtinmodule = function (name) {
                 throw new Sk.builtin.KeyError(Sk.misceval.objectRepr(key));
             }
             else {
-                return Sk.misceval.callsim(this.default_factory);
+                return Sk.misceval.callsimArray(this.default_factory);
             }
         };
 
@@ -426,7 +426,7 @@ var $builtinmodule = function (name) {
                 self.orderedkeys.splice(idx, 1);
             }
 
-            return Sk.misceval.callsim(Sk.builtin.dict.prototype["pop"], self, key, d);
+            return Sk.misceval.callsimArray(Sk.builtin.dict.prototype["pop"], [self, key, d]);
         });
 
         mod.OrderedDict.prototype["popitem"] = new Sk.builtin.func(function (self, last) {
@@ -448,7 +448,7 @@ var $builtinmodule = function (name) {
                 key = self.orderedkeys[self.orderedkeys.length - 1];
             }
 
-            val = Sk.misceval.callsim(self["pop"], self, key);
+            val = Sk.misceval.callsimArray(self["pop"], [self, key]);
             return Sk.builtin.tuple([key, val]);
         });
 
@@ -490,7 +490,7 @@ var $builtinmodule = function (name) {
         };
 
         mod.namedtuple = new Sk.builtin.func(function (name, fields) {
-            if (Sk.ffi.remapToJs(Sk.misceval.callsim(keywds.$d['iskeyword'],name ))) {
+            if (Sk.ffi.remapToJs(Sk.misceval.callsimArray(keywds.$d['iskeyword'], [name]))) {
                 throw new Sk.builtin.ValueError("Type names and field names cannot be a keyword: " + name.v);
             }
             var nm = Sk.ffi.remapToJs(name);
@@ -508,7 +508,7 @@ var $builtinmodule = function (name) {
             }
             // import the keyword module here and use iskeyword
             for (i = 0; i < flds.length; i++) {
-                if (Sk.ffi.remapToJs(Sk.misceval.callsim(keywds.$d['iskeyword'],Sk.ffi.remapToPy(flds[i]))) ||
+                if (Sk.ffi.remapToJs(Sk.misceval.callsimArray(keywds.$d['iskeyword'], [Sk.ffi.remapToPy(flds[i])])) ||
                     startsw2.test(flds[i]) || (! alnum.test(flds[i]))
                 ) {
                     throw new Sk.builtin.ValueError("Type names and field names cannot be a keyword: " + flds[i]);

--- a/src/lib/document.js
+++ b/src/lib/document.js
@@ -5,7 +5,7 @@ var $builtinmodule = function (name) {
     mod.getElementById = new Sk.builtin.func(function (id) {
         var result = document.getElementById(id.v);
         if (result) {
-            return Sk.misceval.callsim(mod.Element, result);
+            return Sk.misceval.callsimArray(mod.Element, [result]);
         }
         return Sk.builtin.none.none$;
     });
@@ -13,7 +13,7 @@ var $builtinmodule = function (name) {
     mod.createElement = new Sk.builtin.func(function (eName) {
         var r = document.createElement(eName.v);
         if (r) {
-            return Sk.misceval.callsim(mod.Element, r);
+            return Sk.misceval.callsimArray(mod.Element, [r]);
         }
     });
 
@@ -22,7 +22,7 @@ var $builtinmodule = function (name) {
         var r = document.getElementsByTagName(tag.v)
         var reslist = [];
         for (var i = r.length - 1; i >= 0; i--) {
-            reslist.push(Sk.misceval.callsim(mod.Element, r[i]))
+            reslist.push(Sk.misceval.callsimArray(mod.Element, [r[i]]))
         }
         return new Sk.builtin.list(reslist)
     });
@@ -31,7 +31,7 @@ var $builtinmodule = function (name) {
         var r = document.getElementsByClassName(cname.v);
         var reslist = [];
         for (var i = 0; i < r.length; i++) {
-            reslist.push(Sk.misceval.callsim(mod.Element, r[i]));
+            reslist.push(Sk.misceval.callsimArray(mod.Element, [r[i]]));
         }
         ;
         return new Sk.builtin.list(reslist);
@@ -41,7 +41,7 @@ var $builtinmodule = function (name) {
         var r = document.getElementsByName(cname.v);
         var reslist = [];
         for (var i = 0; i < r.length; i++) {
-            reslist.push(Sk.misceval.callsim(mod.Element, r[i]));
+            reslist.push(Sk.misceval.callsimArray(mod.Element, [r[i]]));
         }
         ;
         return new Sk.builtin.list(reslist);

--- a/src/lib/image.js
+++ b/src/lib/image.js
@@ -129,8 +129,8 @@ $builtinmodule = function (name) {
             Sk.builtin.pyCheckArgsLen("getpixels", arguments.length, 1, 1);
 
             for (i = 0; i < self.image.height * self.image.width; i++) {
-                arr[i] = Sk.misceval.callsim(self.getPixel, self,
-                    i % self.image.width, Math.floor(i / self.image.width));
+                arr[i] = Sk.misceval.callsimArray(self.getPixel, [self,
+                    i % self.image.width, Math.floor(i / self.image.width)]);
             }
             return new Sk.builtin.tuple(arr);
         };
@@ -177,7 +177,7 @@ $builtinmodule = function (name) {
             red = self.imagedata.data[index];
             green = self.imagedata.data[index + 1];
             blue = self.imagedata.data[index + 2];
-            return Sk.misceval.callsim(mod.Pixel, red, green, blue, x, y);
+            return Sk.misceval.callsimArray(mod.Pixel, [red, green, blue, x, y]);
         };
 
         // alias the function with pep8 compliant snake_case and legacy camelCase
@@ -230,9 +230,9 @@ $builtinmodule = function (name) {
             y = Sk.builtin.asnum$(y);
             checkPixelRange(self, x, y);
             index = (y * 4) * self.width + (x * 4);
-            self.imagedata.data[index] = Sk.builtin.asnum$(Sk.misceval.callsim(pix.getRed, pix));
-            self.imagedata.data[index + 1] = Sk.builtin.asnum$(Sk.misceval.callsim(pix.getGreen, pix));
-            self.imagedata.data[index + 2] = Sk.builtin.asnum$(Sk.misceval.callsim(pix.getBlue, pix));
+            self.imagedata.data[index] = Sk.builtin.asnum$(Sk.misceval.callsimArray(pix.getRed, [pix]));
+            self.imagedata.data[index + 1] = Sk.builtin.asnum$(Sk.misceval.callsimArray(pix.getGreen, [pix]));
+            self.imagedata.data[index + 2] = Sk.builtin.asnum$(Sk.misceval.callsimArray(pix.getBlue, [pix]));
             self.imagedata.data[index + 3] = 255;
             return updateCanvasAndSuspend(self, x, y);
         };
@@ -253,9 +253,9 @@ $builtinmodule = function (name) {
             y = Math.floor(count / self.image.width);
             checkPixelRange(self, x, y);
             index = (y * 4) * self.width + (x * 4);
-            self.imagedata.data[index] = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getRed, pixel));
-            self.imagedata.data[index + 1] = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getGreen, pixel));
-            self.imagedata.data[index + 2] = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getBlue, pixel));
+            self.imagedata.data[index] = Sk.builtin.asnum$(Sk.misceval.callsimArray(pixel.getRed, [pixel]));
+            self.imagedata.data[index + 1] = Sk.builtin.asnum$(Sk.misceval.callsimArray(pixel.getGreen, [pixel]));
+            self.imagedata.data[index + 2] = Sk.builtin.asnum$(Sk.misceval.callsimArray(pixel.getBlue, [pixel]));
             self.imagedata.data[index + 3] = 255;
             return updateCanvasAndSuspend(self, x, y);
         };
@@ -271,13 +271,13 @@ $builtinmodule = function (name) {
             var y;
             var index;
             Sk.builtin.pyCheckArgsLen("updatepixel", arguments.length, 2, 2);
-            x = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getX, pixel));
-            y = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getY, pixel));
+            x = Sk.builtin.asnum$(Sk.misceval.callsimArray(pixel.getX, [pixel]));
+            y = Sk.builtin.asnum$(Sk.misceval.callsimArray(pixel.getY, [pixel]));
             checkPixelRange(self, x, y);
             index = (y * 4) * self.width + (x * 4);
-            self.imagedata.data[index] = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getRed, pixel));
-            self.imagedata.data[index + 1] = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getGreen, pixel));
-            self.imagedata.data[index + 2] = Sk.builtin.asnum$(Sk.misceval.callsim(pixel.getBlue, pixel));
+            self.imagedata.data[index] = Sk.builtin.asnum$(Sk.misceval.callsimArray(pixel.getRed, [pixel]));
+            self.imagedata.data[index + 1] = Sk.builtin.asnum$(Sk.misceval.callsimArray(pixel.getGreen, [pixel]));
+            self.imagedata.data[index + 2] = Sk.builtin.asnum$(Sk.misceval.callsimArray(pixel.getBlue, [pixel]));
             self.imagedata.data[index + 3] = 255;
             return updateCanvasAndSuspend(self, x, y);
         };
@@ -342,7 +342,7 @@ $builtinmodule = function (name) {
                     win = Sk.builtin.asnum$(win);
                     ulx = Sk.builtin.asnum$(ulx);
                     uly = Sk.builtin.asnum$(uly);
-                    can = Sk.misceval.callsim(win.getWin, win);
+                    can = Sk.misceval.callsimArray(win.getWin, [win]);
                     ctx = can.getContext("2d");
                     if (ulx === undefined) {
                         ulx = 0;

--- a/src/lib/operator.js
+++ b/src/lib/operator.js
@@ -54,7 +54,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.abs = new Sk.builtin.func(function (obj) {
-        return Sk.misceval.callsim(Sk.builtin.abs, obj);
+        return Sk.misceval.callsimArray(Sk.builtin.abs, [obj]);
     });
     mod.__abs__ = mod.abs;
 

--- a/src/lib/processing.js
+++ b/src/lib/processing.js
@@ -4,9 +4,9 @@
   Testing/debugging:
 
   ProcessingJS from Skulpt:
-  Sk.misceval.callsim(Sk.globals.processing.$d.PShapeSVG, 
+  Sk.misceval.callsimArray(Sk.globals.processing.$d.PShapeSVG, [
       new Sk.builtin.str("string"), 
-      new Sk.builtin.str("bot1.svg"))
+      new Sk.builtin.str("bot1.svg")])
 
   ProcessingJS direct:
   p = Processing.instances[0]
@@ -490,10 +490,10 @@ var $builtinmodule = function (name) {
 
     mod.blendColor = new Sk.builtin.func(function (c1, c2, mode) {
 	// blendColor(c1,c2,MODE)
-        var c = Sk.misceval.callsim(mod.color,
+        var c = Sk.misceval.callsimArray(mod.color, [
 				    new Sk.builtin.int_(0),
 				    new Sk.builtin.int_(0),
-				    new Sk.builtin.int_(0));
+				    new Sk.builtin.int_(0)]);
 	c.v = mod.processing.blendColor(c1.v, c2.v, mode.v);
 	return c;
     });
@@ -543,7 +543,7 @@ var $builtinmodule = function (name) {
 	// createFont(name, size)
 	// createFont(name, size, smooth)
 	// createFont(name, size, smooth, charset)
-	var font = Sk.misceval.callsim(mod.PFont);
+	var font = Sk.misceval.callsimArray(mod.PFont);
         if (typeof(smooth) === "undefined") {
 	    font.v = mod.processing.createFont(name.v, size.v);
 	} else if (typeof(charset) === "undefined") {
@@ -557,7 +557,7 @@ var $builtinmodule = function (name) {
     mod.createGraphics = new Sk.builtin.func(function (width, height, renderer, filename) {
 	// createGraphics(width, height, renderer)
 	// createGraphics(width, height, renderer, filename)
-	var graphics = Sk.misceval.callsim(mod.PGraphics);
+	var graphics = Sk.misceval.callsimArray(mod.PGraphics);
         if (typeof(filename) === "undefined") {
 	    graphics.v = mod.processing.createGraphics(width.v, height.v, renderer.v);
 	} else {
@@ -567,7 +567,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.createImage = new Sk.builtin.func(function (width, height, format) {
-	var image = Sk.misceval.callsim(mod.PImage);
+	var image = Sk.misceval.callsimArray(mod.PImage);
 	image.v = mod.processing.createImage(width.v, height.v, format.v);
 	return image;
     });
@@ -740,10 +740,10 @@ var $builtinmodule = function (name) {
     mod.lerpColor = new Sk.builtin.func(function (c1, c2, amt) {
 	// lerpColor(c1, c2, amt)
 	// returns color
-        var c = Sk.misceval.callsim(mod.color,
+        var c = Sk.misceval.callsimArray(mod.color, [
 				    new Sk.builtin.int_(0),
 				    new Sk.builtin.int_(0),
-				    new Sk.builtin.int_(0));
+				    new Sk.builtin.int_(0)]);
 	c.v = mod.processing.lerpColor(c1.v, c2.v, amt.v);
 	return c;
     });
@@ -771,7 +771,7 @@ var $builtinmodule = function (name) {
     mod.loadFont = new Sk.builtin.func(function (fontname) {
 	// loadFont(fontname)
 	// returns font
-	var font = Sk.misceval.callsim(mod.PFont);
+	var font = Sk.misceval.callsimArray(mod.PFont);
 	font.v = mod.processing.loadFont(fontname.v);
 	return font;
     });
@@ -779,9 +779,9 @@ var $builtinmodule = function (name) {
     mod.loadShape = new Sk.builtin.func(function (filename) {
 	// loadShape(filename)
 	// returns shape
-	var shape = Sk.misceval.callsim(mod.PShapeSVG, 
+	var shape = Sk.misceval.callsimArray(mod.PShapeSVG, [
 					new Sk.builtin.str("string"),
-					filename);
+					filename]);
 	return shape;
     });
 
@@ -964,7 +964,7 @@ var $builtinmodule = function (name) {
     mod.requestImage = new Sk.builtin.func(function (filename, extension) {
 	// requestImage(filename)
 	// requestImage(filename, extension)
-	var image = Sk.misceval.callsim(mod.PImage);
+	var image = Sk.misceval.callsimArray(mod.PImage);
         if (typeof(extension) === "undefined") {
 	    image.v = mod.processing.requestImage(filename.v);
         } else {
@@ -1498,7 +1498,7 @@ var $builtinmodule = function (name) {
 
             // processing.setup = function() {
             //     if Sk.globals["setup"]
-            //         Sk.misceval.callsim(Sk.globals["setup"])
+            //         Sk.misceval.callsimArray(Sk.globals["setup"])
             // }
 
 
@@ -1531,7 +1531,7 @@ var $builtinmodule = function (name) {
                 mod.frameCount = processing.frameCount;
                 if (Sk.globals["draw"]) {
                 	try {
-                   	    Sk.misceval.callsim(Sk.globals["draw"]);
+                   	    Sk.misceval.callsimArray(Sk.globals["draw"]);
                     }
                     catch(e) {
                         Sk.uncaughtException(e);
@@ -1544,7 +1544,7 @@ var $builtinmodule = function (name) {
             ];
             for (var cb in callBacks) {
                 if (Sk.globals[callBacks[cb]]) {
-                    processing[callBacks[cb]] = new Function("try {Sk.misceval.callsim(Sk.globals['" + callBacks[cb] + "']);} catch(e) {Sk.uncaughtException(e);}");
+                    processing[callBacks[cb]] = new Function("try {Sk.misceval.callsimArray(Sk.globals['" + callBacks[cb] + "']);} catch(e) {Sk.uncaughtException(e);}");
                 }
             }
         }
@@ -1601,7 +1601,7 @@ var $builtinmodule = function (name) {
 
     mod.Mouse = Sk.misceval.buildClass(mod, mouseClass, "Mouse", []);
 
-    mod.mouse = Sk.misceval.callsim(mod.Mouse);
+    mod.mouse = Sk.misceval.callsimArray(mod.Mouse);
 
     keyboardClass = function ($gbl, $loc) {
 
@@ -1622,7 +1622,7 @@ var $builtinmodule = function (name) {
 
     mod.Keyboard = Sk.misceval.buildClass(mod, keyboardClass, "Keyboard", []);
 
-    mod.keyboard = Sk.misceval.callsim(mod.Keyboard);
+    mod.keyboard = Sk.misceval.callsimArray(mod.Keyboard);
 
 
     environmentClass = function ($gbl, $loc) {
@@ -1653,7 +1653,7 @@ var $builtinmodule = function (name) {
 
     mod.Environment = Sk.misceval.buildClass(mod, environmentClass, "Environment", []);
 
-    mod.environment = Sk.misceval.callsim(mod.Environment);
+    mod.environment = Sk.misceval.callsimArray(mod.Environment);
 
     screenClass = function ($gbl, $loc) {
 
@@ -1681,7 +1681,7 @@ var $builtinmodule = function (name) {
 
     mod.Screen = Sk.misceval.buildClass(mod, screenClass, "Screen", []);
 
-    mod.screen = Sk.misceval.callsim(mod.Screen);
+    mod.screen = Sk.misceval.callsimArray(mod.Screen);
 
     mod.loadPixels = new Sk.builtin.func(function () {
         mod.processing.loadPixels();
@@ -1754,7 +1754,7 @@ var $builtinmodule = function (name) {
     mod.loadImage = new Sk.builtin.func(function (imfile) {
         var i = mod.processing.loadImage(imfile.v);
         imList.push(i);
-	var image = Sk.misceval.callsim(mod.PImage);
+	var image = Sk.misceval.callsimArray(mod.PImage);
 	image.v = i;
         return image;
     });
@@ -1771,10 +1771,10 @@ var $builtinmodule = function (name) {
 
     mod.get = new Sk.builtin.func(function (x, y) {
         var clr = mod.processing.get(x.v, y.v);
-        return Sk.misceval.callsim(mod.color,
+        return Sk.misceval.callsimArray(mod.color, [
             new Sk.builtin.int_(mod.processing.red(clr)),
             new Sk.builtin.int_(mod.processing.green(clr)),
-            new Sk.builtin.int_(mod.processing.blue(clr)));
+            new Sk.builtin.int_(mod.processing.blue(clr))]);
     });
 
     mod.set = new Sk.builtin.func(function (x, y, color) {
@@ -1810,7 +1810,7 @@ var $builtinmodule = function (name) {
 	    
         $loc.get = new Sk.builtin.func(function (self) {
 	    // get() Gets a copy of the vector
-            var new_vec = Sk.misceval.callsim(mod.PVector);
+            var new_vec = Sk.misceval.callsimArray(mod.PVector);
 	    new_vec.v = self.v.get();
 	    return new_vec;
 	});
@@ -1832,28 +1832,28 @@ var $builtinmodule = function (name) {
 
 	$loc.add = new Sk.builtin.func(function (self, vec) {
 	    // add()	Adds one vector to another
-            var new_vec = Sk.misceval.callsim(mod.PVector);
+            var new_vec = Sk.misceval.callsimArray(mod.PVector);
 	    new_vec.v = self.v.add(vec.v);
 	    return new_vec;
 	});
 
 	$loc.sub = new Sk.builtin.func(function (self, vec) {
 	    // sub()	Subtracts one vector from another
-            var new_vec = Sk.misceval.callsim(mod.PVector);
+            var new_vec = Sk.misceval.callsimArray(mod.PVector);
 	    new_vec.v = self.v.sub(vec.v);
 	    return new_vec;
 	});
 
 	$loc.mult = new Sk.builtin.func(function (self, vec) {
 	    // mult()	Multiplies the vector by a scalar
-            var new_vec = Sk.misceval.callsim(mod.PVector);
+            var new_vec = Sk.misceval.callsimArray(mod.PVector);
 	    new_vec.v = self.v.mult(vec.v);
 	    return new_vec;
 	});
 
 	$loc.div = new Sk.builtin.func(function (self, vec) {
 	    // div()	Divides the vector by a scalar
-            var new_vec = Sk.misceval.callsim(mod.PVector);
+            var new_vec = Sk.misceval.callsimArray(mod.PVector);
 	    new_vec.v = self.v.dic(vec.v);
 	    return new_vec;
 	});
@@ -1877,7 +1877,7 @@ var $builtinmodule = function (name) {
 
 	$loc.cross = new Sk.builtin.func(function (self, vec) {
 	    // cross()	Calculates the cross product
-            var new_vec = Sk.misceval.callsim(mod.PVector);
+            var new_vec = Sk.misceval.callsimArray(mod.PVector);
 	    new_vec.v = self.v.cross(vec.v);
 	    return new_vec;
 	});
@@ -1992,7 +1992,7 @@ var $builtinmodule = function (name) {
 	    var child = self.v.getChild(shape.v);
 	    if (child != null) {
 		// special method for Skulpt:
-		var new_shape = Sk.misceval.callsim(mod.PShapeSVG);
+		var new_shape = Sk.misceval.callsimArray(mod.PShapeSVG);
 		// Now fill in value:
 		new_shape.v = child;
 		return new_shape;

--- a/src/lib/re.js
+++ b/src/lib/re.js
@@ -273,7 +273,7 @@ var $builtinmodule = function (name) {
         if (lst.v.length < 1) {
             return Sk.builtin.none.none$;
         }
-        mob = Sk.misceval.callsim(mod.MatchObject, lst, pattern, string);
+        mob = Sk.misceval.callsimArray(mod.MatchObject, [lst, pattern, string]);
         return mob;
     };
 
@@ -303,7 +303,7 @@ var $builtinmodule = function (name) {
         if (Sk.ffi.remapToJs(lst).length < 1) {
             return Sk.builtin.none.none$;
         }
-        mob = Sk.misceval.callsim(mod.MatchObject, lst, pattern, string);
+        mob = Sk.misceval.callsimArray(mod.MatchObject, [lst, pattern, string]);
         return mob;
     };
 
@@ -425,7 +425,7 @@ var $builtinmodule = function (name) {
         if (!Sk.builtin.checkNumber(flags)) {
             throw new Sk.builtin.TypeError("flags must be a number");
         }
-        rob = Sk.misceval.callsim(mod.RegexObject, pattern, flags);
+        rob = Sk.misceval.callsimArray(mod.RegexObject, [pattern, flags]);
         return rob;
     });
 

--- a/src/lib/string.js
+++ b/src/lib/string.js
@@ -32,12 +32,12 @@ var $builtinmodule = function (name) {
 
 
     mod.split = new Sk.builtin.func(function (s, sep, maxsplit) {
-        return Sk.misceval.callsim(Sk.builtin.str.prototype['split'], s, sep, maxsplit);
+        return Sk.misceval.callsimArray(Sk.builtin.str.prototype['split'], [s, sep, maxsplit]);
     });
 
     /* Return a copy of word with only its first character capitalized. */
     mod.capitalize = new Sk.builtin.func(function (word) {
-        return Sk.misceval.callsim(Sk.builtin.str.prototype['capitalize'], word);
+        return Sk.misceval.callsimArray(Sk.builtin.str.prototype['capitalize'], [word]);
     });
 
     /* Concatenate a list or tuple of words with intervening occurrences
@@ -46,7 +46,7 @@ var $builtinmodule = function (name) {
         if (sep === undefined) {
             sep = Sk.builtin.str(' ');
         }
-        return Sk.misceval.callsim(Sk.builtin.str.prototype['join'], sep, words);
+        return Sk.misceval.callsimArray(Sk.builtin.str.prototype['join'], [sep, words]);
     });
 
 
@@ -66,15 +66,15 @@ var $builtinmodule = function (name) {
             throw new Sk.builtin.TypeError("sep must be a string");
         }
 
-        var words = Sk.misceval.callsim(mod.split, s, sep);
+        var words = Sk.misceval.callsimArray(mod.split, [s, sep]);
         var capWords = [];
         for (var i = 0; i < words.v.length; i++) {
             var word = Sk.builtin.list.prototype['list_subscript_'].call(words, i);
-            var cap = Sk.misceval.callsim(mod.capitalize, word);
+            var cap = Sk.misceval.callsimArray(mod.capitalize, [word]);
             capWords.push(cap);
         }
 
-        return Sk.misceval.callsim(mod.join, new Sk.builtin.list(capWords), sep);
+        return Sk.misceval.callsimArray(mod.join, [new Sk.builtin.list(capWords), sep]);
     });
 
 

--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -1113,13 +1113,13 @@ function generateTurtleModule(_target) {
         proto.$ondrag.co_varnames = ["method", "btn", "add"];
 
         proto.$getscreen = function() {
-            return Sk.misceval.callsim(_module.Screen);
+            return Sk.misceval.callsimArray(_module.Screen);
         };
         proto.$getscreen.isSk = true;
 
         proto.$clone = function() {
 
-            var newTurtleInstance = Sk.misceval.callsimOrSuspend(_module.Turtle);
+            var newTurtleInstance = Sk.misceval.callsimOrSuspendArray(_module.Turtle);
 
             // All the properties that are in getState()
             newTurtleInstance.instance._x = this._x;
@@ -1561,7 +1561,7 @@ function generateTurtleModule(_target) {
 
     function ensureAnonymous() {
         if (!_anonymousTurtle) {
-            _anonymousTurtle = Sk.misceval.callsim(_module.Turtle);
+            _anonymousTurtle = Sk.misceval.callsimArray(_module.Turtle);
         }
 
         return _anonymousTurtle.instance;

--- a/src/lib/urllib/request/__init__.js
+++ b/src/lib/urllib/request/__init__.js
@@ -110,7 +110,7 @@ var $builtinmodule = function (name) {
             var xmlhttp = new XMLHttpRequest();
 
             xmlhttp.addEventListener("loadend", function (e) {
-                resolve(Sk.misceval.callsim(request.Response, xmlhttp));
+                resolve(Sk.misceval.callsimArray(request.Response, [xmlhttp]));
             });
 
             if (!data) {

--- a/src/lib/webgl/__init__.js
+++ b/src/lib/webgl/__init__.js
@@ -216,7 +216,7 @@ var $builtinmodule = function(name)
       var startTime = (new Date()).getTime();
       var intervalId = setInterval(
         function() {
-          Sk.misceval.callsim(func, self, (new Date()).getTime() - startTime);
+          Sk.misceval.callsimArray(func, [self, (new Date()).getTime() - startTime]);
         }, 1000.0 / 60.0); // 60 fps
     });
 

--- a/src/lib/webgl/math.js
+++ b/src/lib/webgl/math.js
@@ -7,7 +7,7 @@ var $builtinmodule = function(name)
             {
                 $loc.__init__ = new Sk.builtin.func(function(self)
                     {
-                        Sk.misceval.callsim($loc.loadIdentity, self);
+                        Sk.misceval.callsimArray($loc.loadIdentity, [self]);
                         self.stack = [];
                     });
 
@@ -32,10 +32,10 @@ var $builtinmodule = function(name)
                 $loc.transform3 = new Sk.builtin.func(function(self, v)
                     {
                         var e = self.elements;
-                        return Sk.misceval.callsim(mod.Vec3,
+                        return Sk.misceval.callsimArray(mod.Vec3, [
                             e[0] * v.x + e[4] * v.y + e[8] * v.z,
                             e[1] * v.x + e[5] * v.y + e[9] * v.z,
-                            e[2] * v.x + e[6] * v.y + e[10] * v.z);
+                            e[2] * v.x + e[6] * v.y + e[10] * v.z]);
                     });
 
                 $loc.scale = new Sk.builtin.func(function(self, sx, sy, sz)
@@ -94,7 +94,7 @@ var $builtinmodule = function(name)
                                 zs = z * sinAngle;
                                 oneMinusCos = 1.0 - cosAngle;
 
-                                rotMat = Sk.misceval.callsim(mod.Mat44);
+                                rotMat = Sk.misceval.callsimArray(mod.Mat44);
 
                                 rotMat.elements[0*4+0] = (oneMinusCos * xx) + cosAngle;
                                 rotMat.elements[0*4+1] = (oneMinusCos * xy) - zs;
@@ -124,7 +124,7 @@ var $builtinmodule = function(name)
 
                 $loc.multiply = new Sk.builtin.func(function(self, right)
                         {
-                            var tmp = Sk.misceval.callsim(mod.Mat44);
+                            var tmp = Sk.misceval.callsimArray(mod.Mat44);
 
                             for (var i = 0; i < 4; i++)
                             {
@@ -212,7 +212,7 @@ var $builtinmodule = function(name)
                                 y[2] /= mag;
                             }
 
-                            var lookAt = Sk.misceval.callsim(mod.Mat44);
+                            var lookAt = Sk.misceval.callsimArray(mod.Mat44);
                             lookAt.elements[0 * 4 + 0] = x[0];
                             lookAt.elements[1 * 4 + 0] = x[1];
                             lookAt.elements[2 * 4 + 0] = x[2];
@@ -248,7 +248,7 @@ var $builtinmodule = function(name)
             {
                 $loc.__init__ = new Sk.builtin.func(function(self)
                     {
-                        Sk.misceval.callsim($loc.loadIdentity, self);
+                        Sk.misceval.callsimArray($loc.loadIdentity, [self]);
                     });
 
                 $loc.loadIdentity = new Sk.builtin.func(function(self)
@@ -270,7 +270,7 @@ var $builtinmodule = function(name)
                     });
                 $loc.__sub__ = new Sk.builtin.func(function(self, other)
                     {
-                        return Sk.misceval.callsim(mod.Vec3, self.x - other.x, self.y - other.y, self.z - other.z);
+                        return Sk.misceval.callsimArray(mod.Vec3, [self.x - other.x, self.y - other.y, self.z - other.z]);
                     });
             },
             'Vec3', []);
@@ -278,10 +278,10 @@ var $builtinmodule = function(name)
     mod.cross = new Sk.builtin.func(function(v1, v2)
             {
                 goog.asserts.assert(v1 instanceof mod.Vec3 && v2 instanceof mod.Vec3);
-                return Sk.misceval.callsim(mod.Vec3,
+                return Sk.misceval.callsimArray(mod.Vec3, [
                     v1.y * v2.z - v1.z * v2.y,
                     v1.z * v2.x - v1.x * v2.z,
-                    v1.x * v2.y - v1.y * v2.x);
+                    v1.x * v2.y - v1.y * v2.x]);
             });
 
     return mod;

--- a/src/lib/webgl/models.js
+++ b/src/lib/webgl/models.js
@@ -109,7 +109,7 @@ var $builtinmodule = function(name)
 
                         uniforms = Sk.ffi.remapToJs(uniforms);
 
-                        Sk.misceval.callsim(shader.use, shader);
+                        Sk.misceval.callsimArray(shader.use, [shader]);
 
                         for (var buffer in buffers) {
                             var b = buffers[buffer];

--- a/src/list.js
+++ b/src/list.js
@@ -451,7 +451,7 @@ Sk.builtin.list.prototype.list_sort_ = function sort(self, cmp, key, reverse) {
     if (has_key) {
         if (has_cmp) {
             timsort.lt = function (a, b) {
-                var res = Sk.misceval.callsim(cmp, a[0], b[0]);
+                var res = Sk.misceval.callsimArray(cmp, [a[0], b[0]]);
                 return Sk.misceval.richCompareBool(res, zero, "Lt");
             };
         } else {
@@ -461,12 +461,12 @@ Sk.builtin.list.prototype.list_sort_ = function sort(self, cmp, key, reverse) {
         }
         for (i = 0; i < timsort.listlength; i++) {
             item = timsort.list.v[i];
-            keyvalue = Sk.misceval.callsim(key, item);
+            keyvalue = Sk.misceval.callsimArray(key, [item]);
             timsort.list.v[i] = [keyvalue, item];
         }
     } else if (has_cmp) {
         timsort.lt = function (a, b) {
-            var res = Sk.misceval.callsim(cmp, a, b);
+            var res = Sk.misceval.callsimArray(cmp, [a, b]);
             return Sk.misceval.richCompareBool(res, zero, "Lt");
         };
     }

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -100,7 +100,7 @@ Sk.misceval.asIndex = function (o) {
     }
     idxfn = Sk.abstr.lookupSpecial(o, "__index__");
     if (idxfn) {
-        ret = Sk.misceval.callsim(idxfn, o);
+        ret = Sk.misceval.callsimArray(idxfn, [o]);
         if (!Sk.builtin.checkInt(ret)) {
             throw new Sk.builtin.TypeError("__index__ returned non-(int,long) (type " +
                                            Sk.abstr.typeName(ret) + ")");
@@ -431,7 +431,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
 
     method = Sk.abstr.lookupSpecial(v, op2method[op]);
     if (method && !v_has_shortcut) {
-        ret = Sk.misceval.callsim(method, v, w);
+        ret = Sk.misceval.callsimArray(method, [v, w]);
         if (ret != Sk.builtin.NotImplemented.NotImplemented$) {
             return Sk.misceval.isTrue(ret);
         }
@@ -439,7 +439,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
 
     swapped_method = Sk.abstr.lookupSpecial(w, op2method[Sk.misceval.swappedOp_[op]]);
     if (swapped_method && !w_has_shortcut) {
-        ret = Sk.misceval.callsim(swapped_method, w, v);
+        ret = Sk.misceval.callsimArray(swapped_method, [w, v]);
         if (ret != Sk.builtin.NotImplemented.NotImplemented$) {
             return Sk.misceval.isTrue(ret);
         }
@@ -448,7 +448,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     vcmp = Sk.abstr.lookupSpecial(v, "__cmp__");
     if (vcmp) {
         try {
-            ret = Sk.misceval.callsim(vcmp, v, w);
+            ret = Sk.misceval.callsimArray(vcmp, [v, w]);
             if (Sk.builtin.checkNumber(ret)) {
                 ret = Sk.builtin.asnum$(ret);
                 if (op === "Eq") {
@@ -478,7 +478,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     if (wcmp) {
         // note, flipped on return value and call
         try {
-            ret = Sk.misceval.callsim(wcmp, w, v);
+            ret = Sk.misceval.callsimArray(wcmp, [w, v]);
             if (Sk.builtin.checkNumber(ret)) {
                 ret = Sk.builtin.asnum$(ret);
                 if (op === "Eq") {
@@ -631,14 +631,14 @@ Sk.misceval.isTrue = function (x) {
         return x.v !== 0;
     }
     if (x["__nonzero__"]) {
-        ret = Sk.misceval.callsim(x["__nonzero__"], x);
+        ret = Sk.misceval.callsimArray(x["__nonzero__"], [x]);
         if (!Sk.builtin.checkInt(ret)) {
             throw new Sk.builtin.TypeError("__nonzero__ should return an int");
         }
         return Sk.builtin.asnum$(ret) !== 0;
     }
     if (x["__len__"]) {
-        ret = Sk.misceval.callsim(x["__len__"], x);
+        ret = Sk.misceval.callsimArray(x["__len__"], [x]);
         if (!Sk.builtin.checkInt(ret)) {
             throw new Sk.builtin.TypeError("__len__ should return an int");
         }
@@ -1288,7 +1288,7 @@ Sk.misceval.buildClass = function (globals, func, name, bases, cell) {
     }
     _locals = new Sk.builtin.dict(_locals);
 
-    klass = Sk.misceval.callsim(meta, _name, _bases, _locals);
+    klass = Sk.misceval.callsimArray(meta, [_name, _bases, _locals]);
 
     return klass;
 };

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -814,16 +814,6 @@ goog.exportSymbol("Sk.misceval.callOrSuspend", Sk.misceval.callOrSuspend);
 
 /**
  * @param {Object} func the thing to call
- * @param {...*} args stuff to pass it
- */
-Sk.misceval.callsim = function (func, args) {
-    args = Array.prototype.slice.call(arguments, 1);
-    return Sk.misceval.apply(func, undefined, undefined, undefined, args);
-};
-goog.exportSymbol("Sk.misceval.callsim", Sk.misceval.callsim);
-
-/**
- * @param {Object} func the thing to call
  * @param {Array=} args an array of arguments to pass to the func
  *
  * Does the same thing as callsim without expensive call to Array.slice.
@@ -845,17 +835,6 @@ Sk.misceval.callsimAsync = function (suspensionHandlers, func, args) {
     return Sk.misceval.applyAsync(suspensionHandlers, func, undefined, undefined, undefined, args);
 };
 goog.exportSymbol("Sk.misceval.callsimAsync", Sk.misceval.callsimAsync);
-
-
-/**
- * @param {Object} func the thing to call
- * @param {...*} args stuff to pass it
- */
-Sk.misceval.callsimOrSuspend = function (func, args) {
-    args = Array.prototype.slice.call(arguments, 1);
-    return Sk.misceval.applyOrSuspend(func, undefined, undefined, undefined, args);
-};
-goog.exportSymbol("Sk.misceval.callsimOrSuspend", Sk.misceval.callsimOrSuspend);
 
 /**
  * @param {Object} func the thing to call

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -823,6 +823,19 @@ Sk.misceval.callsim = function (func, args) {
 goog.exportSymbol("Sk.misceval.callsim", Sk.misceval.callsim);
 
 /**
+ * @param {Object} func the thing to call
+ * @param {Array=} args an array of arguments to pass to the func
+ *
+ * Does the same thing as callsim without expensive call to Array.slice.
+ * Requires args to be a Javascript array.
+ */
+Sk.misceval.callsimArray = function(func, args) {
+    var argarray = args ? args : [];
+    return Sk.misceval.apply(func, undefined, undefined, undefined, argarray);
+};
+goog.exportSymbol("Sk.misceval.callsimArray", Sk.misceval.callsimArray);
+
+/**
  * @param {?Object} suspensionHandlers any custom suspension handlers
  * @param {Object} func the thing to call
  * @param {...*} args stuff to pass it
@@ -843,6 +856,19 @@ Sk.misceval.callsimOrSuspend = function (func, args) {
     return Sk.misceval.applyOrSuspend(func, undefined, undefined, undefined, args);
 };
 goog.exportSymbol("Sk.misceval.callsimOrSuspend", Sk.misceval.callsimOrSuspend);
+
+/**
+ * @param {Object} func the thing to call
+ * @param {Array=} args an array of arguments to pass to the func
+ *
+ * Does the same thing as callsimOrSuspend without expensive call to
+ * Array.slice.  Requires args to be a Javascript array.
+ */
+Sk.misceval.callsimOrSuspendArray = function (func, args) {
+    var argarray = args ? args : [];
+    return Sk.misceval.applyOrSuspend(func, undefined, undefined, undefined, argarray);
+};
+goog.exportSymbol("Sk.misceval.callsimOrSuspendArray", Sk.misceval.callsimOrSuspendArray);
 
 /**
  * Wrap Sk.misceval.applyOrSuspend, but throw an error if we suspend

--- a/src/object.js
+++ b/src/object.js
@@ -96,7 +96,7 @@ Sk.builtin.object.prototype.GenericGetAttr = function (name, canSuspend) {
         }
 
         res = Sk.misceval.tryCatch(function() {
-            return Sk.misceval.callsimOrSuspend(getf, pyName);
+            return Sk.misceval.callsimOrSuspendArray(getf, [pyName]);
         }, function(e) {
             if (e instanceof Sk.builtin.AttributeError) {
                 return undefined;

--- a/src/print.js
+++ b/src/print.js
@@ -70,7 +70,7 @@ var print_f = function function_print(kwa) {
 
     if(kw_list.file !== null) {
         // currently not tested, though it seems that we need to see how we should access the write function in a correct manner
-        Sk.misceval.callsim(kw_list.file.write, kw_list.file, new Sk.builtin.str(s)); // callsim to write function
+        Sk.misceval.callsimArray(kw_list.file.write, [kw_list.file, new Sk.builtin.str(s)]); // callsim to write function
     } else {
         return Sk.misceval.chain(Sk.importModule("sys", false, true), function(sys) {
             return Sk.misceval.apply(sys["$d"]["stdout"]["write"], undefined, undefined, undefined, [sys["$d"]["stdout"], new Sk.builtin.str(s)]);

--- a/src/sorted.js
+++ b/src/sorted.js
@@ -23,14 +23,14 @@ Sk.builtin.sorted = function sorted (iterable, cmp, key, reverse) {
             };
         } else {
             compare_func = function (a, b) {
-                return Sk.misceval.callsim(cmp, a[0], b[0]);
+                return Sk.misceval.callsimArray(cmp, [a[0], b[0]]);
             };
         }
         iter = iterable.tp$iter();
         next = iter.tp$iternext();
         arr = [];
         while (next !== undefined) {
-            arr.push([Sk.misceval.callsim(key, next), next]);
+            arr.push([Sk.misceval.callsimArray(key, [next]), next]);
             next = iter.tp$iternext();
         }
         list = new Sk.builtin.list(arr);

--- a/src/str.js
+++ b/src/str.js
@@ -592,7 +592,7 @@ Sk.builtin.str.prototype["find"] = new Sk.builtin.func(function (self, tgt, star
 Sk.builtin.str.prototype["index"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
     Sk.builtin.pyCheckArgsLen("index", arguments.length, 2, 4);
-    idx = Sk.misceval.callsim(self["find"], self, tgt, start, end);
+    idx = Sk.misceval.callsimArray(self["find"], [self, tgt, start, end]);
     if (Sk.builtin.asnum$(idx) === -1) {
         throw new Sk.builtin.ValueError("substring not found");
     }
@@ -636,7 +636,7 @@ Sk.builtin.str.prototype["rfind"] = new Sk.builtin.func(function (self, tgt, sta
 Sk.builtin.str.prototype["rindex"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
     Sk.builtin.pyCheckArgsLen("rindex", arguments.length, 2, 4);
-    idx = Sk.misceval.callsim(self["rfind"], self, tgt, start, end);
+    idx = Sk.misceval.callsimArray(self["rfind"], [self, tgt, start, end]);
     if (Sk.builtin.asnum$(idx) === -1) {
         throw new Sk.builtin.ValueError("substring not found");
     }

--- a/src/type.js
+++ b/src/type.js
@@ -333,7 +333,7 @@ Sk.builtin.type = function (name, bases, dict) {
             if (iterf === undefined) {
                 throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(this) + "' object is not iterable");
             }
-            return Sk.misceval.callsim(iterf);
+            return Sk.misceval.callsimArray(iterf);
         };
         klass.prototype.tp$iternext = function (canSuspend) {
             var self = this;

--- a/src/type.js
+++ b/src/type.js
@@ -265,7 +265,7 @@ Sk.builtin.type = function (name, bases, dict) {
         klass.prototype.tp$setattr = function(name, data, canSuspend) {
             var r, /** @type {(Object|undefined)} */ setf = Sk.builtin.object.prototype.GenericGetAttr.call(this, "__setattr__");
             if (setf !== undefined) {
-                r = Sk.misceval.callsimOrSuspend(/** @type {Object} */ (setf), new Sk.builtin.str(name), data);
+                r = Sk.misceval.callsimOrSuspendArray(/** @type {Object} */ (setf), [new Sk.builtin.str(name), data]);
                 return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
             }
 
@@ -289,7 +289,7 @@ Sk.builtin.type = function (name, bases, dict) {
             // Convert AttributeErrors back into 'undefined' returns to match the tp$getattr
             // convention
             r = Sk.misceval.tryCatch(function() {
-                return Sk.misceval.callsimOrSuspend(/** @type {Object} */ (getf), new Sk.builtin.str(name));
+                return Sk.misceval.callsimOrSuspendArray(/** @type {Object} */ (getf), [new Sk.builtin.str(name)]);
             }, function (e) {
                 if (e instanceof Sk.builtin.AttributeError) {
                     return undefined;
@@ -350,7 +350,7 @@ Sk.builtin.type = function (name, bases, dict) {
                 }
 
                 return Sk.misceval.tryCatch(function() {
-                    return Sk.misceval.callsimOrSuspend(iternextf);
+                    return Sk.misceval.callsimOrSuspendArray(iternextf);
                 }, function(e) {
                     if (e instanceof Sk.builtin.StopIteration) {
                         return undefined;
@@ -397,18 +397,31 @@ Sk.builtin.type = function (name, bases, dict) {
 
         var shortcutDunder = function (skulpt_name, magic_name, magic_func, canSuspendIdx) {
             klass.prototype[skulpt_name] = function () {
-                var args = Array.prototype.slice.call(arguments), canSuspend;
-                args.unshift(magic_func, this);
+                var canSuspend = false;
+                var len = arguments.length;
+                var args, i, j;
+                if ((canSuspendIdx !== null) && (canSuspendIdx <= len)) {
+                    args = new Array(len);
+                } else {
+                    args = new Array(len+1);
+                }
 
-                if (canSuspendIdx !== null) {
-                    canSuspend = args[canSuspendIdx+1];
-                    args.splice(canSuspendIdx+1, 1);
-
-                    if (canSuspend) {
-                        return Sk.misceval.callsimOrSuspend.apply(undefined, args);
+                args[0] = this;
+                j = 1;
+                for (i = 0; i < len; i++) {
+                    if (i === (canSuspendIdx-1)) {
+                        canSuspend = arguments[i];
+                    } else {
+                        args[j] = arguments[i];
+                        j += 1;
                     }
                 }
-                return Sk.misceval.callsim.apply(undefined, args);
+
+                if (canSuspend) {
+                    return Sk.misceval.callsimOrSuspendArray(magic_func, args);
+                } else {
+                    return Sk.misceval.callsimArray(magic_func, args);
+                }
             };
         };
 

--- a/src/typeobject.js
+++ b/src/typeobject.js
@@ -38,7 +38,7 @@ Sk.builtin.super_ = function super_ (a_type, self) {
         return new Sk.builtin.super_(a_type, self);
     }
 
-    Sk.misceval.callsim(Sk.builtin.super_.__init__, this, a_type, self);
+    Sk.misceval.callsimArray(Sk.builtin.super_.__init__, [this, a_type, self]);
 
     return this;
 };


### PR DESCRIPTION
This introduces callsimArray and callsimOrSuspendArray which takes a function to call and an array of arguments.  The array can then be passed on directly to apply/applyOrSuspend without needing to slice the arguments.  This helps the optimizer and eliminates the unnecessary array construction.

All calls to callsim and callsimOrSuspend have been replaced with calls to the Array versions and these functions have been dropped.