### PR TITLE
Fix bug in default wildcard import policy. Add more tests.

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -585,7 +585,7 @@ Sk.importStar = function (module, loc, global) {
     } else {
         let props = Object["getOwnPropertyNames"](module["$d"]);
         for (let i in props) {
-            if (props[i].substr(0,2) != "_") {
+            if (props[i].charAt(0) != "_") {
                 loc[props[i]] = module["$d"][props[i]];
             }
         }

--- a/test/unit/subpackage/implicit_import_2.py
+++ b/test/unit/subpackage/implicit_import_2.py
@@ -1,0 +1,3 @@
+implicit_a = 42
+
+_implicit_b = 43

--- a/test/unit/subpackage/importable_module.py
+++ b/test/unit/subpackage/importable_module.py
@@ -9,9 +9,12 @@ if __name__ != "subpackage.importable_module":
 
 from implicit_import import *
 
-_implicit_y # will fail if the import isn't right
 if 'implicit_z' in globals() or '_implicit_y' not in globals():
     raise Exception("Wildcard import not successfully masked off by __all__")
+
+from implicit_import_2 import *
+if 'implicit_a' not in globals() or '_implicit_b' in globals():
+    raise Exception("Default wildcard import did not behave")
 
 from .explicit_relative_import import explicit_load_succeeded
 if not explicit_load_succeeded:


### PR DESCRIPTION
Well, this is embarrassing. I introduced a bug in #972 that broke the default `import *` policy (ignoring names that begin with `_`). This PR fixes (and adds a test for) that functionality.