### PR TITLE
Support multiple decorators + class decorators (+ symtable fix)

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2036,10 +2036,6 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         out(scopename, ".$kwdefs=[", kw_defaults.join(","), "];");
     }
 
-    if (decos.length > 0) {
-        out(scopename, ".$decorators=[", decos.join(","), "];");
-    }
-
     //
     // attach co_varnames (only the argument names) for keyword argument
     // binding.
@@ -2101,8 +2097,11 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     else {
         var res;
         if (decos.length > 0) {
-            out("$ret = Sk.misceval.callsimOrSuspendArray(", scopename, ".$decorators[0], [new Sk.builtins['function'](", scopename, ",$gbl", frees, ")]);");
-            this._checkSuspension();
+            out("$ret = new Sk.builtins['function'](", scopename, ",$gbl", frees, ");");
+            for (let decorator of decos) {
+                out("$ret = Sk.misceval.callsimOrSuspendArray(", decorator, ",[$ret]);");
+                this._checkSuspension();
+            }
             return this._gr("funcobj", "$ret");
         }
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -2242,10 +2242,8 @@ Compiler.prototype.cclass = function (s) {
     var bases;
     var decos;
     Sk.asserts.assert(s instanceof Sk.astnodes.ClassDef);
-    decos = s.decorator_list;
 
-    // decorators and bases need to be eval'd out here
-    //this.vseqexpr(decos);
+    decos = this.vseqexpr(s.decorator_list);
 
     bases = this.vseqexpr(s.bases);
 
@@ -2276,15 +2274,20 @@ Compiler.prototype.cclass = function (s) {
 
     // build class
 
-    // apply decorators
-
     this.exitScope();
 
     // todo; metaclass
-    wrapped = this._gr("built", "Sk.misceval.buildClass($gbl,", scopename, ",", s.name["$r"]().v, ",[", bases, "], $cell)");
+    out("$ret = Sk.misceval.buildClass($gbl,", scopename, ",", s.name["$r"]().v, ",[", bases, "], $cell);")
+
+    // apply decorators
+
+    for (let decorator of decos) {
+        out("$ret = Sk.misceval.callsimOrSuspendArray(", decorator, ", [$ret]);");
+        this._checkSuspension();
+    }
 
     // store our new class under the right name
-    this.nameop(s.name, Sk.astnodes.Store, wrapped);
+    this.nameop(s.name, Sk.astnodes.Store, "$ret");
 };
 
 Compiler.prototype.ccontinue = function (s) {

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -894,7 +894,8 @@ SymbolTable.prototype.analyzeBlock = function (ste, bound, free, global) {
     if (ste.blockType === FunctionBlock) {
         this.analyzeCells(scope, newfree);
     }
-    this.updateSymbols(ste.symFlags, scope, bound, newfree, ste.blockType === ClassBlock);
+    let discoveredFree = this.updateSymbols(ste.symFlags, scope, bound, newfree, ste.blockType === ClassBlock);
+    ste.hasFree = ste.hasFree || discoveredFree;
 
     _dictUpdate(free, newfree);
 };
@@ -941,6 +942,7 @@ SymbolTable.prototype.updateSymbols = function (symbols, scope, bound, free, cla
     var w;
     var flags;
     var name;
+    var discoveredFree = false;
     for (name in symbols) {
         flags = symbols[name];
         w = scope[name];
@@ -966,7 +968,9 @@ SymbolTable.prototype.updateSymbols = function (symbols, scope, bound, free, cla
             continue;
         }
         symbols[name] = freeValue;
+        discoveredFree = true;
     }
+    return discoveredFree;
 };
 
 SymbolTable.prototype.analyzeName = function (ste, dict, name, flags, bound, local, free, global) {

--- a/test/unit3/test_decorators.py
+++ b/test/unit3/test_decorators.py
@@ -312,13 +312,13 @@ class TestDecorators(unittest.TestCase):
                 return wrapped
             return wrap
 
-        @decorate('first')
-        @decorate('second')
+        @decorate('outer')
+        @decorate('inner')
         def f(x):
             return x
 
         self.assertEqual(42, f(42))
-        self.assertEqual(['first', 'second'], calls)
+        self.assertEqual(['inner', 'outer'], calls)
         
 
 if __name__ == '__main__':

--- a/test/unit3/test_decorators.py
+++ b/test/unit3/test_decorators.py
@@ -319,7 +319,22 @@ class TestDecorators(unittest.TestCase):
 
         self.assertEqual(42, f(42))
         self.assertEqual(['inner', 'outer'], calls)
-        
+
+
+    def test_class_decorator(self):
+        def decorate(c):
+            def f():
+                return c(42)
+            return f
+
+        @decorate
+        class Foo:
+            def __init__(self, value):
+                self.value = value
+
+        foo = Foo()
+        self.assertEqual(42, foo.value)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_decorators.py
+++ b/test/unit3/test_decorators.py
@@ -302,5 +302,24 @@ class TestDecorators(unittest.TestCase):
         self.assertEqual(ff.__get__(0, int)(42), (int, 42))
         self.assertEqual(ff.__get__(0)(42), (int, 42))
 
+    def test_nested_decorators(self):
+        calls = []
+        def decorate(call_name):
+            def wrap(f):
+                def wrapped(*args, **kwargs):
+                    calls.append(call_name)
+                    return f(*args, **kwargs)
+                return wrapped
+            return wrap
+
+        @decorate('first')
+        @decorate('second')
+        def f(x):
+            return x
+
+        self.assertEqual(42, f(42))
+        self.assertEqual(['first', 'second'], calls)
+        
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously, we only supported up to 1 decorator per function, and did not support class decorators at all. This PR fixes this.

---

In the process of writing the tests for this PR (which are quite closure-heavy), I discovered a nasty `symtable` issue -- namely, that `ste.hasFree` is not set for functions that _contain_ functions with free variables. For example:
```python
def f():
    v = 4
    def g():
        def h():
            return v+1
```
`symtable.js` did not set the `hasFree` flag on `g()`, even though it correctly notices that it has a free variable (`v`), because it computed the `hasFree` flag *before* walking child scopes (in this case, `h()`).

This actually appears to be a logic bug inherited from Python 2's `symtable.c`, which doesn't matter there because CPython's compiler doesn't rely on the `ste_free`(/`hasFree`) flag. Our compiler does, so I have added logic to keep that flag up to date when we gain free variables from child blocks.

(Why yes, it has been a long afternoon. Why do you ask? ;) )