### PR TITLE
Normalize get/set attribute infrastructure to take Python attribute names

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -233,7 +233,7 @@ Sk.builtin.round = function round (number, ndigits) {
     }
 
     // try calling internal magic method
-    special = Sk.abstr.lookupSpecial(number, "__round__");
+    special = Sk.abstr.lookupSpecial(number, Sk.builtin.str.$round);
     if (special != null) {
         // method on builtin, provide this arg
         if (!Sk.builtin.checkFunction(number)) {
@@ -274,7 +274,7 @@ Sk.builtin.len = function len (item) {
 
     if (item.tp$length) {
         if (Sk.builtin.checkFunction(item)) {
-            special = Sk.abstr.lookupSpecial(item, "__len__");
+            special = Sk.abstr.lookupSpecial(item, Sk.builtin.str.$len);
             if (special != null) {
                 return Sk.misceval.callsimArray(special, [item]);
             } else {
@@ -475,7 +475,7 @@ Sk.builtin.abs = function abs (x) {
 
     // call custom __abs__ methods
     if (x.tp$getattr) {
-        var f = x.tp$getattr("__abs__");
+        var f = x.tp$getattr(Sk.builtin.str.$abs);
         return Sk.misceval.callsimArray(f);
     }
 
@@ -622,7 +622,7 @@ Sk.builtin.dir = function dir (x) {
     var _seq;
 
     // try calling magic method
-    var special = Sk.abstr.lookupSpecial(x, "__dir__");
+    var special = Sk.abstr.lookupSpecial(x, Sk.builtin.str.$dir);
     if(special != null) {
         // method on builtin, provide this arg
         _seq = Sk.misceval.callsimArray(special, [x]);
@@ -819,36 +819,39 @@ Sk.builtin.hash = function hash (value) {
     // todo; throw properly for unhashable types
 };
 
-Sk.builtin.getattr = function getattr (obj, name, default_) {
-    var ret, mangledName;
+Sk.builtin.getattr = function getattr (obj, pyName, default_) {
+    var ret, mangledName, jsName;
     Sk.builtin.pyCheckArgsLen("getattr", arguments.length, 2, 3);
-    if (!Sk.builtin.checkString(name)) {
+    if (!Sk.builtin.checkString(pyName)) {
         throw new Sk.builtin.TypeError("attribute name must be string");
     }
 
-    mangledName = Sk.fixReservedWords(Sk.ffi.remapToJs(name));
+    jsName = pyName.$jsstr();
+    mangledName = new Sk.builtin.str(Sk.fixReservedWords(jsName));
     ret = obj.tp$getattr(mangledName);
     if (ret === undefined) {
         if (default_ !== undefined) {
             return default_;
         } else {
-            throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + name.v + "'");
+            throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + jsName + "'");
         }
     }
     return ret;
 };
 
-Sk.builtin.setattr = function setattr (obj, name, value) {
+Sk.builtin.setattr = function setattr (obj, pyName, value) {
+    var jsName;
     Sk.builtin.pyCheckArgsLen("setattr", arguments.length, 3, 3);
     // cannot set or del attr from builtin type
     if (obj === undefined || obj["$r"] === undefined || obj["$r"]().v.slice(1,5) !== "type") {
-        if (!Sk.builtin.checkString(name)) {
+        if (!Sk.builtin.checkString(pyName)) {
             throw new Sk.builtin.TypeError("attribute name must be string");
         }
+        jsName = pyName.$jsstr();
         if (obj.tp$setattr) {
-            obj.tp$setattr(Sk.fixReservedWords(Sk.ffi.remapToJs(name)), value);
+            obj.tp$setattr(new Sk.builtin.str(Sk.fixReservedWords(jsName)), value);
         } else {
-            throw new Sk.builtin.AttributeError("object has no attribute " + Sk.ffi.remapToJs(name));
+            throw new Sk.builtin.AttributeError("object has no attribute " + jsName);
         }
         return Sk.builtin.none.none$;
     }
@@ -1064,7 +1067,7 @@ Sk.builtin.hasattr = function hasattr (obj, attr) {
     }
 
     if (obj.tp$getattr) {
-        if (obj.tp$getattr(attr.v)) {
+        if (obj.tp$getattr(attr)) {
             return Sk.builtin.bool.true$;
         } else {
             return Sk.builtin.bool.false$;
@@ -1246,7 +1249,7 @@ Sk.builtin.format = function format (value, format_spec) {
 Sk.builtin.reversed = function reversed (seq) {
     Sk.builtin.pyCheckArgsLen("reversed", arguments.length, 1, 1);
 
-    var special = Sk.abstr.lookupSpecial(seq, "__reversed__");
+    var special = Sk.abstr.lookupSpecial(seq, Sk.builtin.str.$reversed);
     if (special != null) {
         return Sk.misceval.callsimArray(special, [seq]);
     } else {
@@ -1262,7 +1265,7 @@ Sk.builtin.reversed = function reversed (seq) {
         var reverseIter = function (obj) {
             this.idx = obj.sq$length() - 1;
             this.myobj = obj;
-            this.getitem = Sk.abstr.lookupSpecial(obj, "__getitem__");
+            this.getitem = Sk.abstr.lookupSpecial(obj, Sk.builtin.str.$getitem);
             this.tp$iter = function() {
                 return this;
             },

--- a/src/complex.js
+++ b/src/complex.js
@@ -24,7 +24,7 @@ Math.hypot = Math.hypot || function() {
  * Prefering here == instead of ===, otherwise also undefined has to be matched explicitly
  *
  * FIXME: it seems that we somehow need to call __float__/__int__ if arguments provide those methods
- * 
+ *
  */
 Sk.builtin.complex = function (real, imag) {
     Sk.builtin.pyCheckArgsLen("complex", arguments.length, 0, 2);
@@ -90,7 +90,7 @@ Sk.builtin.complex = function (real, imag) {
             return true;
         }
 
-        if(Sk.builtin.type.typeLookup(op.ob$type, "__float__") !== undefined) {
+        if(Sk.builtin.type.typeLookup(op.ob$type, Sk.builtin.str.$float_) !== undefined) {
             return true;
         }
     };
@@ -163,20 +163,20 @@ Sk.builtin.complex = function (real, imag) {
 
     // adjust for negated imaginary literal
     if (cr.real === 0 && (ci.real < 0 || Sk.builtin.complex._isNegativeZero(ci.real))) {
-        cr.real = -0;   
+        cr.real = -0;
     }
 
     // save them as properties
     this.real = new Sk.builtin.float_(cr.real);
     this.imag = new Sk.builtin.float_(ci.real);
 
-    this.__class__ = Sk.builtin.complex;
-
     return this;
 };
 
 Sk.abstr.setUpInheritance("complex", Sk.builtin.complex, Sk.builtin.numtype);
 //Sk.builtin.complex.co_kwargs = true;
+
+Sk.builtin.complex.prototype.__class__ = Sk.builtin.complex;
 
 Sk.builtin.complex.prototype.nb$int_ = function () {
     throw new Sk.builtin.TypeError("can't convert complex to int");
@@ -204,7 +204,6 @@ Sk.builtin.complex._isNegativeZero = function (val) {
  * Internal method to check if op has __complex__
  */
 Sk.builtin.complex.try_complex_special_method = function (op) {
-    var complexstr = new Sk.builtin.str("__complex__");
     var f; // PyObject
     var res;
 
@@ -214,7 +213,7 @@ Sk.builtin.complex.try_complex_special_method = function (op) {
     }
 
     // the lookup special method does already all the magic
-    f = Sk.abstr.lookupSpecial(op, "__complex__");
+    f = Sk.abstr.lookupSpecial(op, Sk.builtin.str.$complex);
 
     if (f != null) {
         // method on builtin, provide this arg
@@ -265,7 +264,7 @@ Sk.builtin.complex.complex_subtype_from_string = function (val) {
 
     /* This is an python specific error, this does not do any harm in js, but we want
      * to be as close to the orginial impl. as possible.
-     * 
+     *
      * Check also for empty strings. They are not allowed.
      */
     if (val.indexOf("\0") !== -1 || val.length === 0 || val === "") {
@@ -409,7 +408,7 @@ Sk.builtin.complex.complex_subtype_from_string = function (val) {
     _PyHASH_IMAG refers to _PyHASH_MULTIPLIER which refers to 1000003
  */
 Sk.builtin.complex.prototype.tp$hash = function () {
-    return new Sk.builtin.int_(this.tp$getattr("imag").v * 1000003 + this.tp$getattr("real").v);
+    return new Sk.builtin.int_(this.tp$getattr(Sk.builtin.str.$imag).v * 1000003 + this.tp$getattr(Sk.builtin.str.$real).v);
 };
 
 Sk.builtin.complex.prototype.nb$add = function (other) {
@@ -418,8 +417,8 @@ Sk.builtin.complex.prototype.nb$add = function (other) {
 
     other = Sk.builtin.complex.check_number_or_complex(other);
 
-    real = this.tp$getattr("real").v + other.tp$getattr("real").v;
-    imag = this.tp$getattr("imag").v + other.tp$getattr("imag").v;
+    real = this.tp$getattr(Sk.builtin.str.$real).v + other.tp$getattr(Sk.builtin.str.$real).v;
+    imag = this.tp$getattr(Sk.builtin.str.$imag).v + other.tp$getattr(Sk.builtin.str.$imag).v;
 
     return new Sk.builtin.complex(new Sk.builtin.float_(real), new Sk.builtin.float_(imag));
 };
@@ -530,7 +529,7 @@ Sk.builtin.complex.prototype.nb$power = function (other, z) {
 
     // none is allowed
     if (z != null && !Sk.builtin.checkNone(z)) {
-        throw new Sk.builtin.ValueError("complex modulo");  
+        throw new Sk.builtin.ValueError("complex modulo");
     }
 
     a = this;
@@ -693,8 +692,8 @@ Sk.builtin.complex.prototype.tp$richcompare = function (w, op) {
 
     // assert(PyComplex_Check(v)));
     i = Sk.builtin.complex.check_number_or_complex(this);
-    var _real = i.tp$getattr("real").v;
-    var _imag = i.tp$getattr("imag").v;
+    var _real = i.tp$getattr(Sk.builtin.str.$real).v;
+    var _imag = i.tp$getattr(Sk.builtin.str.$imag).v;
 
     if (Sk.builtin.checkInt(w)) {
         /* Check for 0.0 imaginary part first to avoid the rich
@@ -704,7 +703,7 @@ Sk.builtin.complex.prototype.tp$richcompare = function (w, op) {
         // if true, the complex number has just a real part
         if (_imag === 0.0) {
             equal = Sk.misceval.richCompareBool(new Sk.builtin.float_(_real), w, op);
-            result = new Sk.builtin.bool( equal);
+            result = new Sk.builtin.bool(equal);
             return result;
         } else {
             equal = false;
@@ -713,8 +712,8 @@ Sk.builtin.complex.prototype.tp$richcompare = function (w, op) {
         equal = (_real === Sk.builtin.float_.PyFloat_AsDouble(w) && _imag === 0.0);
     } else if (Sk.builtin.complex._complex_check(w)) {
         // ToDo: figure if we need to call to_complex
-        var w_real = w.tp$getattr("real").v;
-        var w_imag = w.tp$getattr("imag").v;
+        var w_real = w.tp$getattr(Sk.builtin.str.$real).v;
+        var w_imag = w.tp$getattr(Sk.builtin.str.$imag).v;
         equal = _real === w_real && _imag === w_imag;
     } else {
         return Sk.builtin.NotImplemented.NotImplemented$;
@@ -726,7 +725,7 @@ Sk.builtin.complex.prototype.tp$richcompare = function (w, op) {
     }
 
     // wrap as bool
-    result = new Sk.builtin.bool( equal);
+    result = new Sk.builtin.bool(equal);
 
     return result;
 };
@@ -743,7 +742,7 @@ Sk.builtin.complex.prototype.__ne__ = function (me, other) {
 };
 
 /**
- * Do we really need to implement those? Otherwise I can't find in Sk.abstr a place where this particular 
+ * Do we really need to implement those? Otherwise I can't find in Sk.abstr a place where this particular
  * expcetion is thrown.git co
  */
 Sk.builtin.complex.prototype.__lt__ = function (me, other) {
@@ -850,7 +849,7 @@ Sk.builtin.complex.complex_format = function (v, precision, format_code){
         re = pre;
 
         im = Sk.builtin.complex.PyOS_double_to_string(v.imag.v, format_code, precision, Sk.builtin.complex.PyOS_double_to_string.Py_DTSF_SIGN, null);
-        
+
         if (v.imag.v === 0 && 1/v.imag.v === -Infinity && im && im[0] !== "-"){
             im = "-" + im; // force negative zero sign
         }
@@ -896,7 +895,7 @@ Sk.builtin.complex.prototype.int$format = function __format__(self, format_spec)
     throw new Sk.builtin.TypeError("__format__ requires str or unicode");
 };
 Sk.builtin.complex.prototype.int$format.co_name = new Sk.builtin.str("__format__");
-Sk.builtin.complex.prototype.__format__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$format); 
+Sk.builtin.complex.prototype.__format__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$format);
 
 Sk.builtin.complex._PyComplex_FormatAdvanced = function(self, format_spec) {
     throw new Sk.builtin.NotImplementedError("__format__ is not implemented for complex type.");
@@ -953,20 +952,20 @@ Sk.builtin.complex.prototype.int$abs = function __abs__(self) {
     return new Sk.builtin.float_(result);
 };
 Sk.builtin.complex.prototype.int$abs.co_name = new Sk.builtin.str("__abs__");
-Sk.builtin.complex.prototype.__abs__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$abs); 
+Sk.builtin.complex.prototype.__abs__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$abs);
 
 Sk.builtin.complex.prototype.int$bool = function __bool__(self) {
-    return new Sk.builtin.bool( self.tp$getattr("real").v || self.tp$getattr("real").v);
+    return new Sk.builtin.bool(self.tp$getattr(Sk.builtin.str.$real).v || self.tp$getattr(Sk.builtin.str.$real).v);
 };
 Sk.builtin.complex.prototype.int$bool.co_name = new Sk.builtin.str("__bool__");
-Sk.builtin.complex.prototype.__bool__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$bool); 
+Sk.builtin.complex.prototype.__bool__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$bool);
 
 Sk.builtin.complex.prototype.int$truediv = function __truediv__(self, other){
     Sk.builtin.pyCheckArgsLen("__truediv__", arguments.length, 1, 1, true);
     return self.nb$divide.call(self, other);
 };
 Sk.builtin.complex.prototype.int$truediv.co_name = new Sk.builtin.str("__truediv__");
-Sk.builtin.complex.prototype.__truediv__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$truediv); 
+Sk.builtin.complex.prototype.__truediv__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$truediv);
 
 Sk.builtin.complex.prototype.int$hash = function __hash__(self){
     Sk.builtin.pyCheckArgsLen("__hash__", arguments.length, 0, 0, true);
@@ -974,14 +973,14 @@ Sk.builtin.complex.prototype.int$hash = function __hash__(self){
     return self.tp$hash.call(self);
 };
 Sk.builtin.complex.prototype.int$hash.co_name = new Sk.builtin.str("__hash__");
-Sk.builtin.complex.prototype.__hash__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$hash); 
+Sk.builtin.complex.prototype.__hash__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$hash);
 
 Sk.builtin.complex.prototype.int$add = function __add__(self, other){
     Sk.builtin.pyCheckArgsLen("__add__", arguments.length, 1, 1, true);
     return self.nb$add.call(self, other);
 };
 Sk.builtin.complex.prototype.int$add.co_name = new Sk.builtin.str("__add__");
-Sk.builtin.complex.prototype.__add__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$add); 
+Sk.builtin.complex.prototype.__add__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$add);
 
 
 Sk.builtin.complex.prototype.int$repr = function __repr__(self){
@@ -990,7 +989,7 @@ Sk.builtin.complex.prototype.int$repr = function __repr__(self){
     return self["r$"].call(self);
 };
 Sk.builtin.complex.prototype.int$repr.co_name = new Sk.builtin.str("__repr__");
-Sk.builtin.complex.prototype.__repr__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$repr); 
+Sk.builtin.complex.prototype.__repr__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$repr);
 
 Sk.builtin.complex.prototype.int$str = function __str__(self){
     Sk.builtin.pyCheckArgsLen("__str__", arguments.length, 0, 0, true);
@@ -998,62 +997,62 @@ Sk.builtin.complex.prototype.int$str = function __str__(self){
     return self.tp$str.call(self);
 };
 Sk.builtin.complex.prototype.int$str.co_name = new Sk.builtin.str("__str__");
-Sk.builtin.complex.prototype.__str__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$str); 
+Sk.builtin.complex.prototype.__str__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$str);
 
 Sk.builtin.complex.prototype.int$sub = function __sub__(self, other){
     Sk.builtin.pyCheckArgsLen("__sub__", arguments.length, 1, 1, true);
     return self.nb$subtract.call(self, other);
 };
 Sk.builtin.complex.prototype.int$sub.co_name = new Sk.builtin.str("__sub__");
-Sk.builtin.complex.prototype.__sub__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$sub); 
+Sk.builtin.complex.prototype.__sub__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$sub);
 
 Sk.builtin.complex.prototype.int$mul = function __mul__(self, other){
     Sk.builtin.pyCheckArgsLen("__mul__", arguments.length, 1, 1, true);
     return self.nb$multiply.call(self, other);
 };
 Sk.builtin.complex.prototype.int$mul.co_name = new Sk.builtin.str("__mul__");
-Sk.builtin.complex.prototype.__mul__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$mul); 
+Sk.builtin.complex.prototype.__mul__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$mul);
 
 Sk.builtin.complex.prototype.int$div = function __div__(self, other){
     Sk.builtin.pyCheckArgsLen("__div__", arguments.length, 1, 1, true);
     return self.nb$divide.call(self, other);
 };
 Sk.builtin.complex.prototype.int$div.co_name = new Sk.builtin.str("__div__");
-Sk.builtin.complex.prototype.__div__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$div); 
+Sk.builtin.complex.prototype.__div__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$div);
 
 Sk.builtin.complex.prototype.int$floordiv = function __floordiv__(self, other){
     Sk.builtin.pyCheckArgsLen("__floordiv__", arguments.length, 1, 1, true);
     return self.nb$floor_divide.call(self, other);
 };
 Sk.builtin.complex.prototype.int$floordiv.co_name = new Sk.builtin.str("__floordiv__");
-Sk.builtin.complex.prototype.__floordiv__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$floordiv); 
+Sk.builtin.complex.prototype.__floordiv__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$floordiv);
 
 Sk.builtin.complex.prototype.int$mod = function __mod__(self, other){
     Sk.builtin.pyCheckArgsLen("__mod__", arguments.length, 1, 1, true);
     return self.nb$remainder.call(self, other);
 };
 Sk.builtin.complex.prototype.int$mod.co_name = new Sk.builtin.str("__mod__");
-Sk.builtin.complex.prototype.__mod__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$mod); 
+Sk.builtin.complex.prototype.__mod__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$mod);
 
 Sk.builtin.complex.prototype.int$pow = function __pow__(self, other, z){
     Sk.builtin.pyCheckArgsLen("__pow__", arguments.length, 1, 2, true);
     return self.nb$power.call(self, other, z);
 };
 Sk.builtin.complex.prototype.int$pow.co_name = new Sk.builtin.str("__pow__");
-Sk.builtin.complex.prototype.__pow__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$pow); 
+Sk.builtin.complex.prototype.__pow__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$pow);
 
 Sk.builtin.complex.prototype.int$neg = function __neg__(self){
     Sk.builtin.pyCheckArgsLen("__neg__", arguments.length, 0, 0, true);
     return self.nb$negative.call(self);
 };
-Sk.builtin.complex.prototype.__neg__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$neg); 
+Sk.builtin.complex.prototype.__neg__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$neg);
 
 Sk.builtin.complex.prototype.int$pos = function __pos__(self){
     Sk.builtin.pyCheckArgsLen("__pos__", arguments.length, 0, 0, true);
     return self.nb$positive.call(self);
 };
 Sk.builtin.complex.prototype.int$pos.co_name = new Sk.builtin.str("__pos__");
-Sk.builtin.complex.prototype.__pos__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$pos); 
+Sk.builtin.complex.prototype.__pos__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$pos);
 
 Sk.builtin.complex.prototype.int$conjugate = function conjugate(self){
     Sk.builtin.pyCheckArgsLen("conjugate", arguments.length, 0, 0, true);
@@ -1063,7 +1062,7 @@ Sk.builtin.complex.prototype.int$conjugate = function conjugate(self){
     return new Sk.builtin.complex(self.real, new Sk.builtin.float_(_imag));
 };
 Sk.builtin.complex.prototype.int$conjugate.co_name = new Sk.builtin.str("conjugate");
-Sk.builtin.complex.prototype.conjugate = new Sk.builtin.func(Sk.builtin.complex.prototype.int$conjugate); 
+Sk.builtin.complex.prototype.conjugate = new Sk.builtin.func(Sk.builtin.complex.prototype.int$conjugate);
 
 // deprecated
 Sk.builtin.complex.prototype.int$divmod = function __divmod__(self, other){
@@ -1087,7 +1086,7 @@ Sk.builtin.complex.prototype.int$divmod = function __divmod__(self, other){
     return z;
 };
 Sk.builtin.complex.prototype.int$divmod.co_name = new Sk.builtin.str("__divmod__");
-Sk.builtin.complex.prototype.__divmod__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$divmod); 
+Sk.builtin.complex.prototype.__divmod__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$divmod);
 
 Sk.builtin.complex.prototype.int$getnewargs = function __getnewargs__(self){
     Sk.builtin.pyCheckArgsLen("__getnewargs__", arguments.length, 0, 0, true);
@@ -1095,7 +1094,7 @@ Sk.builtin.complex.prototype.int$getnewargs = function __getnewargs__(self){
     return new Sk.builtin.tuple([self.real, self.imag]);
 };
 Sk.builtin.complex.prototype.int$getnewargs.co_name = new Sk.builtin.str("__getnewargs__");
-Sk.builtin.complex.prototype.__getnewargs__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$getnewargs); 
+Sk.builtin.complex.prototype.__getnewargs__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$getnewargs);
 
 Sk.builtin.complex.prototype.int$nonzero = function __nonzero__(self){
     Sk.builtin.pyCheckArgsLen("__nonzero__", arguments.length, 0, 0, true);
@@ -1107,7 +1106,7 @@ Sk.builtin.complex.prototype.int$nonzero = function __nonzero__(self){
     }
 };
 Sk.builtin.complex.prototype.int$nonzero.co_name = new Sk.builtin.str("__nonzero__");
-Sk.builtin.complex.prototype.__nonzero__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$nonzero); 
+Sk.builtin.complex.prototype.__nonzero__ = new Sk.builtin.func(Sk.builtin.complex.prototype.int$nonzero);
 
 
 // ToDo: think about inplace methods too

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,6 +32,62 @@ Sk.builtin.sorted.$defaults = [Sk.builtin.none.none$, Sk.builtin.none.none$, Sk.
 Sk.builtin.dict.$fromkeys.co_name = new Sk.builtin.str("fromkeys");
 Sk.builtin.dict.prototype["fromkeys"] = new Sk.builtin.func(Sk.builtin.dict.$fromkeys);
 
+// String constants
+Sk.builtin.str.$empty = new Sk.builtin.str("");
+
+Sk.builtin.str.$default_factory = new Sk.builtin.str("default_factory");
+Sk.builtin.str.$imag = new Sk.builtin.str("imag");
+Sk.builtin.str.$real = new Sk.builtin.str("real");
+
+Sk.builtin.str.$abs = new Sk.builtin.str("__abs__");
+Sk.builtin.str.$call = new Sk.builtin.str("__call__");
+Sk.builtin.str.$cmp = new Sk.builtin.str("__cmp__");
+Sk.builtin.str.$complex = new Sk.builtin.str("__complex__");
+Sk.builtin.str.$contains = new Sk.builtin.str("__contains__");
+Sk.builtin.str.$copy = new Sk.builtin.str("__copy__");
+Sk.builtin.str.$dict = new Sk.builtin.str("__dict__");
+Sk.builtin.str.$dir = new Sk.builtin.str("__dir__");
+Sk.builtin.str.$enter = new Sk.builtin.str("__enter__");
+Sk.builtin.str.$eq = new Sk.builtin.str("__eq__");
+Sk.builtin.str.$exit = new Sk.builtin.str("__exit__");
+Sk.builtin.str.$index = new Sk.builtin.str("__index__");
+Sk.builtin.str.$init = new Sk.builtin.str("__init__");
+Sk.builtin.str.$int_ = new Sk.builtin.str("__int__");
+Sk.builtin.str.$iter = new Sk.builtin.str("__iter__");
+Sk.builtin.str.$float_ = new Sk.builtin.str("__float__");
+Sk.builtin.str.$format = new Sk.builtin.str("__format__");
+Sk.builtin.str.$ge = new Sk.builtin.str("__ge__");
+Sk.builtin.str.$getattr = new Sk.builtin.str("__getattr__");
+Sk.builtin.str.$getattribute = new Sk.builtin.str("__getattribute__");
+Sk.builtin.str.$getitem = new Sk.builtin.str("__getitem__");
+Sk.builtin.str.$gt = new Sk.builtin.str("__gt__");
+Sk.builtin.str.$le = new Sk.builtin.str("__le__");
+Sk.builtin.str.$len = new Sk.builtin.str("__len__");
+Sk.builtin.str.$lt = new Sk.builtin.str("__lt__");
+Sk.builtin.str.$name = new Sk.builtin.str("__name__");
+Sk.builtin.str.$ne = new Sk.builtin.str("__ne__");
+Sk.builtin.str.$new = new Sk.builtin.str("__new__");
+Sk.builtin.str.$next2 = new Sk.builtin.str("next");
+Sk.builtin.str.$next3 = new Sk.builtin.str("__next__");
+Sk.builtin.str.$path = new Sk.builtin.str("__path__");
+Sk.builtin.str.$repr = new Sk.builtin.str("__repr__");
+Sk.builtin.str.$reversed = new Sk.builtin.str("__reversed__");
+Sk.builtin.str.$round = new Sk.builtin.str("__round__");
+Sk.builtin.str.$setattr = new Sk.builtin.str("__setattr__");
+Sk.builtin.str.$setitem = new Sk.builtin.str("__setitem__");
+Sk.builtin.str.$str = new Sk.builtin.str("__str__");
+Sk.builtin.str.$trunc = new Sk.builtin.str("__trunc__");
+Sk.builtin.str.$write = new Sk.builtin.str("write");
+
+Sk.misceval.op2method_ = {
+    "Eq"   : Sk.builtin.str.$eq,
+    "NotEq": Sk.builtin.str.$ne,
+    "Gt"   : Sk.builtin.str.$gt,
+    "GtE"  : Sk.builtin.str.$ge,
+    "Lt"   : Sk.builtin.str.$lt,
+    "LtE"  : Sk.builtin.str.$le
+};
+
 var builtinNames = [
     "int_",
     "lng",

--- a/src/dict.js
+++ b/src/dict.js
@@ -455,7 +455,7 @@ Sk.builtin.dict.prototype.__len__ = new Sk.builtin.func(function (self) {
 Sk.builtin.dict.prototype.__getattribute__ = new Sk.builtin.func(function (self, attr) {
     Sk.builtin.pyCheckArgsLen("__getattribute__", arguments.length, 1, 1, false, true);
     if (!Sk.builtin.checkString(attr)) { throw new Sk.builtin.TypeError("__getattribute__ requires a string"); }
-    return Sk.builtin.dict.prototype.tp$getattr.call(self, Sk.ffi.remapToJs(attr));
+    return Sk.builtin.dict.prototype.tp$getattr.call(self, attr);
 });
 
 Sk.builtin.dict.prototype.__iter__ = new Sk.builtin.func(function (self) {

--- a/src/float.js
+++ b/src/float.js
@@ -57,7 +57,7 @@ Sk.builtin.float_ = function (x) {
     }
 
     // try calling __float__
-    var special = Sk.abstr.lookupSpecial(x, "__float__");
+    var special = Sk.abstr.lookupSpecial(x, Sk.builtin.str.$float_);
     if (special != null) {
         // method on builtin, provide this arg
         return Sk.misceval.callsimArray(special, [x]);
@@ -164,7 +164,7 @@ Sk.builtin.float_.PyFloat_AsDouble = function (op) {
     }
 
     // check if special method exists (nb_float is not implemented in skulpt, hence we use __float__)
-    f = Sk.builtin.type.typeLookup(op.ob$type, "__float__");
+    f = Sk.builtin.type.typeLookup(op.ob$type, Sk.builtin.str.$float_);
     if (f == null) {
         throw new Sk.builtin.TypeError("a float is required");
     }

--- a/src/function.js
+++ b/src/function.js
@@ -146,7 +146,7 @@ Sk.builtin.checkCallable = function (obj) {
         return true;
     }
     // go up the prototype chain to see if the class has a __call__ method
-    if (Sk.abstr.lookupSpecial(obj, "__call__") !== undefined) {
+    if (Sk.abstr.lookupSpecial(obj, Sk.builtin.str.$call) !== undefined) {
         return true;
     }
     return false;

--- a/src/import.js
+++ b/src/import.js
@@ -175,9 +175,9 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, rela
     var ret;
     var module;
     var topLevelModuleToReturn = null;
-    var relativePackageName = relativeToPackage !== undefined ? relativeToPackage.tp$getattr("__name__") : undefined;
+    var relativePackageName = relativeToPackage !== undefined ? relativeToPackage.tp$getattr(Sk.builtin.str.$name) : undefined;
     var absolutePackagePrefix = relativePackageName !== undefined ? relativePackageName.v + "." : "";
-    var searchPath = relativeToPackage !== undefined ? relativeToPackage.tp$getattr("__path__") : undefined;
+    var searchPath = relativeToPackage !== undefined ? relativeToPackage.tp$getattr(Sk.builtin.str.$path) : undefined;
     Sk.importSetUpPath(canSuspend);
 
     if (relativeToPackage && !relativePackageName) {
@@ -231,7 +231,7 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, rela
             }
             parentModule = Sk.sysmodules.mp$subscript(absolutePackagePrefix + parentModName);
             searchFileName = modNameSplit[modNameSplit.length-1];
-            searchPath = parentModule.tp$getattr("__path__");
+            searchPath = parentModule.tp$getattr(Sk.builtin.str.$path);
         }
 
         // otherwise:
@@ -389,13 +389,13 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, rela
         if (topLevelModuleToReturn) {
             // if we were a dotted name, then we want to return the top-most
             // package. we store ourselves into our parent as an attribute
-            parentModule.tp$setattr(modNameSplit[modNameSplit.length - 1], module);
+            parentModule.tp$setattr(new Sk.builtin.str(modNameSplit[modNameSplit.length - 1]), module);
             //print("import returning parent module, modname", modname, "__name__", toReturn.tp$getattr("__name__").v);
             return topLevelModuleToReturn;
         }
 
         if (relativeToPackage) {
-            relativeToPackage.tp$setattr(name, module);
+            relativeToPackage.tp$setattr(new Sk.builtin.str(name), module);
         }
 
         //print("name", name, "modname", modname, "returning leaf");
@@ -418,7 +418,7 @@ Sk.importModule = function (name, dumpJS, canSuspend) {
 Sk.importMain = function (name, dumpJS, canSuspend) {
     Sk.dateSet = false;
     Sk.filesLoaded = false;
-    //	Added to reset imports
+    // Added to reset imports
     Sk.sysmodules = new Sk.builtin.dict([]);
     Sk.realsyspath = undefined;
 
@@ -441,7 +441,7 @@ Sk.importMain = function (name, dumpJS, canSuspend) {
 Sk.importMainWithBody = function (name, dumpJS, body, canSuspend) {
     Sk.dateSet = false;
     Sk.filesLoaded = false;
-    //	Added to reset imports
+    // Added to reset imports
     Sk.sysmodules = new Sk.builtin.dict([]);
     Sk.realsyspath = undefined;
 
@@ -553,7 +553,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
 
                     // "ret" is the module we're importing from
                     // Only import from file system if we have not found the fromName in the current module
-                    if (fromName != "*" && leafModule.tp$getattr(fromName) === undefined) {
+                    if (fromName != "*" && leafModule.tp$getattr(new Sk.builtin.str(fromName)) === undefined) {
                         importChain = Sk.misceval.chain(importChain,
                             Sk.importModuleInternal_.bind(null, fromName, undefined, undefined, undefined, leafModule, true, true)
                         );

--- a/src/int.js
+++ b/src/int.js
@@ -26,6 +26,7 @@
  */
 Sk.builtin.int_ = function (x, base) {
     var val;
+    var func;
     var ret; // return value
     var magicName; // name of magic method
 
@@ -88,18 +89,18 @@ Sk.builtin.int_ = function (x, base) {
      *  1. __int__
      *  2. __trunc__
      */
-    if(x !== undefined && (x.tp$getattr && x.tp$getattr("__int__"))) {
+    if(x !== undefined && (x.tp$getattr && (func = x.tp$getattr(Sk.builtin.str.$int_)))) {
         // calling a method which contains im_self and im_func
         // causes skulpt to automatically map the im_self as first argument
-        ret = Sk.misceval.callsimArray(x.tp$getattr("__int__"));
+        ret = Sk.misceval.callsimArray(func);
         magicName = "__int__";
     } else if(x !== undefined && x.__int__) {
         // required for internal types
         // __int__ method is on prototype
         ret = Sk.misceval.callsimArray(x.__int__, [x]);
         magicName = "__int__";
-    } else if(x !== undefined && (x.tp$getattr && x.tp$getattr("__trunc__"))) {
-        ret = Sk.misceval.callsimArray(x.tp$getattr("__trunc__"));
+    } else if(x !== undefined && (x.tp$getattr && (func = x.tp$getattr(Sk.builtin.str.$trunc)))) {
+        ret = Sk.misceval.callsimArray(func);
         magicName = "__trunc__";
     } else if(x !== undefined && x.__trunc__) {
         ret = Sk.misceval.callsimArray(x.__trunc__, [x]);

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -16,7 +16,7 @@ Sk.builtin.iterator = function (obj, sentinel) {
     if (obj instanceof Sk.builtin.generator) {
         return obj;
     }
-    objit = Sk.abstr.lookupSpecial(obj, "__iter__");
+    objit = Sk.abstr.lookupSpecial(obj, Sk.builtin.str.$iter);
     if (objit) {
         return Sk.misceval.callsimArray(objit, [obj]);
     }
@@ -25,12 +25,12 @@ Sk.builtin.iterator = function (obj, sentinel) {
     this.idx = 0;
     this.obj = obj;
     if (sentinel === undefined) {
-        this.getitem = Sk.abstr.lookupSpecial(obj, "__getitem__");
+        this.getitem = Sk.abstr.lookupSpecial(obj, Sk.builtin.str.$getitem);
         this.$r = function () {
             return new Sk.builtin.str("<iterator object>");
         };
     } else {
-        this.call = Sk.abstr.lookupSpecial(obj, "__call__");
+        this.call = Sk.abstr.lookupSpecial(obj, Sk.builtin.str.$call);
         this.$r = function () {
             return new Sk.builtin.str("<callable-iterator object>");
         };

--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -128,7 +128,7 @@ $builtinmodule = function (name) {
         $loc.__str__ = $loc.__repr__;
 
         $loc.__getattribute__ = new Sk.builtin.func(function (self, attr) {
-            return self.tp$getattr(Sk.ffi.remapToJs(attr));
+            return self.tp$getattr(attr);
         });
 
         $loc.append = new Sk.builtin.func(function (self, item) {

--- a/src/lib/collections.js
+++ b/src/lib/collections.js
@@ -554,15 +554,16 @@ var $builtinmodule = function (name) {
                 return new Sk.builtin.str(nm + "(" + ret + ")");
             };
 
-            cons.prototype.tp$getattr = function (name) {
-                var i = flds.indexOf(name);
+            cons.prototype.tp$getattr = function (pyName) {
+                var jsName = pyName.$jsstr();
+                var i = flds.indexOf(jsName);
                 if (i >= 0) {
                     return this.v[i];
                 }
                 return undefined;
             };
 
-            cons.prototype.tp$setattr = function (name, value) {
+            cons.prototype.tp$setattr = function (pyName, value) {
                 throw new Sk.builtin.AttributeError("can't set attribute");
             };
 

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -64,7 +64,7 @@ Sk.misceval.isIndex = function (o) {
     if (Sk.builtin.checkInt(o)) {
         return true;
     }
-    if (Sk.abstr.lookupSpecial(o, "__index__")) {
+    if (Sk.abstr.lookupSpecial(o, Sk.builtin.str.$index)) {
         return true;
     }
     return false;
@@ -98,7 +98,7 @@ Sk.misceval.asIndex = function (o) {
     if (o.constructor === Sk.builtin.bool) {
         return Sk.builtin.asnum$(o);
     }
-    idxfn = Sk.abstr.lookupSpecial(o, "__index__");
+    idxfn = Sk.abstr.lookupSpecial(o, Sk.builtin.str.$index);
     if (idxfn) {
         ret = Sk.misceval.callsimArray(idxfn, [o]);
         if (!Sk.builtin.checkInt(ret)) {
@@ -420,16 +420,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     // depending on the op, try left:op:right, and if not, then
     // right:reversed-top:left
 
-    op2method = {
-        "Eq"   : "__eq__",
-        "NotEq": "__ne__",
-        "Gt"   : "__gt__",
-        "GtE"  : "__ge__",
-        "Lt"   : "__lt__",
-        "LtE"  : "__le__"
-    };
-
-    method = Sk.abstr.lookupSpecial(v, op2method[op]);
+    method = Sk.abstr.lookupSpecial(v, this.op2method_[op]);
     if (method && !v_has_shortcut) {
         ret = Sk.misceval.callsimArray(method, [v, w]);
         if (ret != Sk.builtin.NotImplemented.NotImplemented$) {
@@ -437,7 +428,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
         }
     }
 
-    swapped_method = Sk.abstr.lookupSpecial(w, op2method[Sk.misceval.swappedOp_[op]]);
+    swapped_method = Sk.abstr.lookupSpecial(w, this.op2method_[Sk.misceval.swappedOp_[op]]);
     if (swapped_method && !w_has_shortcut) {
         ret = Sk.misceval.callsimArray(swapped_method, [w, v]);
         if (ret != Sk.builtin.NotImplemented.NotImplemented$) {
@@ -445,7 +436,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
         }
     }
 
-    vcmp = Sk.abstr.lookupSpecial(v, "__cmp__");
+    vcmp = Sk.abstr.lookupSpecial(v, Sk.builtin.str.$cmp);
     if (vcmp) {
         try {
             ret = Sk.misceval.callsimArray(vcmp, [v, w]);
@@ -474,7 +465,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
         }
     }
 
-    wcmp = Sk.abstr.lookupSpecial(w, "__cmp__");
+    wcmp = Sk.abstr.lookupSpecial(w, Sk.builtin.str.$cmp);
     if (wcmp) {
         // note, flipped on return value and call
         try {
@@ -1181,7 +1172,7 @@ Sk.misceval.applyOrSuspend = function (func, kwdict, varargseq, kws, args) {
     if (func === null || func instanceof Sk.builtin.none) {
         throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(func) + "' object is not callable");
     }
-    
+
     if (typeof func === "function" && func.tp$call === undefined) {
         func = new Sk.builtin.func(func);
     }

--- a/src/str.js
+++ b/src/str.js
@@ -69,6 +69,10 @@ goog.exportSymbol("Sk.builtin.str", Sk.builtin.str);
 
 Sk.abstr.setUpInheritance("str", Sk.builtin.str, Sk.builtin.seqtype);
 
+Sk.builtin.str.prototype.$jsstr = function () {
+    return this.v;
+};
+
 Sk.builtin.str.prototype.mp$subscript = function (index) {
     var ret;
     if (Sk.misceval.isIndex(index)) {
@@ -993,7 +997,7 @@ Sk.builtin.str.prototype.nb$remainder = function (rhs) {
                 neg = n.nb$isnegative();
             } else if (n instanceof Sk.builtin.lng) {
                 r = n.str$(base, false);
-                neg = n.nb$isnegative();	//	neg = n.size$ < 0;	RNL long.js change
+                neg = n.nb$isnegative();
             }
 
             goog.asserts.assert(r !== undefined, "unhandled number format");

--- a/src/structseq.js
+++ b/src/structseq.js
@@ -73,16 +73,17 @@ Sk.builtin.make_structseq = function (module, name, fields, doc) {
         }
         return new Sk.builtin.str(nm + "(" + ret + ")");
     };
-    cons.prototype.tp$setattr = function (name, value) {
+    cons.prototype.tp$setattr = function (pyName, value) {
         throw new Sk.builtin.AttributeError("readonly property");
     };
 
-    cons.prototype.tp$getattr = function (name) {
-        var i = flds.indexOf(name);
+    cons.prototype.tp$getattr = function (pyName) {
+        var jsName = pyName.$jsstr();
+        var i = flds.indexOf(jsName);
         if (i >= 0) {
             return this.v[i];
         } else {
-            return  Sk.builtin.object.prototype.GenericGetAttr(name);
+            return  Sk.builtin.object.prototype.GenericGetAttr(pyName);
         }
     };
 

--- a/src/typeobject.js
+++ b/src/typeobject.js
@@ -70,18 +70,17 @@ Sk.abstr.setUpInheritance("super", Sk.builtin.super_, Sk.builtin.object);
 
 /**
  * Get an attribute
- * @param {string} name JS name of the attribute
+ * @param {Object} pyName Python name of the attribute
  * @param {boolean=} canSuspend Can we return a suspension?
  * @return {undefined}
  */
-Sk.builtin.super_.prototype.tp$getattr = function (name, canSuspend) {
+Sk.builtin.super_.prototype.tp$getattr = function (pyName, canSuspend) {
     var res;
     var f;
     var descr;
     var tp;
     var dict;
-    var pyName = new Sk.builtin.str(name);
-    goog.asserts.assert(typeof name === "string");
+    var jsName = pyName.$jsstr();
 
     tp = this.obj_type;
     goog.asserts.assert(tp !== undefined, "object has no ob$type!");
@@ -96,14 +95,14 @@ Sk.builtin.super_.prototype.tp$getattr = function (name, canSuspend) {
             res = Sk.builtin._tryGetSubscript(dict, pyName);
         } else if (typeof dict === "object") {
             // todo; definitely the wrong place for this. other custom tp$getattr won't work on object -- bnm -- implemented custom __getattr__ in abstract.js
-            res = dict[name];
+            res = dict[jsName];
         }
         if (res !== undefined) {
             return res;
         }
     }
 
-    descr = Sk.builtin.type.typeLookup(tp, name);
+    descr = Sk.builtin.type.typeLookup(tp, pyName);
 
     // otherwise, look in the type for a descr
     if (descr !== undefined && descr !== null) {


### PR DESCRIPTION
In this pull request, all of the get/set attribute functions are converted to take Python strings for the attribute names.  To make it more clear when a variable holds a Python string or a JS string, all variables holding attribute names are called ```pyName``` or ```jsName``` as appropriate.  Python strings for attributes are created once in ```constants.js``` so that they can be used directly.

There are two reasons for this change:

1. The attribute infrastructure can sometimes be relatively deep, and functions were converting names back and forth between Javascript and Python.  This pull request normalizes things so that you always pass down a Python string everywhere.  Previously, the internal functions took Javascript strings and the Python-facing functions took Python strings.  But, these functions have to call each other, and therefore convert their attribute names.
2. The ```Sk.builtin.str``` function is relatively heavyweight.  So, it's expensive to convert a Javascript string into a Python string.  The reverse is very cheap - just grab the ```.v``` attribute.  Given that in many/most instances the Python string object existed somewhere, it was a complete waste to reconstruct it elsewhere.  I added ```Sk.builtin.str.$jsstr()``` to extract the Javascript string from the Python string, rather than directly accessing ```.v```.  Using ```Sk.ffi.remapToJs``` was a waste, as you know you have a Python string, so the type checks in there are unnecessary.

When I originally did this, it yielded a substantial performance benefit for me by eliminating an enormous number of calls to ```Sk.builtin.str```.  I did not rerun any performance tests here.  I feel that whether it still has gains or not, it is still the right thing to do and it makes reading, understanding, and extending the attribute infrastructure much easier (in my opinion) regardless.

For external libraries that explicitly get/set attributes or provide their own get/set attribute functions, this is potentially a breaking change.  You would now have to accept and pass Python string objects as the attribute names.  It is not possible to provide backward compatibility, nor do I think it makes any sense to do so.  We either agree to normalize things this way or we don't.  Leaving some infrastructure the old way is messier than just leaving it all alone, in my opinion.

The one thing that might be an issue is that the test coverage of the libraries is quite light compared to the core.  So, it is possible that there is infrastructure in a library that is not getting tested that does operate on attributes in an incompatible way.  While I have been using this successfully, I could not just cherry pick some commits out of my repository.  The attribute infrastructure changes a lot (it seems like nearly every pull request by @meredydd or @albertjan touches it in some way), so I have repaired things continuously for a long time.  Meaning, I may have missed some modifications that are not explicitly tested by our test suite.  And I do not use all of the modules in ```lib``` (most notably turtle), so those could have issues, too, if they have insufficient test coverage.

