### PR TITLE
Proper unicode support (str/bytes)

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -2241,7 +2241,7 @@ function astForIfexpr (c, n) {
  * s is a python-style string literal, including quote characters and u/r/b
  * prefixes. Returns [decoded string object, is-an-fstring]
  */
-function parsestr (c, s) {
+function parsestr (c, n, s) {
     var encodeUtf8 = function (s) {
         return unescape(encodeURIComponent(s));
     };
@@ -2253,70 +2253,79 @@ function parsestr (c, s) {
         var d2;
         var d1;
         var d0;
-        var c;
+        var ch;
         var i;
         var len = s.length;
         var ret = "";
         for (i = 0; i < len; ++i) {
-            c = s.charAt(i);
-            if (c === "\\") {
+            ch = s.charAt(i);
+            if (ch === "\\") {
                 ++i;
-                c = s.charAt(i);
-                if (c === "n") {
+                ch = s.charAt(i);
+                if (ch === "n") {
                     ret += "\n";
                 }
-                else if (c === "\\") {
+                else if (ch === "\\") {
                     ret += "\\";
                 }
-                else if (c === "t") {
+                else if (ch === "t") {
                     ret += "\t";
                 }
-                else if (c === "r") {
+                else if (ch === "r") {
                     ret += "\r";
                 }
-                else if (c === "b") {
+                else if (ch === "b") {
                     ret += "\b";
                 }
-                else if (c === "f") {
+                else if (ch === "f") {
                     ret += "\f";
                 }
-                else if (c === "v") {
+                else if (ch === "v") {
                     ret += "\v";
                 }
-                else if (c === "0") {
+                else if (ch === "0") {
                     ret += "\0";
                 }
-                else if (c === '"') {
+                else if (ch === '"') {
                     ret += '"';
                 }
-                else if (c === '\'') {
+                else if (ch === '\'') {
                     ret += '\'';
                 }
-                else if (c === "\n") /* escaped newline, join lines */ {
+                else if (ch === "\n") /* escaped newline, join lines */ {
                 }
-                else if (c === "x") {
-                    d0 = s.charAt(++i);
-                    d1 = s.charAt(++i);
-                    ret += encodeUtf8(String.fromCharCode(parseInt(d0 + d1, 16)));
+                else if (ch === "x") {
+                    if (i+2 >= len) {
+                        ast_error(c, n, "Truncated \\xNN escape");
+                    }
+                    ret += String.fromCharCode(parseInt(s.substr(i+1,2), 16));
+                    i += 2;
                 }
-                else if (c === "u" || c === "U") {
-                    d0 = s.charAt(++i);
-                    d1 = s.charAt(++i);
-                    d2 = s.charAt(++i);
-                    d3 = s.charAt(++i);
-                    ret += encodeUtf8(String.fromCharCode(parseInt(d0 + d1, 16), parseInt(d2 + d3, 16)));
+                else if (ch === "u") {
+                    if (i+4 >= len) {
+                        ast_error(c, n, "Truncated \\uXXXX escape");
+                    }
+                    ret += String.fromCharCode(parseInt(s.substr(i+1, 4), 16))
+                    i += 4;
+                }
+                else if (ch === "U") {
+                    if (i+8 >= len) {
+                        ast_error(c, n, "Truncated \\UXXXXXXXX escape");
+                    }
+                    ret += String.fromCodePoint(parseInt(s.substr(i+1, 8), 16))
+                    i += 8;
                 }
                 else {
                     // Leave it alone
-                    ret += "\\" + c;
-                    // Sk.asserts.fail("unhandled escape: '" + c.charCodeAt(0) + "'");
+                    ret += "\\" + ch;
+                    // Sk.asserts.fail("unhandled escape: '" + ch.charCodeAt(0) + "'");
                 }
             }
             else {
-                ret += c;
+                ret += ch;
             }
         }
-        return decodeUtf8(ret);
+        return ret;
     };
 
     //print("parsestr", s);
@@ -2325,6 +2334,7 @@ function parsestr (c, s) {
     var rawmode = false;
     var unicode = false;
     var fmode = false;
+    var bytesmode = false;
 
     // treats every sequence as unicodes even if they are not treated with uU prefix
     // kinda hacking though working for most purposes
@@ -2342,7 +2352,7 @@ function parsestr (c, s) {
             rawmode = true;
         }
         else if (quote === "b" || quote === "B") {
-            Sk.asserts.assert(!"todo; haven't done b'' strings yet")
+            bytesmode = true;
         }
         else if (quote === "f" || quote === "F") {
             fmode = true;
@@ -2356,9 +2366,6 @@ function parsestr (c, s) {
 
     Sk.asserts.assert(quote === "'" || quote === '"' && s.charAt(s.length - 1) === quote);
     s = s.substr(1, s.length - 2);
-    if (unicode) {
-        s = encodeUtf8(s);
-    }
 
     if (s.length >= 4 && s.charAt(0) === quote && s.charAt(1) === quote) {
         Sk.asserts.assert(s.charAt(s.length - 1) === quote && s.charAt(s.length - 2) === quote);
@@ -2366,9 +2373,9 @@ function parsestr (c, s) {
     }
 
     if (rawmode || s.indexOf("\\") === -1) {
-        return [strobj(decodeUtf8(s)), fmode];
+        return [strobj(s), fmode, bytesmode];
     }
-    return [strobj(decodeEscape(s, quote)), fmode];
+    return [strobj(decodeEscape(s, quote)), fmode, bytesmode];
 }
 
 function fstring_compile_expr(str, expr_start, expr_end, c, n) {
@@ -2620,21 +2627,35 @@ function fstring_parse(str, start, end, raw, recurse_lvl, c, n) {
 function parsestrplus (c, n) {
     let strs = [];
     let lastStrNode;
+    let bytesmode;
 
     for (let i = 0; i < NCH(n); ++i) {
         let chstr = CHILD(n, i).value;
-        let str, fmode;
+        let str, fmode, this_bytesmode;
         try {
-            let r = parsestr(c, chstr);
+            let r = parsestr(c, CHILD(n,i), chstr);
             str = r[0];
             fmode = r[1];
+            this_bytesmode = r[2];
         } catch (x) {
-            throw new Sk.builtin.SyntaxError("invalid string (possibly contains a unicode character)", c.c_filename, CHILD(n, i).lineno);
+            if (x instanceof Sk.builtin.SyntaxError) {
+                throw x;
+            } else {
+                throw new Sk.builtin.SyntaxError("invalid string (possibly contains a unicode character)", c.c_filename, CHILD(n, i).lineno);
+            }
         }
+
+        /* Check that we're not mixing bytes with unicode. */
+        if (i != 0 && bytesmode !== this_bytesmode) {
+            ast_error(c, n, "cannot mix bytes and nonbytes literals");
+        }
+        bytesmode = this_bytesmode;
+
         if (fmode) {
             if (!Sk.__future__.python3) {
                 throw new Sk.builtin.SyntaxError("invalid string (f-strings are not supported in Python 2)", c.c_filename, CHILD(n, i).lineno);
             }
+
             let jss = str.$jsstr();
             let [astnode, _] = fstring_parse(jss, 0, jss.length, false, 0, c, CHILD(n, i));
             strs.push.apply(strs, astnode.values);
@@ -2643,7 +2664,8 @@ function parsestrplus (c, n) {
             if (lastStrNode) {
                 lastStrNode.s = lastStrNode.s.sq$concat(str);
             } else {
-                lastStrNode = new Sk.astnodes.Str(str, LINENO(n), n.col_offset, c.end_lineno, n.end_col_offset)
+                let type = bytesmode ? Sk.astnodes.Bytes : Sk.astnodes.Str;
+                lastStrNode = new type(str, LINENO(n), n.col_offset, c.end_lineno, n.end_col_offset)
                 strs.push(lastStrNode);
             }
         }

--- a/src/ast.js
+++ b/src/ast.js
@@ -2242,12 +2242,12 @@ function astForIfexpr (c, n) {
  * prefixes. Returns [decoded string object, is-an-fstring]
  */
 function parsestr (c, n, s) {
-    var encodeUtf8 = function (s) {
-        return unescape(encodeURIComponent(s));
-    };
-    var decodeUtf8 = function (s) {
-        return decodeURIComponent(escape(s));
-    };
+    var quote = s.charAt(0);
+    var rawmode = false;
+    var unicode = false;
+    var fmode = false;
+    var bytesmode = false;
+
     var decodeEscape = function (s, quote) {
         var d3;
         var d2;
@@ -2301,14 +2301,14 @@ function parsestr (c, n, s) {
                     ret += String.fromCharCode(parseInt(s.substr(i+1,2), 16));
                     i += 2;
                 }
-                else if (ch === "u") {
+                else if (!bytesmode && ch === "u") {
                     if (i+4 >= len) {
                         ast_error(c, n, "Truncated \\uXXXX escape");
                     }
                     ret += String.fromCharCode(parseInt(s.substr(i+1, 4), 16))
                     i += 4;
                 }
-                else if (ch === "U") {
+                else if (!bytesmode && ch === "U") {
                     if (i+8 >= len) {
                         ast_error(c, n, "Truncated \\UXXXXXXXX escape");
                     }
@@ -2321,7 +2321,9 @@ function parsestr (c, n, s) {
                     // Sk.asserts.fail("unhandled escape: '" + ch.charCodeAt(0) + "'");
                 }
             }
-            else {
+            else if (bytesmode && ch.charCodeAt(0) > 0xff) {
+                ast_error(c, n, "bytes can only contain ASCII literal characters");
+            } else {
                 ret += ch;
             }
         }
@@ -2329,12 +2331,6 @@ function parsestr (c, n, s) {
     };
 
     //print("parsestr", s);
-
-    var quote = s.charAt(0);
-    var rawmode = false;
-    var unicode = false;
-    var fmode = false;
-    var bytesmode = false;
 
     // treats every sequence as unicodes even if they are not treated with uU prefix
     // kinda hacking though working for most purposes
@@ -2373,6 +2369,13 @@ function parsestr (c, n, s) {
     }
 
     if (rawmode || s.indexOf("\\") === -1) {
+        if (bytesmode) {
+            for (let i=0; i<s.length; i++) {
+                if (s.charCodeAt(i) > 0xff) {
+                    ast_error(c, n, "bytes can only contain ASCII literal characters");
+                }
+            }
+        }
         return [strobj(s), fmode, bytesmode];
     }
     return [strobj(decodeEscape(s, quote)), fmode, bytesmode];

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -491,12 +491,13 @@ Sk.builtin.fabs = function fabs(x) {
 Sk.builtin.ord = function ord (x) {
     Sk.builtin.pyCheckArgsLen("ord", arguments.length, 1, 1);
 
-    if (!Sk.builtin.checkString(x)) {
+    if (!Sk.builtin.checkString(x) && !Sk.builtin.checkBytes(x)) {
         throw new Sk.builtin.TypeError("ord() expected a string of length 1, but " + Sk.abstr.typeName(x) + " found");
-    } else if (x.v.length !== 1) {
+    } else if (x.v.length !== 1 && x.sq$length() !== 1) {
+        // ^^ avoid the astral check unless necessary ^^
         throw new Sk.builtin.TypeError("ord() expected a character, but string of length " + x.v.length + " found");
     }
-    return new Sk.builtin.int_((x.v).charCodeAt(0));
+    return new Sk.builtin.int_((x.v).codePointAt(0));
 };
 
 Sk.builtin.chr = function chr (x) {
@@ -507,11 +508,17 @@ Sk.builtin.chr = function chr (x) {
     x = Sk.builtin.asnum$(x);
 
 
-    if ((x < 0) || (x > 255)) {
-        throw new Sk.builtin.ValueError("chr() arg not in range(256)");
+    if (Sk.__future__.python3) {
+        if ((x < 0) || (x >= 0x110000)) {
+            throw new Sk.builtin.ValueError("chr() arg not in range(0x110000)");
+        }
+    } else {
+        if ((x < 0) || (x >= 256)) {
+            throw new Sk.builtin.ValueError("chr() arg not in range(256)");
+        }
     }
 
-    return new Sk.builtin.str(String.fromCharCode(x));
+    return new Sk.builtin.str(String.fromCodePoint(x));
 };
 
 Sk.builtin.unichr = function unichr (x) {

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -716,6 +716,56 @@ Sk.builtin.repr = function repr (x) {
     return Sk.misceval.objectRepr(x);
 };
 
+Sk.builtin.ascii = function ascii (x) {
+    return Sk.misceval.chain(Sk.misceval.objectRepr(x), (r) => {
+        if (!(r instanceof Sk.builtin.str)) {
+            throw new Sk.builtin.TypeError("__repr__ returned non-string (type " + Sk.abstr.typeName(r) + ")");
+        }
+        let ret;
+        let i;
+        // Fast path
+        for (i=0; i < r.v.length; i++) {
+            if (r.v.charCodeAt(i) >= 0x7f) {
+                ret = r.v.substr(0, i);
+                break;
+            }
+        }
+        if (!ret) {
+            return r;
+        }
+        for (; i < r.v.length; i++) {
+            let c = r.v.charAt(i);
+            let cc = r.v.charCodeAt(i);
+
+            if (cc > 0x7f && cc <= 0xff) {
+                let ashex = cc.toString(16);
+                if (ashex.length < 2) {
+                    ashex = "0" + ashex;
+                }
+                ret += "\\x" + ashex;
+            } else if (cc > 0x7f && cc < 0xd800 || cc >= 0xe000) {
+                // BMP
+                ret += "\\u" + ("000"+cc.toString(16)).slice(-4);
+            } else if (cc >= 0xd800) {
+                // Surrogate pair stuff
+                let val = r.v.codePointAt(i);
+                i++;
+
+                val = val.toString(16);
+                let s = ("0000000"+val.toString(16));
+                if (val.length > 4) {
+                    ret += "\\U" + s.slice(-8);
+                } else {
+                    ret += "\\u" + s.slice(-4);
+                }
+            } else {
+                ret += c;
+            }
+        }
+        return new Sk.builtin.str(ret);
+    });
+};
+
 Sk.builtin.open = function open (filename, mode, bufsize) {
     Sk.builtin.pyCheckArgsLen("open", arguments.length, 1, 3);
     if (mode === undefined) {

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -118,6 +118,8 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["xrange"];
         delete Sk.builtins["StandardError"];
         delete Sk.builtins["unicode"];
+        Sk.builtins["bytes"] = Sk.builtin.bytes;
+        delete Sk.builtin.str.prototype.decode;
     } else {
         Sk.builtins["filter"] = new Sk.builtin.func(Sk.builtin.filter);
         Sk.builtins["map"] = new Sk.builtin.func(Sk.builtin.map);
@@ -126,6 +128,8 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["xrange"] = new Sk.builtin.func(Sk.builtin.xrange);
         Sk.builtins["StandardError"] = Sk.builtin.StandardError;
         Sk.builtins["unicode"] = Sk.builtin.str;
+        delete Sk.builtins["bytes"];
+        Sk.builtin.str.prototype.decode = Sk.builtin.bytes.prototype.decode;
     }
 };
 Sk.exportSymbol("Sk.setupObjects", Sk.setupObjects);

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -118,6 +118,7 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["xrange"];
         delete Sk.builtins["StandardError"];
         delete Sk.builtins["unicode"];
+        delete Sk.builtins["basestring"];
         Sk.builtins["bytes"] = Sk.builtin.bytes;
         delete Sk.builtin.str.prototype.decode;
     } else {
@@ -128,6 +129,7 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["xrange"] = new Sk.builtin.func(Sk.builtin.xrange);
         Sk.builtins["StandardError"] = Sk.builtin.StandardError;
         Sk.builtins["unicode"] = Sk.builtin.str;
+        Sk.builtins["basestring"] = Sk.builtin.str;
         delete Sk.builtins["bytes"];
         Sk.builtin.str.prototype.decode = Sk.builtin.bytes.prototype.decode;
     }

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -121,6 +121,7 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["basestring"];
         Sk.builtins["bytes"] = Sk.builtin.bytes;
         delete Sk.builtin.str.prototype.decode;
+        Sk.builtins["ascii"] = new Sk.builtin.func(Sk.builtin.ascii);
     } else {
         Sk.builtins["filter"] = new Sk.builtin.func(Sk.builtin.filter);
         Sk.builtins["map"] = new Sk.builtin.func(Sk.builtin.map);
@@ -132,6 +133,7 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["basestring"] = Sk.builtin.str;
         delete Sk.builtins["bytes"];
         Sk.builtin.str.prototype.decode = Sk.builtin.bytes.prototype.decode;
+        delete Sk.builtins["ascii"];
     }
 };
 Sk.exportSymbol("Sk.setupObjects", Sk.setupObjects);

--- a/src/compile.js
+++ b/src/compile.js
@@ -823,6 +823,26 @@ Compiler.prototype.cformattedvalue = function(e) {
     return this._gr("formatted", "Sk.abstr.objectFormat("+value+","+formatSpec+")");
 };
 
+function getJsLiteralForString(s) {
+    let r = "\"";
+    for (let i = 0; i < s.length; i++) {
+        let c = s.charCodeAt(i);
+        // Escape quotes, anything before space, and anything non-ASCII
+        if (c == 0x0a) {
+            r += "\\n";
+        } else if (c == 92) {
+            r += "\\\\";
+        } else if (c == 34 || c < 32 || c >= 0x7f && c < 0x100) {
+            r += "\\x" + ("0" + c.toString(16)).substr(-2);
+        } else if (c >= 0x100) {
+            r += "\\u" + ("000" + c.toString(16)).substr(-4);
+        } else {
+            r += s.charAt(i);
+        }
+    }
+    r += "\"";
+    return r;
+}
 
 /**
  *
@@ -899,8 +919,18 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
                 return this.makeConstant("new Sk.builtin.complex(new Sk.builtin.float_(" + real_val + "), new Sk.builtin.float_(" + imag_val + "))");
             }
             Sk.asserts.fail("unhandled Num type");
+        case Sk.astnodes.Bytes:
+            if (Sk.__future__.python3) {
+                for (let i = 0; i < e.s.length; i++) {
+                    if (e.s[i] > String.fromCharCode(0x7f)) {
+                        throw new Sk.builtin.SyntaxError("bytes can only contain ASCII literal characters");
+                    }
+                }
+                return this.makeConstant("new Sk.builtin.bytes(", getJsLiteralForString(e.s.$jsstr()), ")");
+            }
+            // else fall through and make a string instead
         case Sk.astnodes.Str:
-            return this.makeConstant("new Sk.builtin.str(", e.s["$r"]().v, ")");
+            return this.makeConstant("new Sk.builtin.str(", getJsLiteralForString(e.s.$jsstr()), ")");
         case Sk.astnodes.Attribute:
             if (e.ctx !== Sk.astnodes.AugLoad && e.ctx !== Sk.astnodes.AugStore) {
                 val = this.vexpr(e.value);

--- a/src/compile.js
+++ b/src/compile.js
@@ -812,9 +812,8 @@ Compiler.prototype.cformattedvalue = function(e) {
             value = this._gr("value", "Sk.builtin.str(",value,")");
             break;
         case 'a':
-            // TODO when repr() becomes more unicode-aware,
-            // we'll want to handle repr() and ascii() differently.
-            // For now, they're the same
+            value = this._gr("value", "Sk.builtin.ascii(",value,")");
+            break;
         case 'r':
             value = this._gr("value", "Sk.builtin.repr(",value,")");
             break;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 Sk.builtin.str.$emptystr = new Sk.builtin.str("");
+Sk.builtin.bytes.$emptystr = new Sk.builtin.bytes("");
 
 /**
  * Python bool True constant.
@@ -40,6 +41,7 @@ Sk.builtin.str.$imag = new Sk.builtin.str("imag");
 Sk.builtin.str.$real = new Sk.builtin.str("real");
 
 Sk.builtin.str.$abs = new Sk.builtin.str("__abs__");
+Sk.builtin.str.$bytes = new Sk.builtin.str("__bytes__");
 Sk.builtin.str.$call = new Sk.builtin.str("__call__");
 Sk.builtin.str.$cmp = new Sk.builtin.str("__cmp__");
 Sk.builtin.str.$complex = new Sk.builtin.str("__complex__");

--- a/src/errors.js
+++ b/src/errors.js
@@ -522,6 +522,40 @@ Sk.exportSymbol("Sk.builtin.SystemError", Sk.builtin.SystemError);
 
 /**
  * @constructor
+ * @extends Sk.builtin.StandardError
+ * @param {...*} args
+ */
+Sk.builtin.UnicodeEncodeError = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.UnicodeEncodeError)) {
+        o = Object.create(Sk.builtin.UnicodeEncodeError.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.StandardError.apply(this, arguments);
+};
+Sk.abstr.setUpInheritance("UnicodeEncodeError", Sk.builtin.UnicodeEncodeError, Sk.builtin.StandardError);
+Sk.exportSymbol("Sk.builtin.UnicodeEncodeError", Sk.builtin.UnicodeEncodeError);
+
+/**
+ * @constructor
+ * @extends Sk.builtin.StandardError
+ * @param {...*} args
+ */
+Sk.builtin.UnicodeDecodeError = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.UnicodeDecodeError)) {
+        o = Object.create(Sk.builtin.UnicodeDecodeError.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.StandardError.apply(this, arguments);
+};
+Sk.abstr.setUpInheritance("UnicodeDecodeError", Sk.builtin.UnicodeDecodeError, Sk.builtin.StandardError);
+Sk.exportSymbol("Sk.builtin.UnicodeDecodeError", Sk.builtin.UnicodeDecodeError);
+
+/**
+ * @constructor
  * @extends Sk.builtin.Exception
  * @param {...*} args
  */

--- a/src/function.js
+++ b/src/function.js
@@ -187,7 +187,7 @@ Sk.builtin.checkString = function (arg) {
 Sk.exportSymbol("Sk.builtin.checkString", Sk.builtin.checkString);
 
 Sk.builtin.checkBytes = function (arg) {
-    return (arg !== null && arg.__class__ == (Sk.builtin.__python3__ ? Sk.builtin.bytes : Sk.builtin.str));
+    return (arg !== null && arg.__class__ == (Sk.__future__.python3 ? Sk.builtin.bytes : Sk.builtin.str));
 };
 Sk.exportSymbol("Sk.builtin.checkBytes", Sk.builtin.checkBytes);
 

--- a/src/function.js
+++ b/src/function.js
@@ -186,6 +186,11 @@ Sk.builtin.checkString = function (arg) {
 };
 Sk.exportSymbol("Sk.builtin.checkString", Sk.builtin.checkString);
 
+Sk.builtin.checkBytes = function (arg) {
+    return (arg !== null && arg.__class__ == (Sk.builtin.__python3__ ? Sk.builtin.bytes : Sk.builtin.str));
+};
+Sk.exportSymbol("Sk.builtin.checkBytes", Sk.builtin.checkBytes);
+
 Sk.builtin.checkClass = function (arg) {
     return (arg !== null && arg.sk$type);
 };

--- a/src/function.js
+++ b/src/function.js
@@ -428,3 +428,17 @@ Sk.builtin.func.prototype["$r"] = function () {
         return new Sk.builtin.str("<function " + name + ">");
     }
 };
+
+// a Python implementation of @staticmethod
+Sk.builtin.staticfunc = function() {
+    Sk.builtin.func.apply(this, arguments);
+};
+Sk.abstr.setUpInheritance("staticfunction", Sk.builtin.staticfunc, Sk.builtin.func);
+
+Sk.exportSymbol("Sk.builtin.staticfunc", Sk.builtin.staticfunc);
+
+Sk.builtin.staticfunc.prototype.tp$name = "staticmethod";
+
+Sk.builtin.staticfunc.prototype.tp$descr_get = function () {
+    return this;
+};

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1194,6 +1194,39 @@ Sk.misceval.Break = function(brValue) {
 Sk.exportSymbol("Sk.misceval.Break", Sk.misceval.Break);
 
 /**
+ * Create a Python iterator that repeatedly calls a given JS function
+ * until it returns 'undefined'
+ * @constructor
+ */
+Sk.misceval.Iterator = function(fn, handlesOwnSuspensions) {
+    this.tp$iter = this;
+    this.tp$iternext = handlesOwnSuspensions ? fn : function (canSuspend) {
+        let x = fn();
+        if (canSuspend || !x.isSuspension) {
+            return x;
+        } else {
+            return Sk.misceval.retryOptionalSuspensionOrThrow(x);
+        }
+    };
+};
+
+Sk.abstr.setUpInheritance("iterator", Sk.misceval.Iterator, Sk.builtin.object);
+Sk.misceval.Iterator.prototype.__class__ = Sk.misceval.Iterator;
+Sk.misceval.Iterator.prototype.__iter__ = new Sk.builtin.func(function (self) {
+    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 0, 0, true, false);
+    return self;
+});
+Sk.misceval.Iterator.prototype.next$ = function (self) {
+    var ret = self.tp$iternext();
+    if (ret === undefined) {
+        throw new Sk.builtin.StopIteration();
+    }
+    return ret;
+};
+
+
+
+/**
  * same as Sk.misceval.call except args is an actual array, rather than
  * varargs.
  */

--- a/src/str.js
+++ b/src/str.js
@@ -25,7 +25,7 @@ Sk.builtin.bytes = function(source, encoding, errors) {
         if (!(encoding instanceof Sk.builtin.str)) {
             throw new Sk.builtin.TypeError("string argument without an encoding");
         }
-        return Sk.builtin.str.prototype["encode"](source, encoding, errors);
+        return Sk.misceval.callsimArray(Sk.builtin.str.prototype["encode"], [source, encoding, errors]);
 
     } else if (source instanceof Sk.builtin.int_) {
         source = "\x00".repeat(source.v);
@@ -33,16 +33,16 @@ Sk.builtin.bytes = function(source, encoding, errors) {
     } else if (source instanceof Sk.builtin.bytes) {
         source = source.v;
 
-    } else if ((dunderBytes = Sk.builtin.type.typeLookup(s.ob$type, Sk.builtin.str.$bytes))) {
-        let r = Sk.misceval.callsim(dunderBytes);
+    } else if ((dunderBytes = Sk.builtin.type.typeLookup(source.ob$type, Sk.builtin.str.$bytes))) {
+        let r = Sk.misceval.callsimArray(dunderBytes, [source]);
         return isConstructor ? Sk.misceval.retryOptionalSuspensionOrThrow(r) : r;
 
     } else {
         // Try to iterate.
         let v = "";
         let r = Sk.misceval.iterFor(Sk.abstr.iter(source), (byte) => {
-            if (!Sk.builtin.checkInt(j)) {
-                throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(j) + "' object cannot be interpreted as an integer");
+            if (!Sk.builtin.checkInt(byte)) {
+                throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(byte) + "' object cannot be interpreted as an integer");
             }
             let n = Sk.builtin.asnum$(byte);
             if (n < 0 || n > 255) {

--- a/src/str.js
+++ b/src/str.js
@@ -730,38 +730,80 @@ Sk.builtin.str.prototype["center"] = Sk.builtin.bytes.prototype["center"] = new 
 
 });
 
-Sk.builtin.str.prototype["find"] = Sk.builtin.bytes.prototype["find"] = new Sk.builtin.func(function (self, tgt, start, end) {
-    var idx;
-    Sk.builtin.pyCheckArgsLen("find", arguments.length, 2, 4);
-    if (!checkStringish(self, tgt)) {
-        throw new Sk.builtin.TypeError("expected a " + self.__class__.$englishname + " object");
-    }
-    if ((start !== undefined) && !Sk.builtin.checkInt(start)) {
-        throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");
-    }
-    if ((end !== undefined) && !Sk.builtin.checkInt(end)) {
-        throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");
-    }
+function mkFind(isReversed) {
+    return new Sk.builtin.func(function (self, tgt, start, end) {
+        var idx;
+        Sk.builtin.pyCheckArgsLen("find", arguments.length, 2, 4);
+        if (!checkStringish(self, tgt)) {
+            throw new Sk.builtin.TypeError("expected a " + self.__class__.$englishname + " object");
+        }
+        if ((start !== undefined) && (start !== Sk.builtin.none.none$) && !Sk.builtin.checkInt(start)) {
+            throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");
+        }
+        if ((end !== undefined) && (start !== Sk.builtin.none.none$) && !Sk.builtin.checkInt(end)) {
+            throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");
+        }
 
-    if (start === undefined) {
-        start = 0;
-    } else {
-        start = Sk.builtin.asnum$(start);
-        start = start >= 0 ? start : self.v.length + start;
-    }
+        let len = self.$hasAstralCodePoints() ? self.codepoints.length : self.v.length;
 
-    if (end === undefined) {
-        end = self.v.length;
-    } else {
-        end = Sk.builtin.asnum$(end);
-        end = end >= 0 ? end : self.v.length + end;
-    }
+        // Find start and end in Python coordinates
 
-    idx = self.v.indexOf(tgt.v, start);
-    idx = ((idx >= start) && (idx < end)) ? idx : -1;
+        if (start === undefined || start === Sk.builtin.none.none$) {
+            start = 0;
+        } else {
+            start = Sk.builtin.asnum$(start);
+            start = start >= 0 ? start : len + start;
+            if (start < 0) { start = 0; }
+        }
+        if (start > len) {
+            return new Sk.builtin.int_(-1);
+        }
 
-    return new Sk.builtin.int_(idx);
-});
+        if (end === undefined || end === Sk.builtin.none.none$) {
+            end = len;
+        } else {
+            end = Sk.builtin.asnum$(end);
+            end = end >= 0 ? end : len + end;
+        }
+        // This guard makes sure we don't, eg, look for self.codepoints[-1]
+        if (end < start) {
+            return new Sk.builtin.int_(-1);
+        }
+
+        if (self.$hasAstralCodePoints()) {
+            // Convert start and end to JS coordinates...
+
+            start = self.codepoints[start];
+            end = self.codepoints[end];
+            if (start === undefined) { start = self.v.length; }
+            if (end === undefined) { end = self.v.length; }
+
+            // ...do the search..
+            end -= tgt.v.length;
+            let jsidx = isReversed ? self.v.lastIndexOf(tgt.v, end) : self.v.indexOf(tgt.v, start);
+            jsidx = ((jsidx >= start) && (jsidx <= end)) ? jsidx : -1;
+
+            // ...and now convert them back
+
+            idx = -1;
+
+            for (let i = 0; i < len; i++) {
+                if (jsidx == self.codepoints[i]) { 
+                    idx = i;
+                }
+            }
+        } else {
+            // No astral codepoints, no conversion required
+            end -= tgt.v.length;
+            idx = isReversed ? self.v.lastIndexOf(tgt.v, end) : self.v.indexOf(tgt.v, start);
+            idx = ((idx >= start) && (idx <= end)) ? idx : -1;
+        }
+
+        return new Sk.builtin.int_(idx);
+    });
+};
+
+Sk.builtin.str.prototype["find"] = Sk.builtin.bytes.prototype["find"] = mkFind(false);
 
 Sk.builtin.str.prototype["index"] = Sk.builtin.bytes.prototype["index"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
@@ -773,39 +815,7 @@ Sk.builtin.str.prototype["index"] = Sk.builtin.bytes.prototype["index"] = new Sk
     return idx;
 });
 
-Sk.builtin.str.prototype["rfind"] = Sk.builtin.bytes.prototype["rfind"] = new Sk.builtin.func(function (self, tgt, start, end) {
-    var idx;
-    Sk.builtin.pyCheckArgsLen("rfind", arguments.length, 2, 4);
-    if (!checkStringish(self, tgt)) {
-        throw new Sk.builtin.TypeError("expected a " + self.__class__.$englishname + " object");
-    }
-    if ((start !== undefined) && !Sk.builtin.checkInt(start)) {
-        throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");
-    }
-    if ((end !== undefined) && !Sk.builtin.checkInt(end)) {
-        throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");
-    }
-
-    if (start === undefined) {
-        start = 0;
-    } else {
-        start = Sk.builtin.asnum$(start);
-        start = start >= 0 ? start : self.v.length + start;
-    }
-
-    if (end === undefined) {
-        end = self.v.length;
-    } else {
-        end = Sk.builtin.asnum$(end);
-        end = end >= 0 ? end : self.v.length + end;
-    }
-
-    idx = self.v.lastIndexOf(tgt.v, end);
-    idx = (idx !== end) ? idx : self.v.lastIndexOf(tgt.v, end - 1);
-    idx = ((idx >= start) && (idx < end)) ? idx : -1;
-
-    return new Sk.builtin.int_(idx);
-});
+Sk.builtin.str.prototype["rfind"] = Sk.builtin.bytes.prototype["rfind"] = mkFind(true);
 
 Sk.builtin.str.prototype["rindex"] = Sk.builtin.bytes.prototype["rindex"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;

--- a/src/str.js
+++ b/src/str.js
@@ -1013,6 +1013,52 @@ Sk.builtin.str.prototype["istitle"] = Sk.builtin.bytes.prototype["istitle"] = ne
     return new Sk.builtin.bool( cased);
 });
 
+Sk.builtin.str.prototype["encode"] = new Sk.builtin.func(function (self, encoding, errors) {
+    // TODO errors are currently always "strict"
+    // (other modes will require manual UTF-8-bashing)
+
+    Sk.builtin.pyCheckArgsLen("encode", arguments.length, 1, 3);
+
+    if (encoding) {
+        Sk.builtin.pyCheckType("encoding", "string", Sk.builtin.checkString(encoding));
+        if (!/^utf-?8$/i.test(encoding.v)) {
+            throw new Sk.builtin.ValueError("Only UTF-8 or ASCII encoding and decoding is supported");
+        }
+    }
+
+    let v;
+    try {
+        v = unescape(encodeUriComponent(self.v));
+    } catch (e) {
+        throw new Sk.builtin.UnicodeEncodeError("UTF-8 encoding failed");
+    }
+
+    return Sk.__future__.python3 ? new Sk.builtin.bytes(v) : new Sk.builtin.str(v);
+});
+
+Sk.builtin.bytes.prototype["decode"] = new Sk.builtin.func(function (self, encoding, errors) {
+    // TODO errors are currently always "strict"
+    // (other modes will require manual UTF-8-bashing)
+
+    Sk.builtin.pyCheckArgsLen("decode", arguments.length, 1, 3);
+
+    if (encoding) {
+        Sk.builtin.pyCheckType("encoding", "string", Sk.builtin.checkString(encoding));
+        if (!/^utf-?8$/i.test(encoding.v)) {
+            throw new Sk.builtin.ValueError("Only UTF-8 encoding and decoding is supported");
+        }
+    }
+
+    let v;
+    try {
+        v = decodeUriComponent(escape(self.v));
+    } catch (e) {
+        throw new Sk.builtin.UnicodeEncodeError("UTF-8 decoding failed");
+    }
+
+    return new Sk.builtin.str(v);
+});
+
 Sk.builtin.str.prototype.nb$remainder = Sk.builtin.bytes.prototype.nb$remainder = function (rhs) {
     // % format op. rhs can be a value, a tuple, or something with __getitem__ (dict)
 

--- a/src/str.js
+++ b/src/str.js
@@ -92,14 +92,22 @@ Sk.builtin.interned = {};
  * @param {*} x
  * @extends Sk.builtin.object
  */
-Sk.builtin.str = function (x) {
+Sk.builtin.str = function (x, encoding) {
     var ret;
 
-    Sk.builtin.pyCheckArgsLen("str", arguments.length, 0, 1);
+    Sk.builtin.pyCheckArgsLen("str", arguments.length, 0, Sk.__future__ && Sk.__future__.python3 ? 2 : 1);
 
     if (x === undefined) {
         x = "";
     }
+
+    if (encoding || x instanceof Sk.builtin.bytes) {
+        if (!Sk.builtin.checkBytes(x)) {
+            throw new TypeError("decoding " + Sk.abstr.typeName(x) + " is not supported");
+        }
+        return Sk.misceval.callsimArray(x.tp$getattr(new Sk.builtin.str("decode")), encoding ? [encoding] : []);
+    }
+
     if (x instanceof Sk.builtin.str) {
         return x;
     }
@@ -204,7 +212,7 @@ Sk.builtin.str.prototype.$jsstr = Sk.builtin.bytes.prototype.$jsstr = function (
     return this.v;
 };
 
-Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript = function (index) {
+Sk.builtin.str.prototype.mp$subscript = function (index) {
     var ret;
     if (Sk.misceval.isIndex(index)) {
         index = Sk.misceval.asIndex(index);
@@ -213,12 +221,12 @@ Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript 
             index = len + index;
         }
         if (index < 0 || index >= len) {
-            throw new Sk.builtin.IndexError(this.__class__.$englishname + " index out of range");
+            throw new Sk.builtin.IndexError("string index out of range");
         }
         if (this.codepoints) {
-            return new this.__class__(this.v.substring(this.codepoints[index], this.codepoints[index+1]));
+            return new Sk.builtin.str(this.v.substring(this.codepoints[index], this.codepoints[index+1]));
         } else {
-            return new this.__class__(this.v.charAt(index));
+            return new Sk.builtin.str(this.v.charAt(index));
         }
     } else if (index instanceof Sk.builtin.slice) {
         ret = "";
@@ -235,9 +243,32 @@ Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript 
                 }
             });
         };
-        return new this.__class__(ret);
+        return new Sk.builtin.str(ret);
     } else {
-        throw new Sk.builtin.TypeError(this.__class__.$englishname + " indices must be integers, not " + Sk.abstr.typeName(index));
+        throw new Sk.builtin.TypeError("string indices must be integers, not " + Sk.abstr.typeName(index));
+    }
+};
+
+Sk.builtin.bytes.prototype.mp$subscript = function(index) {
+    if (Sk.misceval.isIndex(index)) {
+        index = Sk.misceval.asIndex(index);
+        if (index < 0) {
+            index = this.v.length + index;
+        }
+        if (index < 0 || index >= this.v.length) {
+            throw new Sk.builtin.IndexError("bytestring index out of range");
+        }
+        return new Sk.builtin.int_(this.v.charCodeAt(index));
+    } else if (index instanceof Sk.builtin.slice) {
+        let ret = "";
+        index.sssiter$(this, function (i, wrt) {
+            if (i >= 0 && i < wrt.v.length) {
+                ret += wrt.v.charAt(i);
+            }
+        });
+        return new Sk.builtin.bytes(ret);
+    } else {
+        throw new Sk.builtin.TypeError("bytestring indices must be integers, not " + Sk.abstr.typeName(index));
     }
 };
 
@@ -293,19 +324,42 @@ Sk.builtin.str.prototype.sq$slice = Sk.builtin.bytes.prototype.sq$slice = functi
     }
 };
 
-Sk.builtin.str.prototype.sq$contains = Sk.builtin.bytes.prototype.sq$contains = function (ob) {
-    if (!(ob instanceof this.__class__)) {
-        throw new Sk.builtin.TypeError("TypeError: 'In <" + this.__class__.$englishname + "> requires " + this.__class__.$englishname + " as left operand");
+Sk.builtin.str.prototype.sq$contains = function (ob) {
+    if (!(ob instanceof Sk.builtin.str)) {
+        throw new Sk.builtin.TypeError("TypeError: 'In <string> requires string as left operand");
     }
     return this.v.indexOf(ob.v) != -1;
 };
 
-Sk.builtin.str.prototype.__iter__ = Sk.builtin.bytes.prototype.__iter__ = new Sk.builtin.func(function (self) {
+Sk.builtin.bytes.prototype.sq$contains = function(ob) {
+    if (ob instanceof Sk.builtin.bytes) {
+        return this.v.indexOf(ob.v) != -1;
+    } else if (Sk.builtin.checkInt(ob)) {
+        let v = Sk.ffi.remapToJs(ob);
+        if (v < 0 || v > 0xff) {
+            throw new Sk.builtin.ValueError("byte must be in range (0, 256)");
+        }
+        return this.v.indexOf(String.fromCharCode(v)) != -1;
+    } else {
+        throw new Sk.builtin.TypeError("TypeError: 'In <bytes> requires a bytes-like object as left operand, not " + Sk.abstr.typeName(ob));
+    }
+};
+
+Sk.builtin.str.prototype.__iter__ = new Sk.builtin.func(function (self) {
     return new Sk.builtin.str_iter_(self);
 });
 
-Sk.builtin.str.prototype.tp$iter = Sk.builtin.bytes.prototype.tp$iter = function () {
+Sk.builtin.str.prototype.tp$iter = function () {
     return new Sk.builtin.str_iter_(this);
+};
+
+Sk.builtin.bytes.prototype.tp$iter = function() {
+    let i = 0;
+    return new Sk.misceval.Iterator(() => {
+        if (i < this.v.length) {
+            return new Sk.builtin.int_(this.v.charCodeAt(i++));
+        }
+    }, true);
 };
 
 Sk.builtin.str.prototype.tp$richcompare = Sk.builtin.bytes.prototype.tp$richcompare = function (other, op) {

--- a/src/str.js
+++ b/src/str.js
@@ -65,6 +65,12 @@ Sk.builtin.bytes = function(source, encoding, errors) {
         throw new Sk.builtin.TypeError("encoding without a string argument");
     }
 
+    for (let i=0; i < source.length; i++) {
+        if (source.charCodeAt(i) > 0xff) {
+            throw new ValueError("bytes must be in range(0, 256)");
+        }
+    }
+
     if (isConstructor) {
         this.__class__ = Sk.builtin.bytes;
         this.v = source;
@@ -143,6 +149,7 @@ Sk.builtin.str = function (x) {
     this.v = ret;
     this["v"] = this.v;
     Sk.builtin.interned["1" + ret] = this;
+
     return this;
 
 };
@@ -154,6 +161,44 @@ Sk.builtin.str.$englishname = "string";
 Sk.builtin.bytes.$englishname = "bytes";
 Sk.builtin.str.$englishsingular = "char";
 Sk.builtin.bytes.$englishsingular = "byte";
+
+Sk.builtin.str.prototype.$hasAstralCodePoints = function() {
+    // If a string has astral code points, we have to work
+    // out where they are before we can do things like
+    // slicing, computing length, etc.
+    // We work this out when we need to.
+
+    if (this.codepoints === null) {
+        return false;
+    } else if (this.codepoints !== undefined) {
+        return true;
+    }
+    // Does this string contain astral code points? If so, we have to do things
+    // the slow way.
+    for (let i = 0; i < this.v.length; i++) {
+        let cc = this.v.charCodeAt(i);
+        if (cc >= 0xd800 && cc < 0xe000) {
+            // Yep, it's a surrogate pair. Mark off the
+            // indices of all the code points for O(1) seeking
+            // later
+
+            this.codepoints = [];
+            for (let j = 0; j < this.v.length; j++) {
+                this.codepoints.push(j);
+                cc = this.v.charCodeAt(j);
+                if (cc >= 0xd800 && cc < 0xdc00) {
+                    // High surrogate. Skip next char
+                    j++;
+                }
+            }
+            return true;
+        }
+    }
+    this.codepoints = null;
+    return false;
+}
+
+Sk.builtin.bytes.prototype.$hasAstralCodePoints = () => false;
 
 Sk.builtin.str.prototype.$jsstr = Sk.builtin.bytes.prototype.$jsstr = function () {
     return this.v;
@@ -169,7 +214,7 @@ Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript 
         if (index < 0 || index >= this.v.length) {
             throw new Sk.builtin.IndexError(this.__class__.$englishname + " index out of range");
         }
-        if (this.codepoints) {
+        if (this.$hasAstralCodePoints()) {
             return new this.__class__(this.v.substring(this.codepoints[index], this.codepoints[index+1]));
         } else {
             return new this.__class__(this.v.charAt(index));
@@ -177,9 +222,9 @@ Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript 
     } else if (index instanceof Sk.builtin.slice) {
         ret = "";
         index.sssiter$(this, function (i, wrt) {
-            if (wrt.codepoints) {
+            if (wrt.$hasAstralCodePoints()) {
                 if (i >= 0 && i < wrt.codepoints.length) {
-                    ret += wrt.v.codePointAt(wrt.codePoints[i]);
+                    ret += wrt.v.substring(wrt.codepoints[i], wrt.codepoints[i+1]);
                 }
             } else if (i >= 0 && i < wrt.v.length) {
                 ret += wrt.v.charAt(i);
@@ -192,7 +237,7 @@ Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript 
 };
 
 Sk.builtin.str.prototype.sq$length = function () {
-    return this.codepoints ? this.codepoints.length : this.v.length;
+    return this.$hasAstralCodePoints() ? this.codepoints.length : this.v.length;
 };
 Sk.builtin.bytes.prototype.sq$length = function () {
     return this.v.length;
@@ -233,7 +278,7 @@ Sk.builtin.str.prototype.sq$slice = Sk.builtin.bytes.prototype.sq$slice = functi
     if (i1 < 0) {
         i1 = 0;
     }
-    if (this.codepoints) {
+    if (this.$hasAstralCodePoints()) {
         if (i1 >= this.codepoints.length) {
             return this.__class__.$emptystr;
         }
@@ -1354,7 +1399,7 @@ Sk.builtin.str_iter_ = function (obj) {
     this.$obj = obj.v.slice();
     this.tp$iter = this;
     this.$cls = obj.__class__;
-    if (obj.codepoints) {
+    if (obj.$hasAstralCodePoints()) {
         this.sq$length = obj.codepoints.length;
         this.$codepoints = obj.codepoints.slice();
         this.tp$iternext = function () {

--- a/src/str.js
+++ b/src/str.js
@@ -1,3 +1,84 @@
+// Skulpt handles both 'str' and 'bytes' with Javascript strings.
+// When 'str's contain astral code points, we compute the indices
+// of these codepoints up front, and use those instead of the
+// JS string indices (which are full of surrogate-pair malarkey).
+
+let checkStringish = (self, v) => (v !== null && v.constructor === self.__class__);
+
+Sk.builtin.bytes = function(source, encoding, errors) {
+    Sk.builtin.pyCheckArgsLen("bytes", arguments.length, 0, 3);
+
+    let isConstructor = (this instanceof Sk.builtin.bytes);
+
+    let dunderBytes;
+
+    if (isConstructor && typeof(source) === "string") {
+        this.__class__ = Sk.builtin.bytes;
+        this.v = source;
+        return this;
+    }
+
+    if (source === undefined) {
+        source = "";
+
+    } else if (source instanceof Sk.builtin.str) {
+        if (!(encoding instanceof Sk.builtin.str)) {
+            throw new Sk.builtin.TypeError("string argument without an encoding");
+        }
+        return Sk.builtin.str.prototype["encode"](source, encoding, errors);
+
+    } else if (source instanceof Sk.builtin.int_) {
+        source = "\x00".repeat(source.v);
+
+    } else if (source instanceof Sk.builtin.bytes) {
+        source = source.v;
+
+    } else if ((dunderBytes = Sk.builtin.type.typeLookup(s.ob$type, Sk.builtin.str.$bytes))) {
+        let r = Sk.misceval.callsim(dunderBytes);
+        return isConstructor ? Sk.misceval.retryOptionalSuspensionOrThrow(r) : r;
+
+    } else {
+        // Try to iterate.
+        let v = "";
+        let r = Sk.misceval.iterFor(Sk.abstr.iter(source), (byte) => {
+            if (!Sk.builtin.checkInt(j)) {
+                throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(j) + "' object cannot be interpreted as an integer");
+            }
+            let n = Sk.builtin.asnum$(byte);
+            if (n < 0 || n > 255) {
+                throw new Sk.builtin.ValueError("bytes must be in range(0, 256)");
+            }
+            v += String.fromCodePoint(n);
+        });
+
+        // If we aren't being constructed, we can suspend.
+        if (isConstructor) {
+            Sk.misceval.retryOptionalSuspensionOrThrow(r);
+            source = v;
+        } else {
+            return Sk.misceval.chain(r, () => new Sk.builtin.bytes(v));
+        }
+    }
+
+    if (encoding) {
+        // We haven't got here if it was a string
+        throw new Sk.builtin.TypeError("encoding without a string argument");
+    }
+
+    if (isConstructor) {
+        this.__class__ = Sk.builtin.bytes;
+        this.v = source;
+        return this;
+    } else {
+        return new Sk.builtin.bytes(source);
+    }
+}
+Sk.exportSymbol("Sk.builtin.bytes", Sk.builtin.bytes);
+
+Sk.abstr.setUpInheritance("bytes", Sk.builtin.bytes, Sk.builtin.seqtype);
+
+
+
 Sk.builtin.interned = {};
 
 /**
@@ -69,11 +150,16 @@ Sk.exportSymbol("Sk.builtin.str", Sk.builtin.str);
 
 Sk.abstr.setUpInheritance("str", Sk.builtin.str, Sk.builtin.seqtype);
 
-Sk.builtin.str.prototype.$jsstr = function () {
+Sk.builtin.str.$englishname = "string";
+Sk.builtin.bytes.$englishname = "bytes";
+Sk.builtin.str.$englishsingular = "char";
+Sk.builtin.bytes.$englishsingular = "byte";
+
+Sk.builtin.str.prototype.$jsstr = Sk.builtin.bytes.prototype.$jsstr = function () {
     return this.v;
 };
 
-Sk.builtin.str.prototype.mp$subscript = function (index) {
+Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript = function (index) {
     var ret;
     if (Sk.misceval.isIndex(index)) {
         index = Sk.misceval.asIndex(index);
@@ -81,36 +167,47 @@ Sk.builtin.str.prototype.mp$subscript = function (index) {
             index = this.v.length + index;
         }
         if (index < 0 || index >= this.v.length) {
-            throw new Sk.builtin.IndexError("string index out of range");
+            throw new Sk.builtin.IndexError(this.__class__.$englishname + " index out of range");
         }
-        return new Sk.builtin.str(this.v.charAt(index));
+        if (this.codepoints) {
+            return new this.__class__(this.v.substring(this.codepoints[index], this.codepoints[index+1]));
+        } else {
+            return new this.__class__(this.v.charAt(index));
+        }
     } else if (index instanceof Sk.builtin.slice) {
         ret = "";
         index.sssiter$(this, function (i, wrt) {
-            if (i >= 0 && i < wrt.v.length) {
+            if (wrt.codepoints) {
+                if (i >= 0 && i < wrt.codepoints.length) {
+                    ret += wrt.v.codePointAt(wrt.codePoints[i]);
+                }
+            } else if (i >= 0 && i < wrt.v.length) {
                 ret += wrt.v.charAt(i);
             }
         });
-        return new Sk.builtin.str(ret);
+        return new this.__class__(ret);
     } else {
-        throw new Sk.builtin.TypeError("string indices must be integers, not " + Sk.abstr.typeName(index));
+        throw new Sk.builtin.TypeError(this.__class__.$englishname + " indices must be integers, not " + Sk.abstr.typeName(index));
     }
 };
 
 Sk.builtin.str.prototype.sq$length = function () {
+    return this.codepoints ? this.codepoints.length : this.v.length;
+};
+Sk.builtin.bytes.prototype.sq$length = function () {
     return this.v.length;
 };
-Sk.builtin.str.prototype.sq$concat = function (other) {
+Sk.builtin.str.prototype.sq$concat = Sk.builtin.bytes.prototype.sq$concat = function (other) {
     var otypename;
-    if (!other || !Sk.builtin.checkString(other)) {
+    if (!other || other.__class__ !== this.__class__) {
         otypename = Sk.abstr.typeName(other);
-        throw new Sk.builtin.TypeError("cannot concatenate 'str' and '" + otypename + "' objects");
+        throw new Sk.builtin.TypeError("cannot concatenate '" + this.tp$name + "' and '" + otypename + "' objects");
     }
-    return new Sk.builtin.str(this.v + other.v);
+    return new this.__class__(this.v + other.v);
 };
-Sk.builtin.str.prototype.nb$add = Sk.builtin.str.prototype.sq$concat;
-Sk.builtin.str.prototype.nb$inplace_add = Sk.builtin.str.prototype.sq$concat;
-Sk.builtin.str.prototype.sq$repeat = function (n) {
+Sk.builtin.str.prototype.nb$add = Sk.builtin.bytes.prototype.nb$add = Sk.builtin.str.prototype.sq$concat;
+Sk.builtin.str.prototype.nb$inplace_add = Sk.builtin.bytes.prototype.nb$add = Sk.builtin.str.prototype.sq$concat;
+Sk.builtin.str.prototype.sq$repeat = Sk.builtin.bytes.prototype.sq$repeat = function (n) {
     var i;
     var ret;
 
@@ -123,39 +220,46 @@ Sk.builtin.str.prototype.sq$repeat = function (n) {
     for (i = 0; i < n; ++i) {
         ret += this.v;
     }
-    return new Sk.builtin.str(ret);
+    return new this.__class__(ret);
 };
-Sk.builtin.str.prototype.nb$multiply = Sk.builtin.str.prototype.sq$repeat;
-Sk.builtin.str.prototype.nb$inplace_multiply = Sk.builtin.str.prototype.sq$repeat;
-Sk.builtin.str.prototype.sq$item = function () {
+Sk.builtin.str.prototype.nb$multiply = Sk.builtin.bytes.prototype.nb$multiply = Sk.builtin.str.prototype.sq$repeat;
+Sk.builtin.str.prototype.nb$inplace_multiply = Sk.builtin.bytes.prototype.nb$inplace_multiply = Sk.builtin.str.prototype.sq$repeat;
+Sk.builtin.str.prototype.sq$item = Sk.builtin.bytes.prototype.sq$item = function () {
     Sk.asserts.fail();
 };
-Sk.builtin.str.prototype.sq$slice = function (i1, i2) {
+Sk.builtin.str.prototype.sq$slice = Sk.builtin.bytes.prototype.sq$slice = function (i1, i2) {
     i1 = Sk.builtin.asnum$(i1);
     i2 = Sk.builtin.asnum$(i2);
     if (i1 < 0) {
         i1 = 0;
     }
-    return new Sk.builtin.str(this.v.substr(i1, i2 - i1));
+    if (this.codepoints) {
+        if (i1 >= this.codepoints.length) {
+            return this.__class__.$emptystr;
+        }
+        return new this.__class__(this.v.substring(this.codepoints[i1], this.codepoints[i2]));
+    } else {
+        return new this.__class__(this.v.substring(i1, i2));
+    }
 };
 
-Sk.builtin.str.prototype.sq$contains = function (ob) {
-    if (!(ob instanceof Sk.builtin.str)) {
-        throw new Sk.builtin.TypeError("TypeError: 'In <string> requires string as left operand");
+Sk.builtin.str.prototype.sq$contains = Sk.builtin.bytes.prototype.sq$contains = function (ob) {
+    if (!(ob instanceof this.__class__)) {
+        throw new Sk.builtin.TypeError("TypeError: 'In <" + this.__class__.$englishname + "> requires " + this.__class__.$englishname + " as left operand");
     }
     return this.v.indexOf(ob.v) != -1;
 };
 
-Sk.builtin.str.prototype.__iter__ = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype.__iter__ = Sk.builtin.bytes.prototype.__iter__ = new Sk.builtin.func(function (self) {
     return new Sk.builtin.str_iter_(self);
 });
 
-Sk.builtin.str.prototype.tp$iter = function () {
+Sk.builtin.str.prototype.tp$iter = Sk.builtin.bytes.prototype.tp$iter = function () {
     return new Sk.builtin.str_iter_(this);
 };
 
-Sk.builtin.str.prototype.tp$richcompare = function (other, op) {
-    if (!(other instanceof Sk.builtin.str)) {
+Sk.builtin.str.prototype.tp$richcompare = Sk.builtin.bytes.prototype.tp$richcompare = function (other, op) {
+    if (!(other instanceof this.__class__)) {
         return Sk.builtin.NotImplemented.NotImplemented$;
     }
 
@@ -177,7 +281,7 @@ Sk.builtin.str.prototype.tp$richcompare = function (other, op) {
     }
 };
 
-Sk.builtin.str.prototype["$r"] = function () {
+Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () {
     // single is preferred
     var ashex;
     var c;
@@ -191,7 +295,7 @@ Sk.builtin.str.prototype["$r"] = function () {
     }
     //jshint ignore:end
     len = this.v.length;
-    ret = quote;
+    ret = (this.__class__ === Sk.builtin.bytes) ? "b" + quote : quote;
     for (i = 0; i < len; ++i) {
         c = this.v.charAt(i);
         if (c === quote || c === "\\") {
@@ -202,6 +306,24 @@ Sk.builtin.str.prototype["$r"] = function () {
             ret += "\\n";
         } else if (c === "\r") {
             ret += "\\r";
+        } else if (c > 0xff && c < 0xd800 || c >= 0xe000) {
+            // BMP
+            ret += "\\u" + ("000"+this.v.charCodeAt(i).toString(16)).slice(-4);
+        } else if (c >= 0xd800) {
+            // Surrogate pair stuff
+            let val = this.v.codePointAt(i);
+            i++;
+
+            val = val.toString(16);
+            let s = ("0000000"+val.toString(16));
+            if (val.length > 4) {
+                ret += "\\U" + s.slice(-8);
+            } else {
+                ret += "\\u" + s.slice(-4);
+            }
+        } else if (c > 0xff) {
+            // Invalid!
+            ret += "\\ufffd";
         } else if (c < " " || c >= 0x7f) {
             ashex = c.charCodeAt(0).toString(16);
             if (ashex.length < 2) {
@@ -266,22 +388,22 @@ Sk.builtin.str.prototype["capitalize"] = new Sk.builtin.func(function (self) {
     return new Sk.builtin.str(cap);
 });
 
-Sk.builtin.str.prototype["join"] = new Sk.builtin.func(function (self, seq) {
+Sk.builtin.str.prototype["join"] = Sk.builtin.bytes.prototype["join"] = new Sk.builtin.func(function (self, seq) {
     var it, i;
     var arrOfStrs;
     Sk.builtin.pyCheckArgsLen("join", arguments.length, 2, 2);
     Sk.builtin.pyCheckType("seq", "iterable", Sk.builtin.checkIterable(seq));
     arrOfStrs = [];
     for (it = seq.tp$iter(), i = it.tp$iternext(); i !== undefined; i = it.tp$iternext()) {
-        if (i.constructor !== Sk.builtin.str) {
-            throw new Sk.builtin.TypeError("TypeError: sequence item " + arrOfStrs.length + ": expected string, " + typeof i + " found");
+        if (i.constructor !== self.__class__) {
+            throw new Sk.builtin.TypeError("TypeError: sequence item " + arrOfStrs.length + ": expected " + self.__class__.$englishname + ", " + typeof i + " found");
         }
         arrOfStrs.push(i.v);
     }
-    return new Sk.builtin.str(arrOfStrs.join(self.v));
+    return new self.__class__(arrOfStrs.join(self.v));
 });
 
-Sk.builtin.str.prototype["split"] = new Sk.builtin.func(function (self, on, howmany) {
+Sk.builtin.str.prototype["split"] = Sk.builtin.bytes.prototype["split"] = new Sk.builtin.func(function (self, on, howmany) {
     var splits;
     var index;
     var match;
@@ -293,8 +415,8 @@ Sk.builtin.str.prototype["split"] = new Sk.builtin.func(function (self, on, howm
     if ((on === undefined) || (on instanceof Sk.builtin.none)) {
         on = null;
     }
-    if ((on !== null) && !Sk.builtin.checkString(on)) {
-        throw new Sk.builtin.TypeError("expected a string");
+    if ((on !== null) && !checkStringish(self, on)) {
+        throw new Sk.builtin.TypeError("expected " + self.__class__.$englishname);
     }
     if ((on !== null) && on.v === "") {
         throw new Sk.builtin.ValueError("empty separator");
@@ -326,7 +448,7 @@ Sk.builtin.str.prototype["split"] = new Sk.builtin.func(function (self, on, howm
             // empty match
             break;
         }
-        result.push(new Sk.builtin.str(str.substring(index, match.index)));
+        result.push(new self.__class__(str.substring(index, match.index)));
         index = regex.lastIndex;
         splits += 1;
         if (howmany && (splits >= howmany)) {
@@ -335,18 +457,18 @@ Sk.builtin.str.prototype["split"] = new Sk.builtin.func(function (self, on, howm
     }
     str = str.substring(index);
     if (on !== null || (str.length > 0)) {
-        result.push(new Sk.builtin.str(str));
+        result.push(new self.__class__(str));
     }
 
     return new Sk.builtin.list(result);
 });
 
-Sk.builtin.str.prototype["strip"] = new Sk.builtin.func(function (self, chars) {
+Sk.builtin.str.prototype["strip"] = Sk.builtin.bytes.prototype["strip"] = new Sk.builtin.func(function (self, chars) {
     var regex;
     var pattern;
     Sk.builtin.pyCheckArgsLen("strip", arguments.length, 1, 2);
-    if ((chars !== undefined) && !Sk.builtin.checkString(chars)) {
-        throw new Sk.builtin.TypeError("strip arg must be None or str");
+    if ((chars !== undefined) && chars.__class__ !== self.__class__) {
+        throw new Sk.builtin.TypeError("strip arg must be None or " + self.__class__.$englishname);
     }
     if (chars === undefined) {
         pattern = /^\s+|\s+$/g;
@@ -354,15 +476,15 @@ Sk.builtin.str.prototype["strip"] = new Sk.builtin.func(function (self, chars) {
         regex = Sk.builtin.str.re_escape_(chars.v);
         pattern = new RegExp("^[" + regex + "]+|[" + regex + "]+$", "g");
     }
-    return new Sk.builtin.str(self.v.replace(pattern, ""));
+    return new self.__class__(self.v.replace(pattern, ""));
 });
 
-Sk.builtin.str.prototype["lstrip"] = new Sk.builtin.func(function (self, chars) {
+Sk.builtin.str.prototype["lstrip"] = Sk.builtin.bytes.prototype["lstrip"] = new Sk.builtin.func(function (self, chars) {
     var regex;
     var pattern;
     Sk.builtin.pyCheckArgsLen("lstrip", arguments.length, 1, 2);
-    if ((chars !== undefined) && !Sk.builtin.checkString(chars)) {
-        throw new Sk.builtin.TypeError("lstrip arg must be None or str");
+    if ((chars !== undefined) && chars.__class__ !== self.__class__) {
+        throw new Sk.builtin.TypeError("lstrip arg must be None or " + self.__class__.$englishname);
     }
     if (chars === undefined) {
         pattern = /^\s+/g;
@@ -370,15 +492,15 @@ Sk.builtin.str.prototype["lstrip"] = new Sk.builtin.func(function (self, chars) 
         regex = Sk.builtin.str.re_escape_(chars.v);
         pattern = new RegExp("^[" + regex + "]+", "g");
     }
-    return new Sk.builtin.str(self.v.replace(pattern, ""));
+    return new self.__class__(self.v.replace(pattern, ""));
 });
 
-Sk.builtin.str.prototype["rstrip"] = new Sk.builtin.func(function (self, chars) {
+Sk.builtin.str.prototype["rstrip"] = Sk.builtin.bytes.prototype["rstrip"] = new Sk.builtin.func(function (self, chars) {
     var regex;
     var pattern;
     Sk.builtin.pyCheckArgsLen("rstrip", arguments.length, 1, 2);
-    if ((chars !== undefined) && !Sk.builtin.checkString(chars)) {
-        throw new Sk.builtin.TypeError("rstrip arg must be None or str");
+    if ((chars !== undefined) && chars.__class__ !== self.__class__) {
+        throw new Sk.builtin.TypeError("rstrip arg must be None or " + self.__class__.$englishname);
     }
     if (chars === undefined) {
         pattern = /\s+$/g;
@@ -386,50 +508,70 @@ Sk.builtin.str.prototype["rstrip"] = new Sk.builtin.func(function (self, chars) 
         regex = Sk.builtin.str.re_escape_(chars.v);
         pattern = new RegExp("[" + regex + "]+$", "g");
     }
-    return new Sk.builtin.str(self.v.replace(pattern, ""));
+    return new self.__class__(self.v.replace(pattern, ""));
 });
 
-Sk.builtin.str.prototype["partition"] = new Sk.builtin.func(function (self, sep) {
+Sk.builtin.str.prototype["__format__"] = new Sk.builtin.func(function (self, format_spec) {
+    var formatstr;
+    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
+
+    if (!Sk.builtin.checkString(format_spec)) {
+        if (Sk.__future__.exceptions) {
+            throw new Sk.builtin.TypeError("format() argument 2 must be str, not " + Sk.abstr.typeName(format_spec));
+        } else {
+            throw new Sk.builtin.TypeError("format expects arg 2 to be string or unicode, not " + Sk.abstr.typeName(format_spec));
+        }
+    } else {
+        formatstr = Sk.ffi.remapToJs(format_spec);
+        if (formatstr !== "" && formatstr !== "s") {
+            throw new Sk.builtin.NotImplementedError("format spec is not yet implemented");
+        }
+    }
+
+    return new Sk.builtin.str(self);
+});
+
+Sk.builtin.str.prototype["partition"] = Sk.builtin.bytes.prototype["partition"] = new Sk.builtin.func(function (self, sep) {
     var pos;
     var sepStr;
     Sk.builtin.pyCheckArgsLen("partition", arguments.length, 2, 2);
-    Sk.builtin.pyCheckType("sep", "string", Sk.builtin.checkString(sep));
-    sepStr = new Sk.builtin.str(sep);
+    Sk.builtin.pyCheckType("sep", self.__class__.$englishname, checkStringish(self, sep));
+    sepStr = new self.__class__(sep);
     pos = self.v.indexOf(sepStr.v);
     if (pos < 0) {
-        return new Sk.builtin.tuple([self, Sk.builtin.str.$emptystr, Sk.builtin.str.$emptystr]);
+        return new Sk.builtin.tuple([self, self.__class__.$emptystr, self.__class__.$emptystr]);
     }
 
     return new Sk.builtin.tuple([
-        new Sk.builtin.str(self.v.substring(0, pos)),
+        new self.__class__(self.v.substring(0, pos)),
         sepStr,
-        new Sk.builtin.str(self.v.substring(pos + sepStr.v.length))]);
+        new self.__class__(self.v.substring(pos + sepStr.v.length))]);
 });
 
-Sk.builtin.str.prototype["rpartition"] = new Sk.builtin.func(function (self, sep) {
+Sk.builtin.str.prototype["rpartition"] = Sk.builtin.bytes.prototype["rpartition"] = new Sk.builtin.func(function (self, sep) {
     var pos;
     var sepStr;
     Sk.builtin.pyCheckArgsLen("rpartition", arguments.length, 2, 2);
-    Sk.builtin.pyCheckType("sep", "string", Sk.builtin.checkString(sep));
-    sepStr = new Sk.builtin.str(sep);
+    Sk.builtin.pyCheckType("sep", self.__class__.$englishname, checkStringish(self, sep));
+    sepStr = new self.__class__(sep);
     pos = self.v.lastIndexOf(sepStr.v);
     if (pos < 0) {
-        return new Sk.builtin.tuple([Sk.builtin.str.$emptystr, Sk.builtin.str.$emptystr, self]);
+        return new Sk.builtin.tuple([self.__class__.$emptystr, self.__class__.$emptystr, self]);
     }
 
     return new Sk.builtin.tuple([
-        new Sk.builtin.str(self.v.substring(0, pos)),
+        new self.__class__(self.v.substring(0, pos)),
         sepStr,
-        new Sk.builtin.str(self.v.substring(pos + sepStr.v.length))]);
+        new self.__class__(self.v.substring(pos + sepStr.v.length))]);
 });
 
-Sk.builtin.str.prototype["count"] = new Sk.builtin.func(function (self, pat, start, end) {
+Sk.builtin.str.prototype["count"] = Sk.builtin.bytes.prototype["count"] = new Sk.builtin.func(function (self, pat, start, end) {
     var normaltext;
     var ctl;
     var slice;
     var m;
     Sk.builtin.pyCheckArgsLen("count", arguments.length, 2, 4);
-    if (!Sk.builtin.checkString(pat)) {
+    if (!checkStringish(self, pat)) {
         throw new Sk.builtin.TypeError("expected a character buffer object");
     }
     if ((start !== undefined) && !Sk.builtin.checkInt(start)) {
@@ -465,14 +607,14 @@ Sk.builtin.str.prototype["count"] = new Sk.builtin.func(function (self, pat, sta
 
 });
 
-Sk.builtin.str.prototype["ljust"] = new Sk.builtin.func(function (self, len, fillchar) {
+Sk.builtin.str.prototype["ljust"] = Sk.builtin.bytes.prototype["ljust"] = new Sk.builtin.func(function (self, len, fillchar) {
     var newstr;
     Sk.builtin.pyCheckArgsLen("ljust", arguments.length, 2, 3);
     if (!Sk.builtin.checkInt(len)) {
         throw new Sk.builtin.TypeError("integer argument exepcted, got " + Sk.abstr.typeName(len));
     }
-    if ((fillchar !== undefined) && (!Sk.builtin.checkString(fillchar) || fillchar.v.length !== 1)) {
-        throw new Sk.builtin.TypeError("must be char, not " + Sk.abstr.typeName(fillchar));
+    if ((fillchar !== undefined) && (!checkStringish(self, fillchar) || fillchar.v.length !== 1)) {
+        throw new Sk.builtin.TypeError("must be " + self.__class__.$englishsingular + ", not " + Sk.abstr.typeName(fillchar));
     }
     if (fillchar === undefined) {
         fillchar = " ";
@@ -484,18 +626,18 @@ Sk.builtin.str.prototype["ljust"] = new Sk.builtin.func(function (self, len, fil
         return self;
     } else {
         newstr = Array.prototype.join.call({length: Math.floor(len - self.v.length) + 1}, fillchar);
-        return new Sk.builtin.str(self.v + newstr);
+        return new self.__class__(self.v + newstr);
     }
 });
 
-Sk.builtin.str.prototype["rjust"] = new Sk.builtin.func(function (self, len, fillchar) {
+Sk.builtin.str.prototype["rjust"] = Sk.builtin.bytes.prototype["rjust"] = new Sk.builtin.func(function (self, len, fillchar) {
     var newstr;
     Sk.builtin.pyCheckArgsLen("rjust", arguments.length, 2, 3);
     if (!Sk.builtin.checkInt(len)) {
         throw new Sk.builtin.TypeError("integer argument exepcted, got " + Sk.abstr.typeName(len));
     }
-    if ((fillchar !== undefined) && (!Sk.builtin.checkString(fillchar) || fillchar.v.length !== 1)) {
-        throw new Sk.builtin.TypeError("must be char, not " + Sk.abstr.typeName(fillchar));
+    if ((fillchar !== undefined) && (!checkStringish(self, fillchar) || fillchar.v.length !== 1)) {
+        throw new Sk.builtin.TypeError("must be " + self.__class__.$englishsingular + ", not " + Sk.abstr.typeName(fillchar));
     }
     if (fillchar === undefined) {
         fillchar = " ";
@@ -507,20 +649,20 @@ Sk.builtin.str.prototype["rjust"] = new Sk.builtin.func(function (self, len, fil
         return self;
     } else {
         newstr = Array.prototype.join.call({length: Math.floor(len - self.v.length) + 1}, fillchar);
-        return new Sk.builtin.str(newstr + self.v);
+        return new self.__class__(newstr + self.v);
     }
 
 });
 
-Sk.builtin.str.prototype["center"] = new Sk.builtin.func(function (self, len, fillchar) {
+Sk.builtin.str.prototype["center"] = Sk.builtin.bytes.prototype["center"] = new Sk.builtin.func(function (self, len, fillchar) {
     var newstr;
     var newstr1;
     Sk.builtin.pyCheckArgsLen("center", arguments.length, 2, 3);
     if (!Sk.builtin.checkInt(len)) {
-        throw new Sk.builtin.TypeError("integer argument exepcted, got " + Sk.abstr.typeName(len));
+        throw new Sk.builtin.TypeError("integer argument expected, got " + Sk.abstr.typeName(len));
     }
-    if ((fillchar !== undefined) && (!Sk.builtin.checkString(fillchar) || fillchar.v.length !== 1)) {
-        throw new Sk.builtin.TypeError("must be char, not " + Sk.abstr.typeName(fillchar));
+    if ((fillchar !== undefined) && (!checkStringish(self, fillchar) || fillchar.v.length !== 1)) {
+        throw new Sk.builtin.TypeError("must be " + self.__class__.$englishsingular + ", not " + Sk.abstr.typeName(fillchar));
     }
     if (fillchar === undefined) {
         fillchar = " ";
@@ -536,16 +678,16 @@ Sk.builtin.str.prototype["center"] = new Sk.builtin.func(function (self, len, fi
         if (newstr.length < len) {
             newstr = newstr + fillchar;
         }
-        return new Sk.builtin.str(newstr);
+        return new self.__class__(newstr);
     }
 
 });
 
-Sk.builtin.str.prototype["find"] = new Sk.builtin.func(function (self, tgt, start, end) {
+Sk.builtin.str.prototype["find"] = Sk.builtin.bytes.prototype["find"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
     Sk.builtin.pyCheckArgsLen("find", arguments.length, 2, 4);
-    if (!Sk.builtin.checkString(tgt)) {
-        throw new Sk.builtin.TypeError("expected a character buffer object");
+    if (!checkStringish(self, tgt)) {
+        throw new Sk.builtin.TypeError("expected a " + self.__class__.$englishname + " object");
     }
     if ((start !== undefined) && !Sk.builtin.checkInt(start)) {
         throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");
@@ -574,7 +716,7 @@ Sk.builtin.str.prototype["find"] = new Sk.builtin.func(function (self, tgt, star
     return new Sk.builtin.int_(idx);
 });
 
-Sk.builtin.str.prototype["index"] = new Sk.builtin.func(function (self, tgt, start, end) {
+Sk.builtin.str.prototype["index"] = Sk.builtin.bytes.prototype["index"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
     Sk.builtin.pyCheckArgsLen("index", arguments.length, 2, 4);
     idx = Sk.misceval.callsimArray(self["find"], [self, tgt, start, end]);
@@ -584,11 +726,11 @@ Sk.builtin.str.prototype["index"] = new Sk.builtin.func(function (self, tgt, sta
     return idx;
 });
 
-Sk.builtin.str.prototype["rfind"] = new Sk.builtin.func(function (self, tgt, start, end) {
+Sk.builtin.str.prototype["rfind"] = Sk.builtin.bytes.prototype["rfind"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
     Sk.builtin.pyCheckArgsLen("rfind", arguments.length, 2, 4);
-    if (!Sk.builtin.checkString(tgt)) {
-        throw new Sk.builtin.TypeError("expected a character buffer object");
+    if (!checkStringish(self, tgt)) {
+        throw new Sk.builtin.TypeError("expected a " + self.__class__.$englishname + " object");
     }
     if ((start !== undefined) && !Sk.builtin.checkInt(start)) {
         throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");
@@ -618,7 +760,7 @@ Sk.builtin.str.prototype["rfind"] = new Sk.builtin.func(function (self, tgt, sta
     return new Sk.builtin.int_(idx);
 });
 
-Sk.builtin.str.prototype["rindex"] = new Sk.builtin.func(function (self, tgt, start, end) {
+Sk.builtin.str.prototype["rindex"] = Sk.builtin.bytes.prototype["rindex"] = new Sk.builtin.func(function (self, tgt, start, end) {
     var idx;
     Sk.builtin.pyCheckArgsLen("rindex", arguments.length, 2, 4);
     idx = Sk.misceval.callsimArray(self["rfind"], [self, tgt, start, end]);
@@ -628,25 +770,25 @@ Sk.builtin.str.prototype["rindex"] = new Sk.builtin.func(function (self, tgt, st
     return idx;
 });
 
-Sk.builtin.str.prototype["startswith"] = new Sk.builtin.func(function (self, tgt) {
+Sk.builtin.str.prototype["startswith"] = Sk.builtin.bytes.prototype["startswith"] = new Sk.builtin.func(function (self, tgt) {
     Sk.builtin.pyCheckArgsLen("startswith", arguments.length, 2, 2);
-    Sk.builtin.pyCheckType("tgt", "string", Sk.builtin.checkString(tgt));
+    Sk.builtin.pyCheckType("tgt", self.__class__.$englishname, checkStringish(self, tgt));
     return new Sk.builtin.bool( self.v.indexOf(tgt.v) === 0);
 });
 
 // http://stackoverflow.com/questions/280634/endswith-in-javascript
-Sk.builtin.str.prototype["endswith"] = new Sk.builtin.func(function (self, tgt) {
+Sk.builtin.str.prototype["endswith"] = Sk.builtin.bytes.prototype["endswith"] = new Sk.builtin.func(function (self, tgt) {
     Sk.builtin.pyCheckArgsLen("endswith", arguments.length, 2, 2);
-    Sk.builtin.pyCheckType("tgt", "string", Sk.builtin.checkString(tgt));
+    Sk.builtin.pyCheckType("tgt", self.__class__.$englishname, checkStringish(self, tgt));
     return new Sk.builtin.bool( self.v.indexOf(tgt.v, self.v.length - tgt.v.length) !== -1);
 });
 
-Sk.builtin.str.prototype["replace"] = new Sk.builtin.func(function (self, oldS, newS, count) {
+Sk.builtin.str.prototype["replace"] = Sk.builtin.bytes.prototype["replace"] = new Sk.builtin.func(function (self, oldS, newS, count) {
     var c;
     var patt;
     Sk.builtin.pyCheckArgsLen("replace", arguments.length, 3, 4);
-    Sk.builtin.pyCheckType("oldS", "string", Sk.builtin.checkString(oldS));
-    Sk.builtin.pyCheckType("newS", "string", Sk.builtin.checkString(newS));
+    Sk.builtin.pyCheckType("oldS", self.__class__.$englishname, checkStringish(self, oldS));
+    Sk.builtin.pyCheckType("newS", self.__class__.$englishname, checkStringish(self, newS));
     if ((count !== undefined) && !Sk.builtin.checkInt(count)) {
         throw new Sk.builtin.TypeError("integer argument expected, got " +
             Sk.abstr.typeName(count));
@@ -655,7 +797,7 @@ Sk.builtin.str.prototype["replace"] = new Sk.builtin.func(function (self, oldS, 
     patt = new RegExp(Sk.builtin.str.re_escape_(oldS.v), "g");
 
     if ((count === undefined) || (count < 0)) {
-        return new Sk.builtin.str(self.v.replace(patt, newS.v));
+        return new self.__class__(self.v.replace(patt, newS.v));
     }
 
     c = 0;
@@ -668,10 +810,10 @@ Sk.builtin.str.prototype["replace"] = new Sk.builtin.func(function (self, oldS, 
         return match;
     }
 
-    return new Sk.builtin.str(self.v.replace(patt, replacer));
+    return new self.__class__(self.v.replace(patt, replacer));
 });
 
-Sk.builtin.str.prototype["zfill"] = new Sk.builtin.func(function (self, len) {
+Sk.builtin.str.prototype["zfill"] = Sk.builtin.bytes.prototype["zfill"] = new Sk.builtin.func(function (self, len) {
     var str = self.v;
     var ret;
     var zeroes;
@@ -692,23 +834,23 @@ Sk.builtin.str.prototype["zfill"] = new Sk.builtin.func(function (self, len) {
     }
     // combine the string and the zeroes
     ret = str.substr(0, offset) + pad + str.substr(offset);
-    return new Sk.builtin.str(ret);
+    return new self.__class__(ret);
 
 
 });
 
-Sk.builtin.str.prototype["isdigit"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["isdigit"] = Sk.builtin.bytes.prototype["isdigit"] = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgsLen("isdigit", arguments.length, 1, 1);
     return new Sk.builtin.bool( /^\d+$/.test(self.v));
 });
 
-Sk.builtin.str.prototype["isspace"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["isspace"] = Sk.builtin.bytes.prototype["isspace"] = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgsLen("isspace", arguments.length, 1, 1);
     return new Sk.builtin.bool( /^\s+$/.test(self.v));
 });
 
 
-Sk.builtin.str.prototype["expandtabs"] = new Sk.builtin.func(function (self, tabsize) {
+Sk.builtin.str.prototype["expandtabs"] = Sk.builtin.bytes.prototype["expandtabs"] = new Sk.builtin.func(function (self, tabsize) {
     // var input = self.v;
     // var expanded = "";
     // var split;
@@ -735,10 +877,10 @@ Sk.builtin.str.prototype["expandtabs"] = new Sk.builtin.func(function (self, tab
     expanded = self.v.replace(/([^\r\n\t]*)\t/g, function(a, b) {
         return b + spaces.slice(b.length % tabsize);
     });
-    return new Sk.builtin.str(expanded);
+    return new self.__class__(expanded);
 });
 
-Sk.builtin.str.prototype["swapcase"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["swapcase"] = Sk.builtin.bytes.prototype["swapcase"] = new Sk.builtin.func(function (self) {
     var ret;
     Sk.builtin.pyCheckArgsLen("swapcase", arguments.length, 1, 1);
 
@@ -748,10 +890,10 @@ Sk.builtin.str.prototype["swapcase"] = new Sk.builtin.func(function (self) {
         return lc === c ? c.toUpperCase() : lc;
     });
 
-    return new Sk.builtin.str(ret);
+    return new self.__class__(ret);
 });
 
-Sk.builtin.str.prototype["splitlines"] = new Sk.builtin.func(function (self, keepends) {
+Sk.builtin.str.prototype["splitlines"] = Sk.builtin.bytes.prototype["splitlines"] = new Sk.builtin.func(function (self, keepends) {
     var data = self.v;
     var i = 0;
     var j = i;
@@ -799,12 +941,12 @@ Sk.builtin.str.prototype["splitlines"] = new Sk.builtin.func(function (self, kee
         if (! keepends) {
             slice = slice.replace(/(\r|\n)/g, "");
         }
-        strs_w.push(new Sk.builtin.str(slice));
+        strs_w.push(new self.__class__(slice));
     }
     return new Sk.builtin.list(strs_w);
 });
 
-Sk.builtin.str.prototype["title"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["title"] = Sk.builtin.bytes.prototype["title"] = new Sk.builtin.func(function (self) {
     var ret;
 
     Sk.builtin.pyCheckArgsLen("title", arguments.length, 1, 1);
@@ -813,36 +955,36 @@ Sk.builtin.str.prototype["title"] = new Sk.builtin.func(function (self) {
         return str[0].toUpperCase() + str.substr(1).toLowerCase();
     });
 
-    return new Sk.builtin.str(ret);
+    return new self.__class__(ret);
 });
 
-Sk.builtin.str.prototype["isalpha"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["isalpha"] = Sk.builtin.bytes.prototype["isalpha"] = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgsLen("isalpha", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && !/[^a-zA-Z]/.test(self.v));
 });
 
-Sk.builtin.str.prototype["isalnum"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["isalnum"] = Sk.builtin.bytes.prototype["isalnum"] = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgsLen("isalnum", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && !/[^a-zA-Z0-9]/.test(self.v));
 });
 
 // does not account for unicode numeric values
-Sk.builtin.str.prototype["isnumeric"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["isnumeric"] = Sk.builtin.bytes.prototype["isnumeric"] = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgsLen("isnumeric", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && !/[^0-9]/.test(self.v));
 });
 
-Sk.builtin.str.prototype["islower"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["islower"] = Sk.builtin.bytes.prototype["islower"] = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgsLen("islower", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && /[a-z]/.test(self.v) && !/[A-Z]/.test(self.v));
 });
 
-Sk.builtin.str.prototype["isupper"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["isupper"] = Sk.builtin.bytes.prototype["isupper"] = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgsLen("isupper", arguments.length, 1, 1);
     return new Sk.builtin.bool( self.v.length && !/[a-z]/.test(self.v) && /[A-Z]/.test(self.v));
 });
 
-Sk.builtin.str.prototype["istitle"] = new Sk.builtin.func(function (self) {
+Sk.builtin.str.prototype["istitle"] = Sk.builtin.bytes.prototype["istitle"] = new Sk.builtin.func(function (self) {
     // Comparing to str.title() seems the most intuitive thing, but it fails on "",
     // Other empty-ish strings with no change.
     var input = self.v;
@@ -871,7 +1013,7 @@ Sk.builtin.str.prototype["istitle"] = new Sk.builtin.func(function (self) {
     return new Sk.builtin.bool( cased);
 });
 
-Sk.builtin.str.prototype.nb$remainder = function (rhs) {
+Sk.builtin.str.prototype.nb$remainder = Sk.builtin.bytes.prototype.nb$remainder = function (rhs) {
     // % format op. rhs can be a value, a tuple, or something with __getitem__ (dict)
 
     // From http://docs.python.org/library/stdtypes.html#string-formatting the
@@ -890,6 +1032,8 @@ Sk.builtin.str.prototype.nb$remainder = function (rhs) {
     var index;
     var regex;
     var val;
+
+    let self = this;
 
     if (rhs.constructor !== Sk.builtin.tuple && (rhs.mp$subscript === undefined || rhs.constructor === Sk.builtin.str)) {
         rhs = new Sk.builtin.tuple([rhs]);
@@ -1133,7 +1277,7 @@ Sk.builtin.str.prototype.nb$remainder = function (rhs) {
             }
             return r.v;
         } else if (conversionType === "s") {
-            r = new Sk.builtin.str(value);
+            r = new self.__class__(value);
             r = r.$jsstr();
             if (precision) {
                 return r.substr(0, precision);
@@ -1147,7 +1291,7 @@ Sk.builtin.str.prototype.nb$remainder = function (rhs) {
         }
     };
     ret = this.v.replace(regex, replFunc);
-    return new Sk.builtin.str(ret);
+    return new self.__class__(ret);
 };
 
 /**
@@ -1160,14 +1304,27 @@ Sk.builtin.str_iter_ = function (obj) {
     }
     this.$index = 0;
     this.$obj = obj.v.slice();
-    this.sq$length = this.$obj.length;
     this.tp$iter = this;
-    this.tp$iternext = function () {
-        if (this.$index >= this.sq$length) {
-            return undefined;
+    this.$cls = obj.__class__;
+    if (obj.codepoints) {
+        this.sq$length = obj.codepoints.length;
+        this.$codepoints = obj.codepoints.slice();
+        this.tp$iternext = function () {
+            if (this.$index >= this.sq$length) {
+                return undefined;
+            }
+
+            return new this.$cls(this.$obj.substring(this.$codepoints[this.$index], this.$codepoints[this.$index+1]));
         }
-        return new Sk.builtin.str(this.$obj.substr(this.$index++, 1));
-    };
+    } else {
+        this.sq$length = this.$obj.length;
+        this.tp$iternext = function () {
+            if (this.$index >= this.sq$length) {
+                return undefined;
+            }
+            return new Sk.builtin.str(this.$obj.substr(this.$index++, 1));
+        }
+    }
     this.$r = function () {
         return new Sk.builtin.str("iterator");
     };

--- a/src/str.js
+++ b/src/str.js
@@ -208,13 +208,14 @@ Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript 
     var ret;
     if (Sk.misceval.isIndex(index)) {
         index = Sk.misceval.asIndex(index);
+        let len = this.$hasAstralCodePoints() ? this.codepoints.length : this.v.length;
         if (index < 0) {
-            index = this.v.length + index;
+            index = len + index;
         }
-        if (index < 0 || index >= this.v.length) {
+        if (index < 0 || index >= len) {
             throw new Sk.builtin.IndexError(this.__class__.$englishname + " index out of range");
         }
-        if (this.$hasAstralCodePoints()) {
+        if (this.codepoints) {
             return new this.__class__(this.v.substring(this.codepoints[index], this.codepoints[index+1]));
         } else {
             return new this.__class__(this.v.charAt(index));
@@ -632,23 +633,30 @@ Sk.builtin.str.prototype["count"] = Sk.builtin.bytes.prototype["count"] = new Sk
         throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");
     }
 
+    let len = self.sq$length();
+
     if (start === undefined) {
         start = 0;
     } else {
         start = Sk.builtin.asnum$(start);
-        start = start >= 0 ? start : self.v.length + start;
+        start = start >= 0 ? start : len + start;
+        if (start > len) {
+            // Guard against running off the end of the codepoints array
+            return new Sk.builtin.int_(0);
+        }
     }
 
     if (end === undefined) {
-        end = self.v.length;
+        end = len;
     } else {
         end = Sk.builtin.asnum$(end);
-        end = end >= 0 ? end : self.v.length + end;
+        end = end >= 0 ? end : len + end;
     }
 
     normaltext = pat.v.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
     m = new RegExp(normaltext, "g");
-    slice = self.v.slice(start, end);
+    slice = self.v.slice(self.codepoints ? self.codepoints[start] : start,
+                            self.codepoints ? self.codepoints[end] : end);
     ctl = slice.match(m);
     if (!ctl) {
         return  new Sk.builtin.int_(0);
@@ -658,81 +666,49 @@ Sk.builtin.str.prototype["count"] = Sk.builtin.bytes.prototype["count"] = new Sk
 
 });
 
-Sk.builtin.str.prototype["ljust"] = Sk.builtin.bytes.prototype["ljust"] = new Sk.builtin.func(function (self, len, fillchar) {
-    var newstr;
-    Sk.builtin.pyCheckArgsLen("ljust", arguments.length, 2, 3);
-    if (!Sk.builtin.checkInt(len)) {
-        throw new Sk.builtin.TypeError("integer argument exepcted, got " + Sk.abstr.typeName(len));
-    }
-    if ((fillchar !== undefined) && (!checkStringish(self, fillchar) || fillchar.v.length !== 1)) {
-        throw new Sk.builtin.TypeError("must be " + self.__class__.$englishsingular + ", not " + Sk.abstr.typeName(fillchar));
-    }
-    if (fillchar === undefined) {
-        fillchar = " ";
-    } else {
-        fillchar = fillchar.v;
-    }
-    len = Sk.builtin.asnum$(len);
-    if (self.v.length >= len) {
-        return self;
-    } else {
-        newstr = Array.prototype.join.call({length: Math.floor(len - self.v.length) + 1}, fillchar);
-        return new self.__class__(self.v + newstr);
-    }
-});
-
-Sk.builtin.str.prototype["rjust"] = Sk.builtin.bytes.prototype["rjust"] = new Sk.builtin.func(function (self, len, fillchar) {
-    var newstr;
-    Sk.builtin.pyCheckArgsLen("rjust", arguments.length, 2, 3);
-    if (!Sk.builtin.checkInt(len)) {
-        throw new Sk.builtin.TypeError("integer argument exepcted, got " + Sk.abstr.typeName(len));
-    }
-    if ((fillchar !== undefined) && (!checkStringish(self, fillchar) || fillchar.v.length !== 1)) {
-        throw new Sk.builtin.TypeError("must be " + self.__class__.$englishsingular + ", not " + Sk.abstr.typeName(fillchar));
-    }
-    if (fillchar === undefined) {
-        fillchar = " ";
-    } else {
-        fillchar = fillchar.v;
-    }
-    len = Sk.builtin.asnum$(len);
-    if (self.v.length >= len) {
-        return self;
-    } else {
-        newstr = Array.prototype.join.call({length: Math.floor(len - self.v.length) + 1}, fillchar);
-        return new self.__class__(newstr + self.v);
-    }
-
-});
-
-Sk.builtin.str.prototype["center"] = Sk.builtin.bytes.prototype["center"] = new Sk.builtin.func(function (self, len, fillchar) {
-    var newstr;
-    var newstr1;
-    Sk.builtin.pyCheckArgsLen("center", arguments.length, 2, 3);
-    if (!Sk.builtin.checkInt(len)) {
-        throw new Sk.builtin.TypeError("integer argument expected, got " + Sk.abstr.typeName(len));
-    }
-    if ((fillchar !== undefined) && (!checkStringish(self, fillchar) || fillchar.v.length !== 1)) {
-        throw new Sk.builtin.TypeError("must be " + self.__class__.$englishsingular + ", not " + Sk.abstr.typeName(fillchar));
-    }
-    if (fillchar === undefined) {
-        fillchar = " ";
-    } else {
-        fillchar = fillchar.v;
-    }
-    len = Sk.builtin.asnum$(len);
-    if (self.v.length >= len) {
-        return self;
-    } else {
-        newstr1 = Array.prototype.join.call({length: Math.floor((len - self.v.length) / 2) + 1}, fillchar);
-        newstr = newstr1 + self.v + newstr1;
-        if (newstr.length < len) {
-            newstr = newstr + fillchar;
+function mkJust(isRight, isCenter) {
+    return new Sk.builtin.func(function (self, len, fillchar) {
+        var newstr;
+        Sk.builtin.pyCheckArgsLen(isCenter ? "center" : isRight ? "rjust" : "ljust",
+                                    arguments.length, 2, 3);
+        if (!Sk.builtin.checkInt(len)) {
+            throw new Sk.builtin.TypeError("integer argument expected, got " + Sk.abstr.typeName(len));
         }
-        return new self.__class__(newstr);
-    }
+        if ((fillchar !== undefined) && (!checkStringish(self, fillchar) || fillchar.v.length !== 1 && fillchar.sq$length() !== 1)) {
+            throw new Sk.builtin.TypeError("must be " + self.__class__.$englishsingular + ", not " + Sk.abstr.typeName(fillchar));
+        }
+        if (fillchar === undefined) {
+            fillchar = " ";
+        } else {
+            fillchar = fillchar.v;
+        }
+        len = Sk.builtin.asnum$(len);
+        let mylen = self.sq$length();
+        if (mylen >= len) {
+            return self;
+        } else if (isCenter) {
+            newstr = fillchar.repeat(Math.floor((len - mylen)/2));
 
-});
+            newstr = newstr + self.v + newstr;
+
+            if ((len - mylen) % 2) {
+                newstr += fillchar;
+            }
+
+            return new self.__class__(newstr);
+
+        } else {
+            newstr = fillchar.repeat(len - mylen);
+            return new self.__class__(isRight ? (newstr + self.v) : (self.v + newstr));
+        }
+    });
+}
+
+Sk.builtin.str.prototype["ljust"] = Sk.builtin.bytes.prototype["ljust"] = mkJust(false);
+
+Sk.builtin.str.prototype["rjust"] = Sk.builtin.bytes.prototype["rjust"] = mkJust(true);
+
+Sk.builtin.str.prototype["center"] = Sk.builtin.bytes.prototype["center"] = mkJust(false, true);
 
 function mkFind(isReversed) {
     return new Sk.builtin.func(function (self, tgt, start, end) {
@@ -883,7 +859,7 @@ Sk.builtin.str.prototype["zfill"] = Sk.builtin.bytes.prototype["zfill"] = new Sk
 
     Sk.builtin.pyCheckArgsLen("zfill", arguments.length, 2, 2);
     if (! Sk.builtin.checkInt(len)) {
-        throw new Sk.builtin.TypeError("integer argument exepected, got " + Sk.abstr.typeName(len));
+        throw new Sk.builtin.TypeError("integer argument expected, got " + Sk.abstr.typeName(len));
     }
 
     // figure out how many zeroes are needed to make the proper length
@@ -926,7 +902,7 @@ Sk.builtin.str.prototype["expandtabs"] = Sk.builtin.bytes.prototype["expandtabs"
 
 
     if ((tabsize !== undefined) && ! Sk.builtin.checkInt(tabsize)) {
-        throw new Sk.builtin.TypeError("integer argument exepected, got " + Sk.abstr.typeName(tabsize));
+        throw new Sk.builtin.TypeError("integer argument expected, got " + Sk.abstr.typeName(tabsize));
     }
     if (tabsize === undefined) {
         tabsize = 8;

--- a/src/str.js
+++ b/src/str.js
@@ -1096,6 +1096,36 @@ Sk.builtin.bytes.prototype["decode"] = new Sk.builtin.func(function (self, encod
     return new Sk.builtin.str(v);
 });
 
+Sk.builtin.bytes.prototype["fromhex"] = new Sk.builtin.staticfunc(function(hex) {
+    Sk.builtin.pyCheckArgsLen("decode", arguments.length, 1, 3);
+    Sk.builtin.pyCheckType("hex", "string", Sk.builtin.checkString(hex));
+
+    let h = hex.v.replace(/\s*/g, "");
+    let v = "";
+
+    for (let i = 0; i < h.length; i += 2) {
+        let s = h.substr(i, 2)
+        let n = parseInt(s, 16);
+        if (isNaN(n) || s.length != 2 || !/^[abcdefABCDEF0123456789]{2}$/.test(s)) {
+            throw new Sk.builtin.ValueError("non-hexadecimal number found in fromhex() arg");
+        }
+        v += String.fromCharCode(n);
+    }
+
+    return new Sk.builtin.bytes(v);
+});
+
+Sk.builtin.bytes.prototype["hex"] = new Sk.builtin.func(function(self) {
+    // TODO Python 3.8 has added some args here
+    Sk.builtin.pyCheckArgsLen("hex", arguments.length, 1, 1);
+
+    let r = "";
+    for (let i=0; i < self.v.length; i++) {
+        r += ("0" + self.v.charCodeAt(i).toString(16)).substr(-2);
+    }
+    return new Sk.builtin.str(r);
+});
+
 Sk.builtin.str.prototype.nb$remainder = Sk.builtin.bytes.prototype.nb$remainder = function (rhs) {
     // % format op. rhs can be a value, a tuple, or something with __getitem__ (dict)
 

--- a/src/str.js
+++ b/src/str.js
@@ -221,15 +221,19 @@ Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript 
         }
     } else if (index instanceof Sk.builtin.slice) {
         ret = "";
-        index.sssiter$(this, function (i, wrt) {
-            if (wrt.$hasAstralCodePoints()) {
-                if (i >= 0 && i < wrt.codepoints.length) {
-                    ret += wrt.v.substring(wrt.codepoints[i], wrt.codepoints[i+1]);
+        if (this.$hasAstralCodePoints()) {
+            index.sssiter$(this.codepoints.length, (i, wrt) => {
+                if (i >= 0 && i < this.codepoints.length) {
+                    ret += this.v.substring(this.codepoints[i], this.codepoints[i+1]);
                 }
-            } else if (i >= 0 && i < wrt.v.length) {
-                ret += wrt.v.charAt(i);
-            }
-        });
+            });
+        } else {
+            index.sssiter$(this, function (i, wrt) {
+                if (i >= 0 && i < wrt.v.length) {
+                    ret += wrt.v.charAt(i);
+                }
+            });
+        };
         return new this.__class__(ret);
     } else {
         throw new Sk.builtin.TypeError(this.__class__.$englishname + " indices must be integers, not " + Sk.abstr.typeName(index));
@@ -1417,7 +1421,9 @@ Sk.builtin.str_iter_ = function (obj) {
                 return undefined;
             }
 
-            return new this.$cls(this.$obj.substring(this.$codepoints[this.$index], this.$codepoints[this.$index+1]));
+            let r = new this.$cls(this.$obj.substring(this.$codepoints[this.$index], this.$codepoints[this.$index+1]));
+            this.$index++;
+            return r;
         }
     } else {
         this.sq$length = this.$obj.length;

--- a/src/str.js
+++ b/src/str.js
@@ -67,7 +67,7 @@ Sk.builtin.bytes = function(source, encoding, errors) {
 
     for (let i=0; i < source.length; i++) {
         if (source.charCodeAt(i) > 0xff) {
-            throw new ValueError("bytes must be in range(0, 256)");
+            throw new Sk.builtin.ValueError("bytes must be in range(0, 256)");
         }
     }
 
@@ -78,7 +78,7 @@ Sk.builtin.bytes = function(source, encoding, errors) {
     } else {
         return new Sk.builtin.bytes(source);
     }
-}
+};
 Sk.exportSymbol("Sk.builtin.bytes", Sk.builtin.bytes);
 
 Sk.abstr.setUpInheritance("bytes", Sk.builtin.bytes, Sk.builtin.seqtype);
@@ -196,7 +196,7 @@ Sk.builtin.str.prototype.$hasAstralCodePoints = function() {
     }
     this.codepoints = null;
     return false;
-}
+};
 
 Sk.builtin.bytes.prototype.$hasAstralCodePoints = () => false;
 
@@ -656,7 +656,7 @@ Sk.builtin.str.prototype["count"] = Sk.builtin.bytes.prototype["count"] = new Sk
     normaltext = pat.v.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
     m = new RegExp(normaltext, "g");
     slice = self.v.slice(self.codepoints ? self.codepoints[start] : start,
-                            self.codepoints ? self.codepoints[end] : end);
+                         self.codepoints ? self.codepoints[end] : end);
     ctl = slice.match(m);
     if (!ctl) {
         return  new Sk.builtin.int_(0);
@@ -670,7 +670,7 @@ function mkJust(isRight, isCenter) {
     return new Sk.builtin.func(function (self, len, fillchar) {
         var newstr;
         Sk.builtin.pyCheckArgsLen(isCenter ? "center" : isRight ? "rjust" : "ljust",
-                                    arguments.length, 2, 3);
+                                  arguments.length, 2, 3);
         if (!Sk.builtin.checkInt(len)) {
             throw new Sk.builtin.TypeError("integer argument expected, got " + Sk.abstr.typeName(len));
         }
@@ -1104,7 +1104,7 @@ Sk.builtin.bytes.prototype["fromhex"] = new Sk.builtin.staticfunc(function(hex) 
     let v = "";
 
     for (let i = 0; i < h.length; i += 2) {
-        let s = h.substr(i, 2)
+        let s = h.substr(i, 2);
         let n = parseInt(s, 16);
         if (isNaN(n) || s.length != 2 || !/^[abcdefABCDEF0123456789]{2}$/.test(s)) {
             throw new Sk.builtin.ValueError("non-hexadecimal number found in fromhex() arg");
@@ -1430,7 +1430,7 @@ Sk.builtin.str_iter_ = function (obj) {
             let r = new this.$cls(this.$obj.substring(this.$codepoints[this.$index], this.$codepoints[this.$index+1]));
             this.$index++;
             return r;
-        }
+        };
     } else {
         this.sq$length = this.$obj.length;
         this.tp$iternext = function () {
@@ -1438,7 +1438,7 @@ Sk.builtin.str_iter_ = function (obj) {
                 return undefined;
             }
             return new Sk.builtin.str(this.$obj.substr(this.$index++, 1));
-        }
+        };
     }
     this.$r = function () {
         return new Sk.builtin.str("iterator");

--- a/src/str.js
+++ b/src/str.js
@@ -285,6 +285,7 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
     // single is preferred
     var ashex;
     var c;
+    var cc;
     var i;
     var ret;
     var len;
@@ -298,6 +299,7 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
     ret = (this.__class__ === Sk.builtin.bytes) ? "b" + quote : quote;
     for (i = 0; i < len; ++i) {
         c = this.v.charAt(i);
+        cc = this.v.charCodeAt(i);
         if (c === quote || c === "\\") {
             ret += "\\" + c;
         } else if (c === "\t") {
@@ -306,10 +308,10 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
             ret += "\\n";
         } else if (c === "\r") {
             ret += "\\r";
-        } else if (c > 0xff && c < 0xd800 || c >= 0xe000) {
+        } else if (cc > 0xff && cc < 0xd800 || cc >= 0xe000) {
             // BMP
-            ret += "\\u" + ("000"+this.v.charCodeAt(i).toString(16)).slice(-4);
-        } else if (c >= 0xd800) {
+            ret += "\\u" + ("000"+cc.toString(16)).slice(-4);
+        } else if (cc >= 0xd800) {
             // Surrogate pair stuff
             let val = this.v.codePointAt(i);
             i++;
@@ -321,10 +323,10 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
             } else {
                 ret += "\\u" + s.slice(-4);
             }
-        } else if (c > 0xff) {
+        } else if (cc > 0xff) {
             // Invalid!
             ret += "\\ufffd";
-        } else if (c < " " || c >= 0x7f) {
+        } else if (c < " " || cc >= 0x7f) {
             ashex = c.charCodeAt(0).toString(16);
             if (ashex.length < 2) {
                 ashex = "0" + ashex;
@@ -1028,7 +1030,7 @@ Sk.builtin.str.prototype["encode"] = new Sk.builtin.func(function (self, encodin
 
     let v;
     try {
-        v = unescape(encodeUriComponent(self.v));
+        v = unescape(encodeURIComponent(self.v));
     } catch (e) {
         throw new Sk.builtin.UnicodeEncodeError("UTF-8 encoding failed");
     }
@@ -1051,7 +1053,7 @@ Sk.builtin.bytes.prototype["decode"] = new Sk.builtin.func(function (self, encod
 
     let v;
     try {
-        v = decodeUriComponent(escape(self.v));
+        v = decodeURIComponent(escape(self.v));
     } catch (e) {
         throw new Sk.builtin.UnicodeEncodeError("UTF-8 decoding failed");
     }

--- a/src/str.js
+++ b/src/str.js
@@ -412,10 +412,10 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
             ret += "\\n";
         } else if (c === "\r") {
             ret += "\\r";
-        } else if (cc > 0xff && cc < 0xd800 || cc >= 0xe000) {
+        } else if ((cc > 0xff && cc < 0xd800 || cc >= 0xe000) && !Sk.__future__.python3) {
             // BMP
             ret += "\\u" + ("000"+cc.toString(16)).slice(-4);
-        } else if (cc >= 0xd800) {
+        } else if (cc >= 0xd800 && !Sk.__future__.python3) {
             // Surrogate pair stuff
             let val = this.v.codePointAt(i);
             i++;
@@ -427,10 +427,10 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
             } else {
                 ret += "\\u" + s.slice(-4);
             }
-        } else if (cc > 0xff) {
+        } else if (cc > 0xff && !Sk.__future__.python3) {
             // Invalid!
             ret += "\\ufffd";
-        } else if (c < " " || cc >= 0x7f) {
+        } else if (c < " " || cc >= 0x7f && !Sk.__future__.python3) {
             ashex = c.charCodeAt(0).toString(16);
             if (ashex.length < 2) {
                 ashex = "0" + ashex;

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -744,6 +744,7 @@ SymbolTable.prototype.visitExpr = function (e) {
             break;
         case Sk.astnodes.Num:
         case Sk.astnodes.Str:
+        case Sk.astnodes.Bytes:
             break;
         case Sk.astnodes.JoinedStr:
             for (let s of e.values) {

--- a/test/unit/test_unicode.py
+++ b/test/unit/test_unicode.py
@@ -9,5 +9,31 @@ class TestUnicode(unittest.TestCase):
         unicode_string = u"这是\n这这这"
         self.assertIn(u"是", unicode_string)
 
+    def test_encoding(self):
+        # Unicode snowman: BMP emoji
+        self.assertEqual(u'\u2603'.encode(), '\xe2\x98\x83')
+        self.assertEqual('\xe2\x98\x83'.decode(), u'\u2603')
+
+        self.assertEqual(ord(u'\u2603'), 0x2603) 
+        self.assertRaises(ValueError, chr, 0x2603)
+        self.assertEqual(unichr(0x2603), u'\u2603') 
+
+        # String repr in Python 2 is ascii
+        self.assertEqual(repr(u'\x01\xf0\u2603'), "'\\x01\\xf0\\u2603'")
+        # ...and there is no explicit ascii() function
+        self.assertRaises(NameError, lambda: ascii('hi there'))
+
+        # Piece of pizza: Astral emoji
+        self.assertEqual(u'\U0001f355'.encode(), b'\xf0\x9f\x8d\x95')
+        self.assertEqual('\xf0\x9f\x8d\x95'.decode(), u'\U0001f355')
+
+        # Python 2 silently accepts b'' strings
+        self.assertEqual(b'hello world', 'hello world')
+        self.assertEqual(type(b'hello world'), str)
+
+        # We do not distinguish between str and unicode in Skulpt
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_fstring.py
+++ b/test/unit3/test_fstring.py
@@ -611,20 +611,19 @@ class TestCase(unittest.TestCase):
         self.assertEqual(f'{2}\t{3}', '2\t3')
         self.assertEqual(f'\t{3}', '\t3')
 
-        # Skulpt TODO: These will work after PR#983 (real unicode strings) lands
-        # self.assertEqual(f'\u0394', '\u0394')
-        # self.assertEqual(r'\u0394', '\\u0394')
-        # self.assertEqual(rf'\u0394', '\\u0394')
-        # self.assertEqual(f'{2}\u0394', '2\u0394')
-        # self.assertEqual(f'{2}\u0394{3}', '2\u03943')
-        # self.assertEqual(f'\u0394{3}', '\u03943')
+        self.assertEqual(f'\u0394', '\u0394')
+        self.assertEqual(r'\u0394', '\\u0394')
+        self.assertEqual(rf'\u0394', '\\u0394')
+        self.assertEqual(f'{2}\u0394', '2\u0394')
+        self.assertEqual(f'{2}\u0394{3}', '2\u03943')
+        self.assertEqual(f'\u0394{3}', '\u03943')
 
-        # self.assertEqual(f'\U00000394', '\u0394')
-        # self.assertEqual(r'\U00000394', '\\U00000394')
-        # self.assertEqual(rf'\U00000394', '\\U00000394')
-        # self.assertEqual(f'{2}\U00000394', '2\u0394')
-        # self.assertEqual(f'{2}\U00000394{3}', '2\u03943')
-        # self.assertEqual(f'\U00000394{3}', '\u03943')
+        self.assertEqual(f'\U00000394', '\u0394')
+        self.assertEqual(r'\U00000394', '\\U00000394')
+        self.assertEqual(rf'\U00000394', '\\U00000394')
+        self.assertEqual(f'{2}\U00000394', '2\u0394')
+        self.assertEqual(f'{2}\U00000394{3}', '2\u03943')
+        self.assertEqual(f'\U00000394{3}', '\u03943')
 
         # Skulpt doesn't support \N{} escapes, because we don't bundle the
         # Unicode database

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -193,6 +193,27 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual(b'x' + b'y', b'xy')
         self.assertRaises(TypeError, lambda: b'x' + 'y')
 
+        # Repeat
+        self.assertEqual(b'x'*3, b'xxx')
+
+        # Search
+        self.assertTrue(b'y' in b'xyz')
+        self.assertFalse(b'a' in b'xyz')
+        self.assertEqual(b'abc'.find(b'b'), 1)
+        self.assertEqual(b'abc'.find(b'z'), -1)
+        self.assertRaises(TypeError, lambda: 'y' in b'xyz')
+        self.assertRaises(TypeError, lambda: b'xyz'.find('y'))
+        self.assertRaises(TypeError, lambda: b'y' in 'xyz')
+        self.assertRaises(TypeError, lambda: 'xyz'.find(b'y'))
+
+        # Index and slice
+        self.assertEqual(b'xyz'[2], b'z')
+        self.assertEqual(b'xyz'[-1], b'z')
+        self.assertEqual(b'xyz'[:2], b'xy')
+
+        # To and from hex
+        self.assertEqual(bytes.fromhex('2Ef0 F1f2 '), b'.\xf0\xf1\xf2')
+        self.assertEqual(b'\xf0\xf1\xf2'.hex(), 'f0f1f2')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -129,8 +129,11 @@ class StringMethodsTests(unittest.TestCase):
 
         self.assertEqual(list('Love \U0001f355!'), ['L', 'o', 'v', 'e', ' ', '\U0001f355', '!'])
 
+        # Lookups and slices happen in Python (ie codepoint) coordinates
         self.assertEqual('Love \U0001f355!'[6], '!')
         self.assertEqual('Love \U0001f355!'[5], '\U0001f355')
+        self.assertEqual('Love \U0001f355!'[-2], '\U0001f355')
+
         self.assertEqual('Love \U0001f355!'[4:6], ' \U0001f355')
         self.assertEqual('Love \U0001f355!'[:6], 'Love \U0001f355')
         self.assertEqual('Love \U0001f355!'[4:], ' \U0001f355!')
@@ -139,10 +142,18 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('abc\U0001f355def'[-2::-2], 'e\U0001f355b')
         self.assertEqual('abc\U0001f355def'[-1::-2], 'fdca')
 
+        # find() happens in codepoint coordinates
         self.assertEqual('Love \U0001f355!'.find('!'), 6)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', 0, 6), 5)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -1), 5)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -2), -1)
+
+        # count() too
+        self.assertEqual('Love \U0001f355!'.count('\U0001f355', -2), 1)
+        self.assertEqual('Love \U0001f355!'.count('\U0001f355', -1), 0)
+
+        # ljust() (same impl as rjust())
+        self.assertEqual('Love \U0001f355!'.ljust(10, '\U0001f355'), 'Love \U0001f355!\U0001f355\U0001f355\U0001f355')
 
     def test_bytes(self):
         # Bytes are not strings
@@ -177,6 +188,10 @@ class StringMethodsTests(unittest.TestCase):
         class D:
             pass
         self.assertRaises(TypeError, lambda: bytes(D()))
+
+        # Concatenate
+        self.assertEqual(b'x' + b'y', b'xy')
+        self.assertRaises(TypeError, lambda: b'x' + 'y')
 
 
 if __name__ == '__main__':

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -164,7 +164,11 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual(bytes('hello', 'utf-8'), b'hello')
         self.assertEqual(bytes('Love \U0001f355!', 'utf-8'), b'Love \xf0\x9f\x8d\x95!')
 
-        # Construct from bytestrings
+        # Construct string from bytestring
+        self.assertEqual(str(b'\xf0\x9f\x8d\x95'), '\U0001f355')
+        self.assertEqual(str(b'\xf0\x9f\x8d\x95', "utf-8"), '\U0001f355')
+
+        # Construct bytestring from bytestring
         self.assertEqual(bytes(b'hello'), b'hello')
 
         # Construct empty bytestrings
@@ -199,6 +203,9 @@ class StringMethodsTests(unittest.TestCase):
         # Search
         self.assertTrue(b'y' in b'xyz')
         self.assertFalse(b'a' in b'xyz')
+        self.assertTrue(120 in b'xyz')
+        self.assertFalse(119 in b'xyz')
+        self.assertRaises(ValueError, lambda: 1000 in b'xyz')
         self.assertEqual(b'abc'.find(b'b'), 1)
         self.assertEqual(b'abc'.find(b'z'), -1)
         self.assertRaises(TypeError, lambda: 'y' in b'xyz')
@@ -207,9 +214,12 @@ class StringMethodsTests(unittest.TestCase):
         self.assertRaises(TypeError, lambda: 'xyz'.find(b'y'))
 
         # Index and slice
-        self.assertEqual(b'xyz'[2], b'z')
-        self.assertEqual(b'xyz'[-1], b'z')
+        self.assertEqual(b'xyz'[2], 122)
+        self.assertEqual(b'xyz'[-1], 122)
         self.assertEqual(b'xyz'[:2], b'xy')
+
+        # Iterate
+        self.assertEqual(list(b'xyz'), [120, 121, 122])
 
         # To and from hex
         self.assertEqual(bytes.fromhex('2Ef0 F1f2 '), b'.\xf0\xf1\xf2')

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -107,6 +107,9 @@ class StringMethodsTests(unittest.TestCase):
 
         # Unicode doesn't get escaped in repr(), but escape chars still do
         self.assertEqual(repr('\x01\xf0\u2603'), "'\\x01\xf0\u2603'")
+        # ...but it *does* get escaped in ascii()
+        self.assertEqual(ascii('hi there'), "'hi there'")
+        self.assertEqual(ascii('x\x01\xf0\u2603\U0001f355'), "'x\\x01\\xf0\\u2603\\U0001f355'")
 
         # Indexing: It's a single character
         self.assertEqual(len('Build a \u2603!'), 10)

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -131,6 +131,40 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -1), 5)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -2), -1)
 
+    def test_bytes(self):
+        # Bytes are not strings
+        self.assertNotEqual(b'hello', 'hello')
+
+        # Construct from string
+        self.assertRaises(TypeError, lambda: bytes('hello'))
+        self.assertEqual(bytes('hello', 'utf-8'), b'hello')
+        self.assertEqual(bytes('Love \U0001f355!', 'utf-8'), b'Love \xf0\x9f\x8d\x95!')
+
+        # Construct from bytestrings
+        self.assertEqual(bytes(b'hello'), b'hello')
+
+        # Construct empty bytestrings
+        self.assertEqual(bytes(4), b'\x00\x00\x00\x00')
+
+        # Construct from object with __bytes__
+        class C:
+            def __bytes__(self):
+                return b'hello'
+
+            def __iter__(self):
+                # Gets pre-empted by __bytes__
+                return iter([1,2,3,4])
+        self.assertEqual(bytes(C()), b'hello')
+
+        # Construct from iterables
+        self.assertEqual(bytes([0xf0, 0x9f, 0x8d, 0x95]).decode(), '\U0001f355')
+        self.assertRaises(ValueError, lambda: bytes([0x100]))
+
+        # or give up
+        class D:
+            pass
+        self.assertRaises(TypeError, lambda: bytes(D()))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -105,6 +105,9 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual(ord('\u2603'), 0x2603)
         self.assertEqual(chr(0x2603), '\u2603')
 
+        # Unicode doesn't get escaped in repr(), but escape chars still do
+        self.assertEqual(repr('\x01\xf0\u2603'), "'\\x01\xf0\u2603'")
+
         # Indexing: It's a single character
         self.assertEqual(len('Build a \u2603!'), 10)
         self.assertEqual('Build a \u2603!'[9], '!')

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -110,6 +110,9 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('Build a \u2603!'[:9], 'Build a \u2603')
         self.assertEqual('Build a \u2603!'[6:], 'a \u2603!')
 
+        self.assertEqual('Build a \u2603!'.find('!'), 9)
+        self.assertEqual('Build a \u2603!'.find('\u2603'), 8)
+
         # Piece of pizza: Astral emoji
         self.assertEqual('\U0001f355'.encode(), b'\xf0\x9f\x8d\x95')
         self.assertEqual(b'\xf0\x9f\x8d\x95'.decode(), '\U0001f355')
@@ -122,6 +125,11 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('Love \U0001f355!'[4:6], ' \U0001f355')
         self.assertEqual('Love \U0001f355!'[:6], 'Love \U0001f355')
         self.assertEqual('Love \U0001f355!'[4:], ' \U0001f355!')
+
+        self.assertEqual('Love \U0001f355!'.find('!'), 6)
+        self.assertEqual('Love \U0001f355!'.find('\U0001f355', 0, 6), 5)
+        self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -1), 5)
+        self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -2), -1)
 
 
 if __name__ == '__main__':

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -96,6 +96,34 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual("%g" % (.00012), "0.00012")
         self.assertEqual("%d %i %o %x %X %e %E" % (12,-12,-0O7,0x4a,-0x4a,2.3e10,2.3E-10), "12 -12 -7 4a -4A 2.300000e+10 2.300000E-10")
         self.assertEqual("%g %G %g %G" % (.00000123,.00000123,1.4,-1.4), "1.23e-06 1.23E-06 1.4 -1.4")
+
+    def test_encoding(self):
+        # Unicode snowman: BMP emoji
+        self.assertEqual('\u2603'.encode(), b'\xe2\x98\x83')
+        self.assertEqual(b'\xe2\x98\x83'.decode(), '\u2603')
+
+        # Indexing: It's a single character
+        self.assertEqual(len('Build a \u2603!'), 10)
+        self.assertEqual('Build a \u2603!'[9], '!')
+        self.assertEqual('Build a \u2603!'[8], '\u2603')
+        self.assertEqual('Build a \u2603!'[6:9], 'a \u2603')
+        self.assertEqual('Build a \u2603!'[:9], 'Build a \u2603')
+        self.assertEqual('Build a \u2603!'[6:], 'a \u2603!')
+
+        # Piece of pizza: Astral emoji
+        self.assertEqual('\U0001f355'.encode(), b'\xf0\x9f\x8d\x95')
+        self.assertEqual(b'\xf0\x9f\x8d\x95'.decode(), '\U0001f355')
+
+        # It's *still* a single character, even though it's a surrogate
+        # pair in JS
+        self.assertEqual(len('Love \U0001f355!'), 7)
+        self.assertEqual('Love \U0001f355!'[6], '!')
+        self.assertEqual('Love \U0001f355!'[5], '\U0001f355')
+        self.assertEqual('Love \U0001f355!'[4:6], ' \U0001f355')
+        self.assertEqual('Love \U0001f355!'[:6], 'Love \U0001f355')
+        self.assertEqual('Love \U0001f355!'[4:], ' \U0001f355!')
+
+
 if __name__ == '__main__':
     unittest.main()
             

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -102,6 +102,9 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('\u2603'.encode(), b'\xe2\x98\x83')
         self.assertEqual(b'\xe2\x98\x83'.decode(), '\u2603')
 
+        self.assertEqual(ord('\u2603'), 0x2603)
+        self.assertEqual(chr(0x2603), '\u2603')
+
         # Indexing: It's a single character
         self.assertEqual(len('Build a \u2603!'), 10)
         self.assertEqual('Build a \u2603!'[9], '!')
@@ -117,14 +120,24 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('\U0001f355'.encode(), b'\xf0\x9f\x8d\x95')
         self.assertEqual(b'\xf0\x9f\x8d\x95'.decode(), '\U0001f355')
 
+        self.assertEqual(ord('\U0001f355'), 0x1f355)
+        self.assertEqual(chr(0x1f355), '\U0001f355')
+
         # It's *still* a single character, even though it's a surrogate
         # pair in JS
         self.assertEqual(len('Love \U0001f355!'), 7)
+
+        self.assertEqual(list('Love \U0001f355!'), ['L', 'o', 'v', 'e', ' ', '\U0001f355', '!'])
+
         self.assertEqual('Love \U0001f355!'[6], '!')
         self.assertEqual('Love \U0001f355!'[5], '\U0001f355')
         self.assertEqual('Love \U0001f355!'[4:6], ' \U0001f355')
         self.assertEqual('Love \U0001f355!'[:6], 'Love \U0001f355')
         self.assertEqual('Love \U0001f355!'[4:], ' \U0001f355!')
+
+        self.assertEqual('Love \U0001f355!'[-2:], '\U0001f355!')
+        self.assertEqual('abc\U0001f355def'[-2::-2], 'e\U0001f355b')
+        self.assertEqual('abc\U0001f355def'[-1::-2], 'fdca')
 
         self.assertEqual('Love \U0001f355!'.find('!'), 6)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', 0, 6), 5)


### PR DESCRIPTION
Guido's original reason for moving to Python 3 was so that `str` could be sensible and Unicode-y. This PR makes Skulpt Unicode-aware, and provides the Python 3 `str`/`bytes` interface.

How this change works:

* Skulpt strings are still stored as Javascript strings (which means UTF-16, bletch, but that's the format expected by everything else we touch). Python source code is a Javascript string. No UTF-8 anywhere. (Except if the user calls `encode()` -- but that's a `bytes`, not a `str`.)

* `bytes` is a JS "byte-string" -- a JS string using only chars 0-255. This keeps them very similar to `str`s, which means we can share most of the implementation :)

* `str` is now indexed/sliced/etc by codepoints, not JS string indices. These are _usually_ the same thing, but if you have an astral character they diverge. Eg the string `'\U0001f355!'` ("🍕!") is 2 codepoints long but 3 JS chars long (because the pizza emoji is represented by a surrogate pair). If you're manipulating that string in Python, `s[1]` needs to be `'!'`, not the second half of a surrogate pair.

  Working out which codepoint index corresponds to which JS string index is slow (you have to grovel over the whole string looking for surrogate pairs), so we only compute it if necessary. The first time we do anything that needs to know how many codepoints are in a string, or where they are, the `$hasAstralCodePoints()` method searches for astral characters. _If_ this string has any, we compute an array of codepoints and their position in the string. Once computed, we use this array for all length calculations, slicing, iteration, etc.

  Example: For the string `"🍕!"`, the `codepoints` array is `[0, 2]` (the first codepoint starts at string index 0 and is 2 JS-chars long, and the second codepoint starts at string index 2).

* We explicitly _do not_ make much effort to support Python 2 unicode semantics. `unicode` is an alias for `str`, and all of Python 2's implicit encoding/decoding basically doesn't happen. The goal, as for all our Python 2 support, is "no more broken than we already were".

* I've cleared up some encoding confusion in the parser (Kill UTF-8 with fire! All input data is JS strings! Also, the `\uXXXX`/`\UXXXXXXXX` escape codes now work.)

I would particularly like input from our international users (hi @Dustyposa - This should fix #871 for you!). This should improve things significantly for you!

----

**Note:** This change is built on top of my F-strings branch (#975), because they both touch the string parsing code.