### PR TITLE
Check for integer overflow on add/subtract and fall back to long math.

### DIFF
--- a/src/int.js
+++ b/src/int.js
@@ -216,9 +216,16 @@ Sk.builtin.int_.prototype.clone = function () {
 /** @override */
 Sk.builtin.int_.prototype.nb$add = function (other) {
     var thisAsLong, thisAsFloat;
+    var result;
 
     if (other instanceof Sk.builtin.int_) {
-        return new Sk.builtin.int_(this.v + other.v);
+        result = this.v + other.v;
+        if (result > Sk.builtin.int_.threshold$ ||
+            result < -Sk.builtin.int_.threshold$) {
+            thisAsLong = new Sk.builtin.lng(this.v);
+            return thisAsLong.nb$add(other);
+        }
+        return new Sk.builtin.int_(result);
     }
 
     if (other instanceof Sk.builtin.lng) {
@@ -244,9 +251,16 @@ Sk.builtin.int_.prototype.nb$reflected_add = function (other) {
 /** @override */
 Sk.builtin.int_.prototype.nb$subtract = function (other) {
     var thisAsLong, thisAsFloat;
+    var result;
 
     if (other instanceof Sk.builtin.int_) {
-        return new Sk.builtin.int_(this.v - other.v);
+        result = this.v - other.v;
+        if (result > Sk.builtin.int_.threshold$ ||
+            result < -Sk.builtin.int_.threshold$) {
+            thisAsLong = new Sk.builtin.lng(this.v);
+            return thisAsLong.nb$subtract(other);
+        }
+        return new Sk.builtin.int_(result);
     }
 
     if (other instanceof Sk.builtin.lng) {

--- a/test/unit3/test_int.py
+++ b/test/unit3/test_int.py
@@ -452,5 +452,24 @@ class IntTestCases(unittest.TestCase):
         # check('123\ud800')
         # check('123\ud800', 10)
 
+    def test_skulpt_overflow(self):
+        x = 8000000000000000
+        y = 2821521012635269
+
+        # Addition
+        z = x + y
+        self.assertEqual(z, 10821521012635269)
+
+        # Subtraction
+        y = -y
+        z = x - y
+        self.assertEqual(z, 10821521012635269)
+
+        # Multiplication
+        x = 8000000000000123
+        y = 2821521012635269
+        z = x * y
+        self.assertEqual(z, 22572168101082499047084554138087)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add some simple checks to determine if add/subtract result overflows integers and use long add/subtract when it does.  This fix was so simple, I'm not sure why we didn't do it long ago...

I ran a simple performance test, and using d8, I see about a 2% overhead to doing these checks on a long running while loop that does nothing but add/subtract numbers that don't overflow.

Fixes: #729 