### PR TITLE
Fix string formatting bug that mutates interned strings.

### DIFF
--- a/src/str.js
+++ b/src/str.js
@@ -1138,13 +1138,14 @@ Sk.builtin.str.prototype.nb$remainder = function (rhs) {
             return r.v;
         } else if (conversionType === "s") {
             r = new Sk.builtin.str(value);
+            r = r.$jsstr();
             if (precision) {
-                return r.v.substr(0, precision);
+                return r.substr(0, precision);
             }
             if(fieldWidth) {
-                r.v = handleWidth([" ", r.v]);
+                r = handleWidth([" ", r]);
             }
-            return r.v;
+            return r;
         } else if (conversionType === "%") {
             return "%";
         }


### PR DESCRIPTION
This fixes #876.  This is a textbook example of why we shouldn't be messing with ```.v```.  Line 1145 mutated the internal representation of another string.  If that string were unique, it would be okay.  But, given that it's interned, this messes up all strings with the same original value now and in the future.

I don't think this affects #871, does it?

Please merge this quickly.

