### PR TITLE
Make tokenization errors come out as SyntaxErrors with correct line numbers

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -303,7 +303,7 @@ Sk.parse = function parse (filename, input) {
         };
     }
 
-    Sk._tokenize(readline(input), "utf-8", function (tokenInfo) {
+    Sk._tokenize(filename, readline(input), "utf-8", function (tokenInfo) {
         var s_lineno = tokenInfo.start[0];
         var s_column = tokenInfo.start[1];
         var type = null;

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -1,7 +1,7 @@
 var tokens = Sk.token.tokens
 
-const TokenError = Error;
-const IndentationError = Error;
+const TokenError = Sk.builtin.SyntaxError;
+const IndentationError = Sk.builtin.SyntaxError;
 
 /**
  *
@@ -216,7 +216,7 @@ var tabsize = 8
  * @param {string} encoding
  * @param {function(TokenInfo): void} yield_
  */
-function _tokenize(readline, encoding, yield_) {
+function _tokenize(filename, readline, encoding, yield_) {
     // we make these regexes here because they can
     // be changed by the configuration.
     var LSuffix = !Sk.__future__.python3 ? '(?:L?)' : '';
@@ -278,7 +278,7 @@ function _tokenize(readline, encoding, yield_) {
 
         if (contstr) {                       // continued string
             if (!line) {
-                throw new TokenError("EOF in multi-line string", strstart);
+                throw new TokenError("EOF in multi-line string", filename, strstart[0], strstart[1]);
             }
             endprog.lastIndex = 0;
             var endmatch = endprog.exec(line);
@@ -342,7 +342,7 @@ function _tokenize(readline, encoding, yield_) {
                 if (!contains(indents, column)) {
                     throw new IndentationError(
                         "unindent does not match any outer indentation level",
-                        ["<tokenize>", lnum, pos, line]);
+                        filename, lnum, pos);
                 }
 
                 indents = indents.slice(0, -1);
@@ -351,7 +351,7 @@ function _tokenize(readline, encoding, yield_) {
             }
         } else {                                  // continued statement
             if (!line) {
-                throw new TokenError("EOF in multi-line statement", [lnum, 0]);
+                throw new TokenError("EOF in multi-line statement", filename, lnum, 0);
             }
             continued = 0;
         }


### PR DESCRIPTION
The new tokenizer currently emits weird raw `Error`s without consistent line information. Make these `SyntaxError`s instead, with filenames and line numbers.