### PR TITLE
Fix/decode escape

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -1726,7 +1726,7 @@ function parsestr (c, s) {
                 ret += c;
             }
         }
-        return ret;
+        return decodeUtf8(ret);
     };
 
     // console.log("parsestr", s);

--- a/test/unit/test_unicode.py
+++ b/test/unit/test_unicode.py
@@ -1,0 +1,15 @@
+import unittest
+
+class TestUnicode(unittest.TestCase):
+    def test_normal_string_should_be_parsed_correctly(self):
+        unicode_string = u"这是"
+        self.assertIn(u"是", unicode_string)
+
+    def test_string_with_escape_should_be_parsed_correctly(self):
+        unicode_string = u"这是\n这这这"
+        self.assertIn(u"是", unicode_string)
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A unicode string with an escape in it didn't get correctly decoded, this addresses this.

fixes #871 