### PR TITLE
readline-sync strips whitespace which is not ideal for python :D

### DIFF
--- a/repl/repl.js
+++ b/repl/repl.js
@@ -4,7 +4,7 @@ var readlineSync = require('readline-sync');
 var fs = require('fs');
 
 var readline = function () {
-    return readlineSync.question("");
+    return readlineSync.question("", { keepWhitespace: true });
 };
 
 Sk.configure({
@@ -105,7 +105,7 @@ while (true) {
             process.exit();
         }
 
-        console.log(err);
+        console.log(err.toString());
 
         var index = -1;
         //find the line number


### PR DESCRIPTION
Little fix for the repl.

- `readsync` striped whitespace
- `console.log` tries to pretty print the error so a `.toString()` was required to make it nice.