### PR TITLE
Obey __all__ in wildcard imports

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -572,11 +572,22 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
 };
 
 Sk.importStar = function (module, loc, global) {
-    var i;
-    var props = Object["getOwnPropertyNames"](module["$d"]);
-    for (i in props) {
-        if (props[i].charAt(0) != "_") {
-            loc[props[i]] = module["$d"][props[i]];
+    var __all__ = module.tp$getattr(new Sk.builtin.str("__all__"));
+
+    if (__all__) {
+        // TODO this does not support naming *modules* in __all__,
+        // only variables
+        for(let it = Sk.abstr.iter(__all__), i = it.tp$iternext();
+            i !== undefined; i = it.tp$iternext()) {
+
+            loc[i.v] = Sk.abstr.gattr(module, i);
+        }
+    } else {
+        let props = Object["getOwnPropertyNames"](module["$d"]);
+        for (let i in props) {
+            if (props[i].substr(0,2) != "_") {
+                loc[props[i]] = module["$d"][props[i]];
+            }
         }
     }
 };

--- a/test/unit/subpackage/implicit_import.py
+++ b/test/unit/subpackage/implicit_import.py
@@ -1,1 +1,7 @@
-pass
+implicit_x = 42
+
+_implicit_y = 43
+
+implicit_z = 44
+
+__all__ = ['implicit_x', '_implicit_y']

--- a/test/unit/subpackage/importable_module.py
+++ b/test/unit/subpackage/importable_module.py
@@ -9,6 +9,9 @@ if __name__ != "subpackage.importable_module":
 
 from implicit_import import *
 
+_implicit_y # will fail if the import isn't right
+if 'implicit_z' in globals() or '_implicit_y' not in globals():
+    raise Exception("Wildcard import not successfully masked off by __all__")
 
 from .explicit_relative_import import explicit_load_succeeded
 if not explicit_load_succeeded:


### PR DESCRIPTION
`import *` wasn't obeying `__all__`. Now it does.

(NB - it does _not_ currently support importing submodules via `__all__`, but this is a strict improvement)