### PR TITLE
Stop %% escapes in %-formatted string from consuming a value

### DIFF
--- a/src/str.js
+++ b/src/str.js
@@ -939,7 +939,7 @@ Sk.builtin.str.prototype.nb$remainder = function (rhs) {
         fieldWidth = Sk.builtin.asnum$(fieldWidth);
         precision = Sk.builtin.asnum$(precision);
 
-        if (mappingKey === undefined || mappingKey === "") {
+        if ((mappingKey === undefined || mappingKey === "") && conversionType != "%") {
             i = index++;
         } // ff passes '' not undef for some reason
 

--- a/test/unit/test_format.py
+++ b/test/unit/test_format.py
@@ -201,6 +201,9 @@ class FormatTest(unittest.TestCase):
         self.doboth("%s",{'a':1}, "{'a': 1}")
         self.doboth("%s",[], "[]")
 
+        # test escaping
+        self.doboth("%d%%",(100),"100%")
+
         # alternate float formatting
 #        testformat('%g', 1.1, '1.1')
 #        testformat('%#g', 1.1, '1.10000')


### PR DESCRIPTION
When formatting a string with the % operator, the '%' character
is encoded '%%' (eg '%d%%' % 100 -> '100%').

Skulpt's implementation was consuming an element from the value tuple
for '%%' literals, which was incorrect. This change fixes that, and
adds a test.