### PR TITLE
Add ES5 and unminified builds to skulpt-dist.

### DIFF
--- a/dist-update.sh
+++ b/dist-update.sh
@@ -55,6 +55,10 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_TEST_RESULT" == "0" && "$TRA
     cd ..
     cp bower.json ../dist
     cp .bowerrc ../dist
+    npm run devbuild
+    cp dist/skulpt.js ../dist/skulpt.js
+    npm run build-es5
+    cp dist/skulpt.min.js ../dist/skulpt.es5.min.js
     #put the new version in the dist repository
     cd ../dist
     git add .
@@ -80,6 +84,10 @@ if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_TEST_RESULT" == "0" && "$TRA
   cd ..
   cp bower.json ../dist
   cp .bowerrc ../dist
+  npm run devbuild
+  cp dist/skulpt.js ../dist/skulpt.js
+  npm run build-es5
+  cp dist/skulpt.min.js ../dist/skulpt.es5.min.js
 
   #add, commit and push files to the dist repository
   cd ../dist


### PR DESCRIPTION
As requested by @albertjan in #897, I believe this puts an ES5 build into skulpt-dist.  I am not sure how to test this, though, so please look over it carefully to decide if I'm doing the right thing.

It also seems like there is extraneous stuff in here now that the website has been migrated to use GitHub pages, but I left that alone.

We might also consider updating the README in skulpt-dist to explain what the builds are and how to use a CDN to use them directly from that GitHub repository.