### PR TITLE
Fixes to failing Python 3 tests

### DIFF
--- a/src/function.js
+++ b/src/function.js
@@ -267,6 +267,9 @@ Sk.builtin.func.prototype.tp$name = "function";
 
 Sk.builtin.func.prototype.tp$descr_get = function (obj, objtype) {
     Sk.asserts.assert(!(obj === undefined && objtype === undefined));
+    if (obj === Sk.builtin.none.none$) {
+        return this;
+    }
     if (objtype && objtype.tp$name in Sk.builtin && Sk.builtin[objtype.tp$name] === objtype) {
         // it's a builtin
         return new Sk.builtin.method(this, obj, objtype, true);

--- a/src/lib/collections.js
+++ b/src/lib/collections.js
@@ -39,6 +39,21 @@ var $builtinmodule = function (name) {
             return new Sk.builtin.str("defaultdict(" + def_str + ", " + dict_str + ")");
         };
 
+        mod.defaultdict.prototype['__copy__'] = function (self) {
+            var v;
+            var iter, k;
+            var ret = [];
+
+            for (iter = Sk.abstr.iter(self), k = iter.tp$iternext();
+                k !== undefined;
+                k = iter.tp$iternext()) {
+                v = self.mp$subscript(k);
+                ret.push(k);
+                ret.push(v);
+            }
+            return new mod.defaultdict(self['$d']['default_factory'], ret);
+        };
+
         mod.defaultdict.prototype['__missing__'] = function (key) {
             Sk.builtin.pyCheckArgsLen('__missing__', arguments.length, 0, 1);
             if (key) {

--- a/src/object.js
+++ b/src/object.js
@@ -139,8 +139,7 @@ Sk.builtin.object.prototype.GenericSetAttr = function (pyName, value, canSuspend
     dict = this["$d"] || this.constructor["$d"];
 
     if (jsName == "__class__") {
-        if (value.tp$mro === undefined || value.tp$name === undefined ||
-            value.tp$name === undefined) {
+        if (value.tp$mro === undefined || value.tp$name === undefined) {
             throw new Sk.builtin.TypeError(
                       "attempted to assign non-class to __class__");
         }

--- a/test/unit3/test_defaultdict.py
+++ b/test/unit3/test_defaultdict.py
@@ -96,10 +96,13 @@ class TestDefaultDict(unittest.TestCase):
     #     self.assertEqual(e['a'], 42)
 
     def test_shallow_copy(self):
-        d1 = defaultdict(foobar, {1: 1})
+        d1 = defaultdict(foobar, {1: 1, 2:[2]})
         d2 = copy.copy(d1)
+        d1[2][0] = 3
         self.assertEqual(d2.default_factory, foobar)
         self.assertEqual(d2, d1)
+        d2[1] = 2
+        self.assertNotEqual(d2,d1)
         d1.default_factory = list
         d2 = copy.copy(d1)
         self.assertEqual(d2.default_factory, list)


### PR DESCRIPTION
This pull request fixes the Python 3 failures in ```test_defaultdict.py``` and ```test_class.py``` that were discovered in #889.