### PR TITLE
Refactor string formatting

### DIFF
--- a/repl/repl.js
+++ b/repl/repl.js
@@ -41,7 +41,11 @@ var compilableLines = [],
     lines = [],
     origLines;
 
-console.log("Python 2.6(ish) (skulpt, " + new Date() + ")");
+if (Sk.__future__.python3) {
+    console.log("Python 3.7(ish) (skulpt, " + new Date() + ")");
+} else {
+    console.log("Python 2.7(ish) (skulpt, " + new Date() + ")");
+}
 console.log("[node: " + process.version + "] on a system");
 console.log('Don\'t type "help", "copyright", "credits" or "license" unless you\'ve assigned something to them');
 

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -711,7 +711,7 @@ Sk.abstr.objectFormat = function (obj, format_spec) {
     // Find the (unbound!) __format__ method (a borrowed reference)
     meth = Sk.abstr.lookupSpecial(obj, Sk.builtin.str.$format);
     if (meth == null) {
-        throw new Sk.builtin.TypeError("Type " + Sk.abstr.typeName(obj) + " doesn't define __format__");
+        return Sk.misceval.callsimArray(Sk.builtin.object.prototype["__format__"], [obj, format_spec]);
     }
 
     // And call it

--- a/src/ast.js
+++ b/src/ast.js
@@ -2598,7 +2598,7 @@ function fstring_parse(str, start, end, raw, recurse_lvl, c, n) {
         else if (bidx+1 < end && str.charAt(bidx+1) === "{") {
             // Swallow the double {{
             addLiteral(str.substring(idx, bidx+1));
-            idx = bidx + 1;
+            idx = bidx + 2;
             continue;
         }
         else {

--- a/src/ast.js
+++ b/src/ast.js
@@ -2382,7 +2382,7 @@ function fstring_compile_expr(str, expr_start, expr_end, c, n) {
        here, and not when we call PyParser_SimpleParseStringFlagsFilename,
        because turning the expression '' in to '()' would go from being invalid
        to valid. */
-    if (/^\s+$/.test(s)) {
+    if (/^\s*$/.test(s)) {
         ast_error(c, n, "f-string: empty expression not allowed");
     }
     s = "(" + s + ")";

--- a/src/ast.js
+++ b/src/ast.js
@@ -2239,7 +2239,7 @@ function astForIfexpr (c, n) {
 
 /**
  * s is a python-style string literal, including quote characters and u/r/b
- * prefixes. Returns decoded string object.
+ * prefixes. Returns [decoded string object, is-an-fstring]
  */
 function parsestr (c, s) {
     var encodeUtf8 = function (s) {
@@ -2324,6 +2324,7 @@ function parsestr (c, s) {
     var quote = s.charAt(0);
     var rawmode = false;
     var unicode = false;
+    var fmode = false;
 
     // treats every sequence as unicodes even if they are not treated with uU prefix
     // kinda hacking though working for most purposes
@@ -2331,17 +2332,27 @@ function parsestr (c, s) {
         unicode = true;
     }
 
-    if (quote === "u" || quote === "U") {
+    let seenflags = {};
+
+    while(true) {
+        if (quote === "u" || quote === "U") {
+            unicode = true;
+        }
+        else if (quote === "r" || quote === "R") {
+            rawmode = true;
+        }
+        else if (quote === "b" || quote === "B") {
+            Sk.asserts.assert(!"todo; haven't done b'' strings yet")
+        }
+        else if (quote === "f" || quote === "F") {
+            fmode = true;
+        }
+        else {
+            break;
+        }
         s = s.substr(1);
         quote = s.charAt(0);
-        unicode = true;
     }
-    else if (quote === "r" || quote === "R") {
-        s = s.substr(1);
-        quote = s.charAt(0);
-        rawmode = true;
-    }
-    Sk.asserts.assert(quote !== "b" && quote !== "B", "todo; haven't done b'' strings yet");
 
     Sk.asserts.assert(quote === "'" || quote === '"' && s.charAt(s.length - 1) === quote);
     s = s.substr(1, s.length - 2);
@@ -2355,22 +2366,242 @@ function parsestr (c, s) {
     }
 
     if (rawmode || s.indexOf("\\") === -1) {
-        return strobj(decodeUtf8(s));
+        return [strobj(decodeUtf8(s)), fmode];
     }
-    return strobj(decodeEscape(s, quote));
+    return [strobj(decodeEscape(s, quote)), fmode];
+}
+
+function fstring_find_expr(parsedstr, startIdx, c, n) {
+    let i = startIdx;
+    Sk.asserts.assert(str.charAt(i) == "{");
+    i++;
+    /* null if we're not in a string, else the quote char we're trying to
+       match (single or double quote). */
+    let quote_char = null;
+    /* If we're inside a string, 1=normal, 3=triple-quoted. */
+    let string_type = 0;
+    /* Keep track of nesting level for braces/parens/brackets in
+       expressions. */
+    let nested_depth = 0;
+    let end = parsedstr.length;
+
+    let format_spec, conversion;
+
+    for (; i != end; i++) {
+        let ch = parsedstr.charAt(i);
+
+        /* Nowhere inside an expression is a backslash allowed. */
+        if (ch == '\\') {
+            /* Error: can't include a backslash character, inside
+               parens or strings or not. */
+            ast_error(c, n, "f-string expression part "
+                            "cannot include a backslash");
+        }
+        if (quote_char) {
+            /* We're inside a string. See if we're at the end. */
+            /* This code needs to implement the same non-error logic
+               as tok_get from tokenizer.c, at the letter_quote
+               label. To actually share that code would be a
+               nightmare. But, it's unlikely to change and is small,
+               so duplicate it here. Note we don't need to catch all
+               of the errors, since they'll be caught when parsing the
+               expression. We just need to match the non-error
+               cases. Thus we can ignore \n in single-quoted strings,
+               for example. Or non-terminated strings. */
+            if (ch == quote_char) {
+                /* Does this match the string_type (single or triple
+                   quoted)? */
+                if (string_type == 3) {
+                    if (i+2 < end && parsedstr.charAt(i+1) == ch && parsedstr.charAt(i+2) == ch) {
+                        /* We're at the end of a triple quoted string. */
+                        i += 2;
+                        string_type = 0;
+                        quote_char = 0;
+                        continue;
+                    }
+                } else {
+                    /* We're at the end of a normal string. */
+                    quote_char = 0;
+                    string_type = 0;
+                    continue;
+                }
+            }
+        } else if (ch == '\'' || ch == '"') {
+            /* Is this a triple quoted string? */
+            if (i+2 < end && parsedstr.charAt(i+1) == ch && parsedstr.charAt(i+2) == ch) {
+                string_type = 3;
+                i += 2;
+            } else {
+                /* Start of a normal string. */
+                string_type = 1;
+            }
+            /* Start looking for the end of the string. */
+            quote_char = ch;
+        } else if (ch == '[' || ch == '{' || ch == '(') {
+            nested_depth++;
+        } else if (nested_depth != 0 &&
+                   (ch == ']' || ch == '}' || ch == ')')) {
+            nested_depth--;
+        } else if (ch == '#') {
+            /* Error: can't include a comment character, inside parens
+               or not. */
+            ast_error(c, n, "f-string expression part cannot include '#'");
+        } else if (nested_depth == 0 &&
+                   (ch == '!' || ch == ':' || ch == '}')) {
+            /* First, test for the special case of "!=". Since '=' is
+               not an allowed conversion character, nothing is lost in
+               this test. */
+            if (ch == '!' && i+1 < end && parsedstr.charAt(i+1) == '=') {
+                /* This isn't a conversion character, just continue. */
+                continue;
+            }
+            /* Normal way out of this loop. */
+            break;
+        } else {
+            /* Just consume this char and loop around. */
+        }
+    }
+
+    /* If we leave this loop in a string or with mismatched parens, we
+       don't care. We'll get a syntax error when compiling the
+       expression. But, we can produce a better error message, so
+       let's just do that.*/
+    if (quote_char) {
+        ast_error(c, n, "f-string: unterminated string");
+    }
+    if (nested_depth) {
+        ast_error(c, n, "f-string: mismatched '(', '{', or '['");
+    }
+
+    /* Compile the expression as soon as possible, so we show errors
+       related to the expression before errors related to the
+       conversion or format_spec. */
+    let simple_expression = fstring_compile_expr(parsedstr, expr_start, expr_end, c, n);
+ 
+    /* Check for a conversion char, if present. */
+    if (parsedstr.charAt(i) == '!') {
+        i++;
+        if (i >= end)
+            goto unexpected_end_of_string;
+
+        conversion = parsedstr.charAt(i);
+        i++;
+
+        /* Validate the conversion. */
+        if (!(conversion == 's' || conversion == 'r'
+              || conversion == 'a')) {
+            ast_error(c, n, "f-string: invalid conversion character: "
+                            "expected 's', 'r', or 'a'");
+        }
+    }
+
+    /* Check for the format spec, if present. */
+    if (i >= end)
+        goto unexpected_end_of_string;
+    if (parsedstr.charAt(i) == ':') {
+        i++
+        if (i >= end)
+            goto unexpected_end_of_string;
+
+        /* Parse the format spec. */
+        format_spec = fstring_parse(str, end, raw, recurse_lvl+1, c, n);
+        if (!format_spec)
+            return -1;
+    }
+
+    if (i >= end || parsedstr.charAt(i) != '}')
+        goto unexpected_end_of_string;
+
+    /* We're at a right brace. Consume it. */
+    i++;
+
+    /* And now create the FormattedValue node that represents this
+       entire expression with the conversion and format spec. */
+    let expr = new Sk.astnodes.FormattedValue(simple_expression, conversion,
+                                              format_spec, LINENO(n), n.n_col_offset);
+
+    return [expr, i];
+
+unexpected_end_of_string:
+    ast_error(c, n, "f-string: expecting '}'");
+}
+
+function parsefstring(c, n, parsedstr) {
+    let values = [];
+    let idx = 0;
+
+    let addLiteral = (literal) => {
+        if (literal.indexOf("}") !== -1) {
+            // We need to error out on any lone }s, and
+            // replace doubles with singles.
+            if (/(^|[^}])}(}})*($|[^}])/.test(literal)) {
+                throw new SyntaxError("f-string: single '}' is not allowed", LINENO(n), n.col_offset);
+            }
+            literal = literal.replace(/}}/g, "}");
+        }
+        values.push(Sk.astnodes.Str(literal, LINENO(n), n.col_offset, c.end_lineno, n.end_col_offset));
+    };
+
+    
+    while (idx < parsedstr.length) {
+        let bidx = parsedstr.indexOf("{", idx);
+        if (bidx === -1) {
+            addLiteral(parsedstr.substring(idx));
+            break;
+        }
+        else if (bidx+1 < parsedstr.length && parsedstr.charAt(bidx+1) === "{") {
+            // Swallow the double {{
+            addLiteral(parsedstr.substring(idx, bidx+1));
+            idx = bidx + 1;
+            continue;
+        }
+        else {
+            addLiteral(parsedstr.substring(idx, bidx));
+            idx = bidx;
+
+            // And now parse the f-string expression itself
+            let expr, endIdx = fstring_find_expr(parsedstr, bidx, c, n);
+            values.push(expr);
+            idx = endIdx;
+        }
+    }
+    return values;
 }
 
 function parsestrplus (c, n) {
+    let strs = [];
+
+    for (i = 0; i < NCH(n); ++i) {
+        let chstr = CHILD(n, i).value;
+        let parsedstr, fmode;
+        try {
+            parsedstr, fmode = parsestr(c, chstr);
+        } catch (x) {
+            console.log(x)
+            throw new Sk.builtin.SyntaxError("invalid string (possibly contains a unicode character)", c.c_filename, CHILD(n, i).lineno);
+        }
+        if (fmode) {
+            strs.push.apply(strs, parsefstring(c, CHILD(n, i), parsedstr))
+        }
+    }
+
+    if (strs.length === 1 && strs[0].constructor === Sk.astnodes.Str) {
+        return strs[0];
+    } else {
+        return new Sk.astnodes.JoinedStr(strs, LINENO(n), n.col_offset, c.end_lineno, n.end_col_offset);
+    }
+    //;;;
+    return new Sk.astnodes.Str(str, LINENO(n), n.col_offset, c.end_lineno, n.end_col_offset);
+
+
     var i;
     var ret;
     REQ(CHILD(n, 0), TOK.T_STRING);
     ret = new Sk.builtin.str("");
     for (i = 0; i < NCH(n); ++i) {
-        try {
-            ret = ret.sq$concat(parsestr(c, CHILD(n, i).value));
-        } catch (x) {
-            throw new Sk.builtin.SyntaxError("invalid string (possibly contains a unicode character)", c.c_filename, CHILD(n, i).lineno);
-        }
+        let parse, fmode;
+
+        ret = ret.sq$concat(parse);
     }
     return ret;
 }
@@ -2535,34 +2766,8 @@ function ast_for_atom(c, n)
             return new Sk.astnodes.Name(name, Sk.astnodes.Load, LINENO(n), n.col_offset,
                         n.end_lineno, n.end_col_offset);
         }
-        case TOK.T_STRING: {
-            var str = parsestrplus(c, n);
-            // if (!str) {
-            //     const char *errtype = NULL;
-            //     if (PyErr_ExceptionMatches(PyExc_UnicodeError))
-            //         errtype = "unicode error";
-            //     else if (PyErr_ExceptionMatches(PyExc_ValueError))
-            //         errtype = "value error";
-            //     if (errtype) {
-            //         PyObject *type, *value, *tback, *errstr;
-            //         PyErr_Fetch(&type, &value, &tback);
-            //         errstr = PyObject_Str(value);
-            //         if (errstr) {
-            //             ast_error(c, n, "(%s) %U", errtype, errstr);
-            //             Py_DECREF(errstr);
-            //         }
-            //         else {
-            //             PyErr_Clear();
-            //             ast_error(c, n, "(%s) unknown error", errtype);
-            //         }
-            //         Py_DECREF(type);
-            //         Py_XDECREF(value);
-            //         Py_XDECREF(tback);
-            //     }
-            //     return NULL;
-            // }
-            return new Sk.astnodes.Str(str, LINENO(n), n.col_offset, c.end_lineno, n.end_col_offset);
-        }
+        case TOK.T_STRING:
+            return parsestrplus(c, n);
         case TOK.T_NUMBER:
             return new Sk.astnodes.Num(parsenumber(c, ch.value, n.lineno), n.lineno, n.col_offset);
         case TOK.T_ELLIPSIS: /* Ellipsis */
@@ -2670,114 +2875,6 @@ function ast_for_setdisplay(c, n) {
     }
 
     return new Sk.astnodes.Set(elts, LINENO(n), n.col_offset);
-}
-
-
-function astForAtom(c, n) {
-    /* atom: '(' [yield_expr|testlist_comp] ')' | '[' [testlist_comp] ']'
-       | '{' [dictmaker|testlist_comp] '}' | NAME | NUMBER | STRING+
-       | '...' | 'None' | 'True' | 'False'
-    */
-    var i;
-    var values;
-    var keys;
-    var size;
-    var ch = CHILD(n, 0);
-    var elts;
-    switch (ch.type) {
-        case TOK.T_NAME:
-            var s = ch.value;
-            // All names start in Load context, but may be changed later
-            if (s.length >= 4 && s.length <= 5) {
-                if (s === "None") {
-                    return new Sk.astnodes.NameConstant(Sk.builtin.none.none$, n.lineno, n.col_offset /* c.c_arena*/);
-                }
-
-                if (s === "True") {
-                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.true$, n.lineno, n.col_offset /* c.c_arena*/);
-                }
-
-                if (s === "False") {
-                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.false$, n.lineno, n.col_offset /* c.c_arena*/);
-                }
-
-            }
-            var name = new_identifier(s, c)
-
-            /* All names start in Load context, but may later be changed. */
-            return new Sk.astnodes.Name(name, Sk.astnodes.Load, n.lineno, n.col_offset);
-        case TOK.T_STRING:
-            return new Sk.astnodes.Str(parsestrplus(c, n), n.lineno, n.col_offset);
-        case TOK.T_NUMBER:
-            return new Sk.astnodes.Num(parsenumber(c, ch.value, n.lineno), n.lineno, n.col_offset);
-        case TOK.T_LPAR: // various uses for parens
-            ch = CHILD(n, 1);
-            if (ch.type === TOK.T_RPAR) {
-                return new Sk.astnodes.Tuple([], Sk.astnodes.Load, n.lineno, n.col_offset);
-            }
-            if (ch.type === SYM.yield_expr) {
-                return ast_for_expr(c, ch);
-            }
-            //            if (NCH(ch) > 1 && CHILD(ch, 1).type === SYM.comp_for) {
-            //                return astForComprehension(c, ch);
-            //            }
-            return ast_for_testlistComp(c, ch);
-        case TOK.T_LSQB: // list or listcomp
-            ch = CHILD(n, 1);
-            if (ch.type === TOK.T_RSQB) {
-                return new Sk.astnodes.List([], Sk.astnodes.Load, n.lineno, n.col_offset);
-            }
-            REQ(ch, SYM.listmaker);
-            if (NCH(ch) === 1 || CHILD(ch, 1).type === TOK.T_COMMA) {
-                return new Sk.astnodes.List(seq_for_testlist(c, ch), Sk.astnodes.Load, n.lineno, n.col_offset);
-            }
-            return ast_for_listcomp(c, ch);
-
-        case TOK.T_LBRACE:
-            /* dictorsetmaker:
-             *     (test ':' test (comp_for : (',' test ':' test)* [','])) |
-             *     (test (comp_for | (',' test)* [',']))
-             */
-            keys = [];
-            values = [];
-            ch = CHILD(n, 1);
-            if (n.type === TOK.T_RBRACE) {
-                //it's an empty dict
-                return new Sk.astnodes.Dict([], null, n.lineno, n.col_offset);
-            }
-            else if (NCH(ch) === 1 || (NCH(ch) !== 0 && CHILD(ch, 1).type === TOK.T_COMMA)) {
-                //it's a simple set
-                elts = [];
-                size = Math.floor((NCH(ch) + 1) / 2);
-                for (i = 0; i < NCH(ch); i += 2) {
-                    var expression = ast_for_expr(c, CHILD(ch, i));
-                    elts[i / 2] = expression;
-                }
-                return new Sk.astnodes.Set(elts, n.lineno, n.col_offset);
-            }
-            else if (NCH(ch) !== 0 && CHILD(ch, 1).type == SYM.comp_for) {
-                //it's a set comprehension
-                return ast_for_setcomp(c, ch);
-            }
-            else if (NCH(ch) > 3 && CHILD(ch, 3).type === SYM.comp_for) {
-                //it's a dict compr. I think.
-                return ast_for_dictcomp(c, ch);
-            }
-            else {
-                size = Math.floor((NCH(ch) + 1) / 4); // + 1 for no trailing comma case
-                for (i = 0; i < NCH(ch); i += 4) {
-                    keys[i / 4] = ast_for_expr(c, CHILD(ch, i));
-                    values[i / 4] = ast_for_expr(c, CHILD(ch, i + 2));
-                }
-                return new Sk.astnodes.Dict(keys, values, n.lineno, n.col_offset);
-            }
-        case TOK.T_BACKQUOTE:
-            //throw new Sk.builtin.SyntaxError("backquote not supported, use repr()", c.c_filename, n.lineno);
-            return new Sk.astnodes.Repr(ast_for_testlist(c, CHILD(n, 1)), n.lineno, n.col_offset);
-        default:
-            Sk.asserts.fail("unhandled atom", ch.type);
-
-    }
 }
 
 function astForAtomExpr(c, n) {

--- a/src/ast.js
+++ b/src/ast.js
@@ -2614,7 +2614,6 @@ function fstring_parse(str, start, end, raw, recurse_lvl, c, n) {
             idx = endIdx;
         }
     }
-    Sk.asserts.assert(values.length != 0);
     return [new Sk.astnodes.JoinedStr(values, LINENO(n), n.col_offset), idx];
 }
 

--- a/src/bool.js
+++ b/src/bool.js
@@ -45,4 +45,8 @@ Sk.builtin.bool.prototype.__float__ = new Sk.builtin.func(function(self) {
     return new Sk.builtin.float_(Sk.ffi.remapToJs(self));
 });
 
+Sk.builtin.bool.prototype.__format__ = new Sk.builtin.func(function(self) {
+    return self.$r();
+});
+
 Sk.exportSymbol("Sk.builtin.bool", Sk.builtin.bool);

--- a/src/builtin/sys.js
+++ b/src/builtin/sys.js
@@ -11,6 +11,14 @@ var $builtinmodule = function (name) {
 
     sys.copyright = Sk.builtin["str"]("Copyright 2009-2010 Scott Graham.\nAll Rights Reserved.\n");
 
+    if (Sk.__future__.python3) {
+        sys.version = "3.7(ish) [Skulpt]"
+        sys.version_info = new Sk.builtin.tuple([new Sk.builtin.int_(3), new Sk.builtin.int_(7)]);
+    } else {
+        sys.version = "2.7(ish) [Skulpt]"
+        sys.version_info = new Sk.builtin.tuple([new Sk.builtin.int_(2), new Sk.builtin.int_(7)]);
+    }
+
     sys.maxint = new Sk.builtin.int_(Math.pow(2,53)-1);
 
     /*  The largest positive integer supported by the platform’s Py_ssize_t type,

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -49,6 +49,7 @@ Sk.builtins = {
     "NegativePowerError" : Sk.builtin.NegativePowerError,
     "RuntimeError"       : Sk.builtin.RuntimeError,
     "StopIteration"      : Sk.builtin.StopIteration,
+    "SyntaxError"        : Sk.builtin.SyntaxError,
 
     "float_$rw$": Sk.builtin.float_,
     "int_$rw$"  : Sk.builtin.int_,

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -68,7 +68,6 @@ Sk.builtins = {
     "set"       : Sk.builtin.set,
     "tuple"     : Sk.builtin.tuple,
     "type"      : Sk.builtin.type,
-    "unicode"   : Sk.builtin.str,
 
     "input"     : new Sk.builtin.func(Sk.builtin.input),
     "raw_input" : new Sk.builtin.func(Sk.builtin.raw_input),
@@ -117,6 +116,7 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["range"] = new Sk.builtin.func(Sk.builtin.xrange);
         delete Sk.builtins["xrange"];
         delete Sk.builtins["StandardError"];
+        delete Sk.builtins["unicode"];
     } else {
         Sk.builtins["filter"] = new Sk.builtin.func(Sk.builtin.filter);
         Sk.builtins["map"] = new Sk.builtin.func(Sk.builtin.map);
@@ -124,6 +124,7 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["range"] = new Sk.builtin.func(Sk.builtin.range);
         Sk.builtins["xrange"] = new Sk.builtin.func(Sk.builtin.xrange);
         Sk.builtins["StandardError"] = Sk.builtin.StandardError;
+        Sk.builtins["unicode"] = Sk.builtin.str;
     }
 };
 Sk.exportSymbol("Sk.setupObjects", Sk.setupObjects);

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -68,6 +68,7 @@ Sk.builtins = {
     "set"       : Sk.builtin.set,
     "tuple"     : Sk.builtin.tuple,
     "type"      : Sk.builtin.type,
+    "unicode"   : Sk.builtin.str,
 
     "input"     : new Sk.builtin.func(Sk.builtin.input),
     "raw_input" : new Sk.builtin.func(Sk.builtin.raw_input),

--- a/src/compile.js
+++ b/src/compile.js
@@ -955,6 +955,9 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
             return this.ctuplelistorset(e, data, 'set');
         case Sk.astnodes.Starred:
             break;
+        case Sk.astnodes.JoinedStr:
+            console.log("f-strings:", e);
+            // fall through, we can't compile these yet
         default:
             Sk.asserts.fail("unhandled case " + e.constructor.name + " vexpr");
     }

--- a/src/compile.js
+++ b/src/compile.js
@@ -798,6 +798,10 @@ Compiler.prototype.cjoinedstr = function (e) {
         }
     }
 
+    if (!ret) {
+        ret = 'Sk.builtin.str.$emptystr';
+    }
+
     return ret;
 };
 
@@ -805,17 +809,18 @@ Compiler.prototype.cformattedvalue = function(e) {
     let value = this.vexpr(e.value);
     switch (e.conversion) {
         case 's':
-            out(value,"=Sk.builtin.str(",value,");");
+            value = this._gr("value", "Sk.builtin.str(",value,")");
             break;
         case 'a':
             // TODO when repr() becomes more unicode-aware,
             // we'll want to handle repr() and ascii() differently.
             // For now, they're the same
         case 'r':
-            out(value,"=Sk.builtin.repr(",value,");");
+            value = this._gr("value", "Sk.builtin.repr(",value,")");
             break;
     }
-    return this._gr("formatted", "Sk.abstr.objectFormat("+value+","+(e.format_spec ? this.vexpr(e.format_spec) : "Sk.builtin.str.$emptystr")+")");
+    let formatSpec = (e.format_spec ? this.vexpr(e.format_spec) : "Sk.builtin.str.$emptystr");
+    return this._gr("formatted", "Sk.abstr.objectFormat("+value+","+formatSpec+")");
 };
 
 

--- a/src/float.js
+++ b/src/float.js
@@ -804,26 +804,7 @@ Sk.builtin.float_.prototype.round$ = function (self, ndigits) {
     }
 };
 
-Sk.builtin.float_.prototype.__format__= function (obj, format_spec) {
-    var formatstr;
-    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
-
-    if (!Sk.builtin.checkString(format_spec)) {
-        if (Sk.__future__.exceptions) {
-            throw new Sk.builtin.TypeError("format() argument 2 must be str, not " + Sk.abstr.typeName(format_spec));
-        } else {
-            throw new Sk.builtin.TypeError("format expects arg 2 to be string or unicode, not " + Sk.abstr.typeName(format_spec));
-        }
-    } else {
-        formatstr = Sk.ffi.remapToJs(format_spec);
-        if (formatstr !== "") {
-            throw new Sk.builtin.NotImplementedError("format spec is not yet implemented");
-        }
-    }
-
-    return new Sk.builtin.str(obj);
-};
-
+Sk.builtin.float_.prototype.__format__ = Sk.formatting.mkNumber__format__(true);
 
 Sk.builtin.float_.prototype.conjugate = new Sk.builtin.func(function (self) {
     return new Sk.builtin.float_(self.v);

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -1,3 +1,269 @@
+// Implement the default "format specification mini-language"
+// for numbers and strings
+// https://docs.python.org/3.7/library/string.html#formatspec
+
+const FORMAT_SPEC_REGEX = /^(?:(.)?([<\>\=\^]))?([\+\-\s])?(#)?(0)?(\d+)?(,)?(?:\.(\d+))?([bcdeEfFgGnosxX%])?$/;
+const FMT = {
+    FILL_CHAR: 1,
+    FILL_ALIGN: 2,
+    SIGN: 3,
+    ALT_FORM: 4,
+    ZERO_PAD: 5,
+    FIELD_WIDTH: 6,
+    COMMA: 7,
+    PRECISION: 8,
+    CONVERSION_TYPE: 9
+};
+
+Sk.formatting = {};
+
+let handleWidth = function (m, r, prefix, isNumber) {
+    // print(prefix);
+    Sk.asserts.assert(typeof(r) === "string");
+
+    if (m[FMT.FIELD_WIDTH]) {
+        let fieldWidth = parseInt(m[FMT.FIELD_WIDTH], 10);
+        let fillChar = m[FMT.FILL_CHAR] || (m[FMT.ZERO_PAD] ? "0" : " ");
+        let fillAlign = m[FMT.FILL_ALIGN] || (m[FMT.ZERO_PAD] ? "=" : isNumber ? ">" : "<");
+        let nFill = fieldWidth - (r.length + (prefix ? prefix.length : 0));
+
+        if (nFill <= 0) {
+            return r;
+        }
+
+        let fill = fillChar.repeat(nFill);
+
+        switch (fillAlign) {
+            case "=":
+                if (m[FMT.CONVERSION_TYPE] === "s") {
+                    throw new Sk.builtin.ValueError("'=' alignment not allowed in string format specifier");
+                }
+                return prefix + fill + r;
+            case ">":
+                return fill + prefix + r;
+            case "<":
+                return prefix + r + fill;
+            case "^":
+                let idx = Math.floor(nFill/2);
+                return fill.substring(0, idx) + prefix + r + fill.substring(idx);
+        }
+    }
+    return prefix + r;
+};
+
+let signForNeg = function(m, neg) {
+    return neg ? "-" :
+        (m[FMT.SIGN] === "+") ? "+" :
+        (m[FMT.SIGN] === " ") ? " " : "";
+};
+
+let handleInteger = function(m, n, base){
+    // TODO: Do we need to tolerate float inputs for integer conversions?
+    // Python doesn't, but I'm guessing this is something to do with JS's
+    // int/float ambiguity
+    Sk.asserts.assert(n instanceof Sk.builtin.int_ || n instanceof Sk.builtin.lng);
+
+    if (m[FMT.PRECISION]) {
+        throw new Sk.builtin.ValueError("Precision not allowed in integer format");
+    }
+
+    let r = n.str$(base, false);
+    let neg = n.nb$isnegative();
+
+    let prefix = signForNeg(m, neg);
+
+    if (m[FMT.ALT_FORM]) {
+        if (base === 16) {
+            prefix += "0x";
+        } else if (base === 8) {
+            prefix += "0o";
+        } else if (base === 2){
+            prefix += "0b";
+        }
+    }
+
+    if (m[FMT.CONVERSION_TYPE] === "X") {
+        r = r.toUpperCase();
+    }
+
+    if (m[FMT.CONVERSION_TYPE] === "n"){
+        r = (+r).toLocaleString();
+    } else if (m[FMT.COMMA]){
+        var parts = r.toString().split(".");
+        parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+        r = parts.join(".");
+    }
+
+    return handleWidth(m, r, prefix, true);
+};
+
+// Common implementation of __format__ for Python number objects
+let formatNumber = function(num, formatSpec, isFractional) {
+    if (!formatSpec) { // empty or undefined
+        return num.str$(10, true);
+    }
+    let m = formatSpec.match(FORMAT_SPEC_REGEX);
+    if (!m) {
+        throw new Sk.builtin.ValueError("Invalid format specifier");
+    }
+
+    let conversionType = m[FMT.CONVERSION_TYPE];
+    if (!conversionType) {
+        conversionType = (isFractional ? "g" : "d");
+    }
+
+    let validConversions = isFractional ? "fFeEgG%" : "bcdoxXnfFeEgG%";
+    if (validConversions.indexOf(conversionType) == -1) {
+        throw new Sk.builtin.ValueError("Unknown format code '" + m[FMT.CONVERSION_TYPE] + "' for object of type '" + Sk.abstr.typeName(num) +"'");
+    }
+
+    switch (conversionType) {
+        case "d":
+        case "n":
+            return handleInteger(m, num, 10);
+        case "x":
+        case "X":
+            return handleInteger(m, num, 16);
+        case "o":
+            return handleInteger(m, num, 8);
+        case "b":
+            return handleInteger(m, num, 2);
+        case "c": {
+            if (m[FMT.SIGN]) {
+                throw new Sk.builtin.ValueError("Sign not allowed with integer format specifier 'c'");
+            }
+            if (m[FMT.ALT_FORM]) {
+                throw new Sk.builtin.ValueError("Alternate form not allowed with integer format specifier 'c'");
+            }
+            if (m[FMT.COMMA]) {
+                throw new Sk.builtin.ValueError("Cannot specify ',' with 'c'");
+            }
+            if (m[FMT.PRECISION]) {
+                throw new Sk.builtin.ValueError("Cannot specify ',' with 'c'");
+            }
+            return handleWidth(m, String.fromCodePoint(Sk.builtin.asnum$(num)), "", true);
+        };
+
+        case "f":
+        case "F":
+        case "e":
+        case "E":
+        case "g":
+        case "G": {
+            if (m[FMT.ALT_FORM]){
+                throw new Sk.builtin.ValueError("Alternate form (#) not allowed in float format specifier");
+            }
+            let convValue = Sk.builtin.asnum$(num);
+            if (typeof convValue === "string") {
+                convValue = Number(convValue);
+            }
+            if (convValue === Infinity) {
+                return handleWidth(m, "inf", "", true);
+            }
+            if (convValue === -Infinity) {
+                return handleWidth(m, "inf", "-", true);
+            }
+            if (isNaN(convValue)) {
+                return handleWidth(m, "nan", "", true);
+            }
+            let neg = false;
+            if (convValue < 0) {
+                convValue = -convValue;
+                neg = true;
+            }
+            let convName = ["toExponential", "toFixed", "toPrecision"]["efg".indexOf(conversionType.toLowerCase())];
+            let precision = m[FMT.PRECISION] ? parseInt(m[FMT.PRECISION], 10) : 6;
+            let result = (convValue)[convName](precision);
+            if ("EFG".indexOf(conversionType) !== -1) {
+                result = result.toUpperCase();
+            }
+            // Python's 'g' does not show trailing 0s
+            if (conversionType.toLowerCase()==="g" || !m[FMT.CONVERSION_TYPE]) {
+                let trailingZeros = result.match(/\.(\d*[1-9])?(0+)$/);
+                if (trailingZeros) {
+                    let [_, hasMoreDigits, zs] = trailingZeros;
+                    // Python's default conversion shows at least one trailing zero
+                    result = result.slice(0, hasMoreDigits ? -zs.length : -(zs.length+1));
+                }
+                if (result.indexOf(".") == -1 && !m[FMT.CONVERSION_TYPE]) {
+                    result += ".0";
+                }
+            }
+
+            return handleWidth(m, result, signForNeg(m, neg), true);
+        };
+
+        case "%": {
+            if (m[FMT.ALT_FORM]) {
+                throw new Sk.builtin.ValueError("Alternate form (#) not allowed with format specifier '%'");
+            }
+            let convValue = Sk.builtin.asnum$(num);
+            if (typeof convValue === "string") {
+                convValue = Number(convValue);
+            }
+            if (convValue === Infinity) {
+                return handleWidth(m, "inf%", "", true);
+            }
+            if (convValue === -Infinity) {
+                return handleWidth(m, "inf%", "-", true);
+            }
+            if (isNaN(convValue)) {
+                return handleWidth(m, "nan%", "", true);
+            }
+            let precision = m[FMT.PRECISION] ? parseInt(m[FMT.PRECISION], 10) : 6;
+            let result = (convValue*100.0).toFixed(precision) + "%";
+            return handleWidth(m, result, signForNeg(m, convValue < 0), true);
+        };
+
+        default:
+            throw new Sk.builtin.ValueError("Unknown format code '" + m[FMT.CONVERSION_TYPE] + "'");
+    }
+};
+
+Sk.formatting.mkNumber__format__ = (isFractional) => new Sk.builtin.func(function (self, format_spec) {
+    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
+
+    if (!Sk.builtin.checkString(format_spec)) {
+        throw new Sk.builtin.TypeError("format() argument 2 must be str, not " + Sk.abstr.typeName(format_spec));
+    }
+
+    return new Sk.builtin.str(formatNumber(self, format_spec.$jsstr(), isFractional));
+});
+
+let formatString = function (self, format_spec) {
+    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
+
+    if (!Sk.builtin.checkString(format_spec)) {
+        throw new Sk.builtin.TypeError("format() argument 2 must be str, not " + Sk.abstr.typeName(format_spec));
+    }
+
+    let m = format_spec.$jsstr().match(FORMAT_SPEC_REGEX);
+    if (m[FMT.CONVERSION_TYPE] && m[FMT.CONVERSION_TYPE] !== "s") {
+        throw new Sk.builtin.ValueError("Unknown format code '" + m[FMT.CONVERSION_TYPE] + "' for object of type 'str'");
+    }
+
+    if (m[FMT.SIGN]) {
+        throw new Sk.builtin.ValueError("Sign not allowed in string format specifier");
+    }
+
+    if (m[FMT.ALT_FORM]) {
+        throw new Sk.builtin.ValueError("Alternate form (#) not allowed with string format specifier");
+    }
+
+    if (m[FMT.COMMA]) {
+        throw new Sk.builtin.ValueError("Cannot specify ',' with 's'");
+    }
+
+    let value = self.v;
+
+    if (m[FMT.PRECISION]) {
+        value = value.substring(0, m[FMT.PRECISION]);
+    }
+
+    return new Sk.builtin.str(handleWidth(m, value, "", false));
+};
+
+// str.format() implementation
 var format = function (kwa) {
     // following PEP 3101
 
@@ -17,7 +283,7 @@ var format = function (kwa) {
         return args.v;
     }
     index = 0;
-    regex = /{(((?:\d+)|(?:\w+))?((?:\.(\w+))|(?:\[((?:\d+)|(?:\w+))\])?))?(?:\!([rs]))?(?:\:((?:(.)?([<\>\=\^]))?([\+\-\s])?(#)?(0)?(\d+)?(,)?(?:\.(\d+))?([bcdeEfFgGnosxX%])?))?}/g;
+    regex = /{(((?:\d+)|(?:\w+))?((?:\.(\w+))|(?:\[((?:\d+)|(?:\w+))\])?))?(?:\!([rs]))?(?:\:([^}]*))?}/g;
     // ex: {o.name!r:*^+#030,.9b}
     // Field 1, Field_name, o.name
     // Field 2, arg_name, o
@@ -26,15 +292,6 @@ var format = function (kwa) {
     // Field 5, element_index, [0]
     // Field 6, conversion, r
     // Field 7, format_spec,*^+#030,.9b
-    // Field 9, fill_character,*
-    // Field 10, fill_align, ^
-    // Field 11, sign, +
-    // Field 12, 0x, #
-    // Filed 13, sign-aware 0 padding, 0
-    // Field 14, width, 30
-    // Field 15, comma, ,
-    // Field 16, precision, .9
-    // Field 17, conversionType, b
 
     // Detect empty/int/complex name
     // retrive field value
@@ -56,289 +313,43 @@ var format = function (kwa) {
         }
     }
 
-    replFunc = function (substring, field_name, arg_name, attr_name, attribute_name, element_index, conversion, format_spec, fill_char, fill_align, sign, zero_pad, sign_aware, fieldWidth, comma, precision, conversionType, offset, str_whole) {
-        var return_str;
-        var formatNumber;
-        var formatFormat;
-        var result;
-        var base;
-        var value;
-        var handleWidth;
-        var alternateForm;
-        var precedeWithSign;
-        var blankBeforePositive;
-        var leftAdjust;
-        var centerAdjust;
-        var zeroPad;
-        var convName;
-        var convValue;
-        var percent;
-        var container;
-        fieldWidth = Sk.builtin.asnum$(fieldWidth);
-        precision = Sk.builtin.asnum$(precision);
+    replFunc = function (substring, field_name, arg_name, attr_name, attribute_name, element_index, conversion, format_spec, offset, str_whole) {
+        let value;
 
         if(element_index !== undefined && element_index !== ""){
-            container = arg_dict[arg_name];
+            let container = arg_dict[arg_name];
             if (container.constructor === Array) {
                 value = container[element_index];
+            } else if (/^\d+$/.test(element_index)) {
+                value = Sk.abstr.objectGetItem(container, new Sk.builtin.int_(parseInt(element_index, 10)), false);
             } else {
-                if (container instanceof Sk.builtin.dict) {
-                    value = Sk.abstr.objectGetItem(container, new Sk.builtin.str(element_index), false);
-                } else {
-                    value = Sk.abstr.objectGetItem(container, new Sk.builtin.int_(parseInt(element_index, 10)), false);
-                }
+                value = Sk.abstr.objectGetItem(container, new Sk.builtin.str(element_index), false);
             }
             index++;
         } else if(attribute_name !== undefined && attribute_name !== ""){
-            value = arg_dict[arg_name][attribute_name];
-            index++;
+            value = Sk.abstr.gattr(arg_dict[arg_name || (index++)], new Sk.builtin.str(attribute_name));
         } else if(arg_name !== undefined && arg_name !== ""){
             value = arg_dict[arg_name];
-            index++;
         } else if(field_name === undefined || field_name === ""){
-            return_str = arg_dict[index];
+            value = arg_dict[index];
             index++;
-            value = return_str;
-        } else if(field_name instanceof Sk.builtin.int_ ||
-                  field_name instanceof Sk.builtin.float_ ||
-                  field_name instanceof Sk.builtin.lng || !isNaN(parseInt(field_name, 10))){
-            return_str = arg_dict[field_name];
+        } else if (field_name instanceof Sk.builtin.int_ ||
+                   field_name instanceof Sk.builtin.float_ ||
+                   field_name instanceof Sk.builtin.lng || /^\d+$/.test(field_name)) {
+            value = arg_dict[field_name];
             index++;
-            value = return_str;
         }
 
-        if (precision === "") { // ff passes '' here aswell causing problems with G,g, etc.
-            precision = undefined;
+        if (conversion === "s") {
+            value = new Sk.builtin.str(value);
+        } else if (conversion === "r") {
+            value = Sk.builtin.repr(value);
+        } else if (conversion !== "" && conversion !== undefined) {
+            throw new Sk.builtin.ValueError("Unknown conversion specifier " + conversion);
         }
-        if(fill_char === undefined || fill_char === ""){
-            fill_char = " ";
-        }
+        // TODO "!a" I guess?
 
-        zeroPad = false;
-        leftAdjust = false;
-        centerAdjust = false;
-        blankBeforePositive = false;
-        precedeWithSign = false;
-        alternateForm = false;
-        if (format_spec) {
-            if(sign !== undefined && sign !== ""){
-                if ("-".indexOf(sign) !== -1) {
-                    leftAdjust = true;
-                } else if ("+".indexOf(sign) !== -1) {
-                    precedeWithSign = true;
-                } else if (" ".indexOf(sign) !== -1) {
-                    blankBeforePositive = true;
-                }
-            }
-            if(zero_pad){
-                alternateForm = "#".indexOf(zero_pad) !== -1;
-            }
-            if(fieldWidth !== undefined && fieldWidth !== ""){
-                if(fill_char === undefined || fill_char === ""){
-                    fill_char = " ";
-                }
-            }
-            if("%".indexOf(conversionType) !== -1){
-                percent = true;
-            }
-        }
-        if (precision) {
-            precision = parseInt(precision, 10);
-        }
-
-        formatFormat = function(value){
-            var r;
-            var s;
-            if(conversion === undefined || conversion === "" || conversion == "s"){
-                s = new Sk.builtin.str(value);
-                return s.v;
-            } else if(conversion == "r"){
-                r = Sk.builtin.repr(value);
-                return r.v;
-            }
-
-        };
-
-        handleWidth = function (prefix, r) {
-            // print(prefix);
-            var totLen;
-            r = Sk.ffi.remapToJs(r);
-
-            var j;
-            if(percent){
-                r = r +"%";
-            }
-            if (fieldWidth !== undefined && fieldWidth !== "") {
-                fieldWidth = parseInt(fieldWidth, 10);
-                totLen = r.length + prefix.length;
-                if (zeroPad) {
-                    for (j = totLen; j < fieldWidth; ++j) {
-                        r = "0" + r;
-                    }
-                } else if (leftAdjust) {
-                    for (j = totLen; j < fieldWidth; ++j) {
-                        r = r + fill_char;
-                    }
-                } else if(">".indexOf(fill_align) !== -1){
-                    for (j = totLen; j < fieldWidth; ++j) {
-                        prefix = fill_char + prefix;
-                    }
-                } else if("^".indexOf(fill_align) !== -1){
-                    for (j = totLen; j < fieldWidth; ++j) {
-                        if(j % 2 === 0){
-                            prefix = fill_char + prefix;
-                        } else if ( j % 2 === 1){
-                            r = r + fill_char;
-                        }
-                    }
-                } else if("=".indexOf(fill_align) !== -1){
-                    for (j = totLen; j < fieldWidth; ++j) {
-                        r =  fill_char + r;
-                    }
-                } else{
-                    for (j = totLen; j < fieldWidth; ++j) {
-                        r = r + fill_char;
-                    }
-                }
-            }
-            return formatFormat(prefix + r);
-        };
-
-        formatNumber = function(n, base){
-            var precZeroPadded;
-            var prefix;
-            var neg;
-            var r;
-
-            base = Sk.builtin.asnum$(base);
-            neg = false;
-
-            if(format_spec === undefined){
-                return formatFormat(value);
-            }
-
-            if (typeof n === "number") {
-                if (n < 0) {
-                    n = -n;
-                    neg = true;
-                }
-                r = n.toString(base);
-            } else if (n instanceof Sk.builtin.float_) {
-                r = n.str$(base, false);
-                if (r.length > 2 && r.substr(-2) === ".0") {
-                    r = r.substr(0, r.length - 2);
-                }
-                neg = n.nb$isnegative();
-            } else if (n instanceof Sk.builtin.int_) {
-                r = n.str$(base, false);
-                neg = n.nb$isnegative();
-            } else if (n instanceof Sk.builtin.lng) {
-                r = n.str$(base, false);
-                neg = n.nb$isnegative();    //  neg = n.size$ < 0;  RNL long.js change
-            } else{
-                r = n;
-            }
-
-            if (precision) {
-                n = Number(r);
-                if (n < 0) {
-                    n = -n;
-                    neg = true;
-                }
-                r = n.toFixed(precision);
-            }
-
-            precZeroPadded = false;
-            prefix = "";
-
-            if (neg) {
-                prefix = "-";
-            } else if (precedeWithSign) {
-                prefix = "+" ;
-            } else if (blankBeforePositive) {
-                prefix = " " ;
-            }
-
-            if (alternateForm) {
-                if (base === 16) {
-                    prefix += "0x";
-                } else if (base === 8 && !precZeroPadded && r !== "0") {
-                    prefix += "0o";
-                } else if (base === 2 && !precZeroPadded && r !== "0"){
-                    prefix += "0b";
-                }
-            }
-
-            if(conversionType === "n"){
-                r=r.toLocaleString();
-            } else if(",".indexOf(comma) !== -1){
-                var parts = r.toString().split(".");
-                parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-                r = parts.join(".");
-            }
-            return handleWidth(prefix, r);
-        };
-
-        base = 10;
-        if(conversionType === "d" || conversionType === "n" || conversionType === "" || conversionType === undefined){
-            return formatNumber(value, 10);
-        }else if (conversionType === "b") {
-            return formatNumber(value, 2);
-        }else if (conversionType === "o") {
-            return formatNumber(value, 8);
-        } else if (conversionType === "x") {
-            return formatNumber(value, 16);
-        } else if (conversionType === "X") {
-            return formatNumber(value, 16).toUpperCase();
-        } else if (conversionType === "f" || conversionType === "F" || conversionType === "e" || conversionType === "E" || conversionType === "g" || conversionType === "G") {
-            if(alternateForm){
-                throw new Sk.builtin.ValueError("Alternate form (#) not allowed in float format specifier");
-            }
-            convValue = Sk.builtin.asnum$(value);
-            if (typeof convValue === "string") {
-                convValue = Number(convValue);
-            }
-            if (convValue === Infinity) {
-                return handleWidth("","inf");
-            }
-            if (convValue === -Infinity) {
-                return handleWidth("-","inf");
-            }
-            if (isNaN(convValue)) {
-                return handleWidth("","nan");
-            }
-            convName = ["toExponential", "toFixed", "toPrecision"]["efg".indexOf(conversionType.toLowerCase())];
-            if (precision === undefined || precision === "") {
-                if (conversionType === "e" || conversionType === "E" || conversionType === "%") {
-                    precision = parseInt(6, 10);
-                } else if (conversionType === "f" || conversionType === "F") {
-                    precision = parseInt(6, 10);
-                }
-            }
-            result = (convValue)[convName](precision);
-            if ("EFG".indexOf(conversionType) !== -1) {
-                result = result.toUpperCase();
-            }
-            return formatNumber(result, 10);
-        } else if (conversionType === "c") {
-            if (typeof value === "number") {
-                return handleWidth("", String.fromCharCode(value));
-            } else if (value instanceof Sk.builtin.int_) {
-                return handleWidth("", String.fromCharCode(value.v));
-            } else if (value instanceof Sk.builtin.float_) {
-                return handleWidth("", String.fromCharCode(value.v));
-            } else if (value instanceof Sk.builtin.lng) {
-                return handleWidth("", String.fromCharCode(value.str$(10, false)[0]));
-            } else if (value.constructor === Sk.builtin.str) {
-                return handleWidth("", value.v.substr(0, 1));
-            } else {
-                throw new Sk.builtin.TypeError("an integer is required");
-            }
-        } else if (percent) {
-            if(precision === undefined){precision = parseInt(7,10);}
-            return formatNumber(value.nb$multiply(new Sk.builtin.int_(100)), 10);
-        }
-
+        return Sk.abstr.objectFormat(value, new Sk.builtin.str(format_spec)).$jsstr();
     };
 
     ret = args.v[0].v.replace(regex, replFunc);
@@ -347,3 +358,4 @@ var format = function (kwa) {
 
 format["co_kwargs"] = true;
 Sk.builtin.str.prototype["format"] = new Sk.builtin.func(format);
+Sk.builtin.str.prototype["__format__"] = new Sk.builtin.func(formatString);

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -189,6 +189,11 @@ let formatNumber = function(num, formatSpec, isFractional) {
                     result += ".0";
                 }
             }
+            if (m[FMT.COMMA]){
+                var parts = result.toString().split(".");
+                parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+                result = parts.join(".");
+            }
 
             return handleWidth(m, result, signForNeg(m, neg), true);
         };

--- a/src/int.js
+++ b/src/int.js
@@ -176,6 +176,8 @@ Sk.builtin.int_.prototype.__complex__ = new Sk.builtin.func(function(self) {
     return Sk.builtin.NotImplemented.NotImplemented$;
 });
 
+Sk.builtin.int_.prototype.__format__ = Sk.formatting.mkNumber__format__(false);
+
 /**
  * Return this instance's Javascript value.
  *
@@ -1012,26 +1014,6 @@ Sk.builtin.int_.prototype.round$ = function (self, ndigits) {
 
         return new Sk.builtin.int_(result);
     }
-};
-
-Sk.builtin.int_.prototype.__format__= function (obj, format_spec) {
-    var formatstr;
-    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
-
-    if (!Sk.builtin.checkString(format_spec)) {
-        if (Sk.__future__.exceptions) {
-            throw new Sk.builtin.TypeError("format() argument 2 must be str, not " + Sk.abstr.typeName(format_spec));
-        } else {
-            throw new Sk.builtin.TypeError("format expects arg 2 to be string or unicode, not " + Sk.abstr.typeName(format_spec));
-        }
-    } else {
-        formatstr = Sk.ffi.remapToJs(format_spec);
-        if (formatstr !== "") {
-            throw new Sk.builtin.NotImplementedError("format spec is not yet implemented");
-        }
-    }
-
-    return new Sk.builtin.str(obj);
 };
 
 Sk.builtin.int_.prototype.conjugate = new Sk.builtin.func(function (self) {

--- a/src/lib/datetime.py
+++ b/src/lib/datetime.py
@@ -24,6 +24,10 @@ and pickle support (which requires 'struct', which Skulpt does not currently
 import time as _time
 import math as _math
 
+# Python 2-vs-3 compat hack
+import sys
+unicode = unicode if sys.version_info < (3,) else str
+
 _SENTINEL = object()
 
 def _cmp(x, y):

--- a/src/long.js
+++ b/src/long.js
@@ -77,26 +77,6 @@ Sk.builtin.lng.prototype.nb$int_ = function() {
     return new Sk.builtin.int_(this.toInt$());
 };
 
-Sk.builtin.lng.prototype.__format__= function (obj, format_spec) {
-    var formatstr;
-    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
-
-    if (!Sk.builtin.checkString(format_spec)) {
-        if (Sk.__future__.exceptions) {
-            throw new Sk.builtin.TypeError("format() argument 2 must be str, not " + Sk.abstr.typeName(format_spec));
-        } else {
-            throw new Sk.builtin.TypeError("format expects arg 2 to be string or unicode, not " + Sk.abstr.typeName(format_spec));
-        }
-    } else {
-        formatstr = Sk.ffi.remapToJs(format_spec);
-        if (formatstr !== "") {
-            throw new Sk.builtin.NotImplementedError("format spec is not yet implemented");
-        }
-    }
-
-    return new Sk.builtin.str(obj);
-};
-
 Sk.builtin.lng.prototype.round$ = function (self, ndigits) {
     Sk.builtin.pyCheckArgsLen("__round__", arguments.length, 1, 2);
 
@@ -130,6 +110,8 @@ Sk.builtin.lng.prototype.round$ = function (self, ndigits) {
 Sk.builtin.lng.prototype.__index__ = new Sk.builtin.func(function(self) {
     return self.nb$int_(self);
 });
+
+Sk.builtin.lng.prototype.__format__ = Sk.formatting.mkNumber__format__(false);
 
 Sk.builtin.lng.prototype.nb$lng_ = function () {
     return this;

--- a/src/module.js
+++ b/src/module.js
@@ -9,3 +9,11 @@ Sk.builtin.module.prototype.ob$type = Sk.builtin.type.makeIntoTypeObj("module", 
 Sk.builtin.module.prototype.tp$getattr = Sk.builtin.object.prototype.GenericGetAttr;
 Sk.builtin.module.prototype.tp$setattr = Sk.builtin.object.prototype.GenericSetAttr;
 Sk.builtin.module.prototype.tp$name = "module";
+
+Sk.builtin.module.prototype.$r = function() {
+    let get = (s) => {
+        let v = this.tp$getattr(new Sk.builtin.str(s));
+        return Sk.builtin.repr(v || Sk.builtin.str.$emptystr).$jsstr();
+    };
+    return new Sk.builtin.str("<module " + get("__name__") + " from " + get("__file__") + ">");
+};

--- a/src/str.js
+++ b/src/str.js
@@ -389,26 +389,6 @@ Sk.builtin.str.prototype["rstrip"] = new Sk.builtin.func(function (self, chars) 
     return new Sk.builtin.str(self.v.replace(pattern, ""));
 });
 
-Sk.builtin.str.prototype["__format__"] = new Sk.builtin.func(function (self, format_spec) {
-    var formatstr;
-    Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 2, 2);
-
-    if (!Sk.builtin.checkString(format_spec)) {
-        if (Sk.__future__.exceptions) {
-            throw new Sk.builtin.TypeError("format() argument 2 must be str, not " + Sk.abstr.typeName(format_spec));
-        } else {
-            throw new Sk.builtin.TypeError("format expects arg 2 to be string or unicode, not " + Sk.abstr.typeName(format_spec));
-        }
-    } else {
-        formatstr = Sk.ffi.remapToJs(format_spec);
-        if (formatstr !== "" && formatstr !== "s") {
-            throw new Sk.builtin.NotImplementedError("format spec is not yet implemented");
-        }
-    }
-
-    return new Sk.builtin.str(self);
-});
-
 Sk.builtin.str.prototype["partition"] = new Sk.builtin.func(function (self, sep) {
     var pos;
     var sepStr;

--- a/src/str.js
+++ b/src/str.js
@@ -156,11 +156,7 @@ Sk.builtin.str.prototype.tp$iter = function () {
 
 Sk.builtin.str.prototype.tp$richcompare = function (other, op) {
     if (!(other instanceof Sk.builtin.str)) {
-        if (Sk.__future__.python3) {
-            return Sk.builtin.NotImplemented.NotImplemented$;
-        } else {
-            return false;
-        }
+        return Sk.builtin.NotImplemented.NotImplemented$;
     }
 
     switch (op) {

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -745,6 +745,11 @@ SymbolTable.prototype.visitExpr = function (e) {
         case Sk.astnodes.Num:
         case Sk.astnodes.Str:
             break;
+        case Sk.astnodes.JoinedStr:
+            for (let s of e.values) {
+                this.visitExpr(s);
+            }
+            break;
         case Sk.astnodes.Attribute:
             this.visitExpr(e.value);
             break;

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -750,6 +750,12 @@ SymbolTable.prototype.visitExpr = function (e) {
                 this.visitExpr(s);
             }
             break;
+        case Sk.astnodes.FormattedValue:
+            this.visitExpr(e.value);
+            if (e.format_spec) {
+                this.visitExpr(e.format_spec);
+            }
+            break;
         case Sk.astnodes.Attribute:
             this.visitExpr(e.value);
             break;

--- a/test/unit/test_regressions.py
+++ b/test/unit/test_regressions.py
@@ -1,0 +1,16 @@
+"""Tests for bug regressions."""
+
+import unittest
+
+class RegressionTest(unittest.TestCase):
+    def test_string_equality(self):
+        self.assertTrue("1" == "1")
+        self.assertFalse("1" != "1")
+        self.assertFalse("1" == "2")
+        self.assertTrue("1" != "2")
+        self.assertFalse("1" == 1)
+        self.assertTrue("1" != 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_strformat.py
+++ b/test/unit/test_strformat.py
@@ -10,34 +10,36 @@ class string_format(unittest.TestCase):
         self.assertEqual('c, b, a', '{2}, {1}, {0}'.format(*'abc'))
         self.assertEqual('abracadabra', '{0}{1}{0}'.format('abra', 'cad'))
 
-    #Kwargs don't work
     def test_arg_names(self):
         self.assertEqual('Coordinates: 37.24N, -115.81W', 'Coordinates: {latitude}, {longitude}'.format(latitude='37.24N', longitude='-115.81W'))
-        ## **kwargs does not work properly in Skulpt
-        # coord = {'latitude': '37.24N', 'longitude': '-115.81W'}
-        # self.assertEqual('Coordinates: 37.24N, -115.81W', 'Coordinates: {latitude}, {longitude}'.format(**coord))
+
+        coord = {'latitude': '37.24N', 'longitude': '-115.81W'}
+        self.assertEqual('Coordinates: 37.24N, -115.81W', 'Coordinates: {latitude}, {longitude}'.format(**coord))
     
-    ## Complex Numbers Currently unsupported
     
-    # def test_arg_attr(self):
-    #     c = 3-5j
-    #     self.assertEqual('The complex number (3-5j) is formed from the real part 3.0 and the imaginary part -5.0.', ('The complex number {0} is formed from the real part {0.real} and the imaginary part {0.imag}.').format(c))
-    #     class Point(object):
-    #         def __init__(self, x, y):
-    #             self.x, self.y = x, y
-    #         def __str__(self):
-    #             return 'Point({self.x}, {self.y})'.format(self=self)
-    #     self.assertEqual('Point(4, 2)', str(Point(4, 2)))
+    def test_arg_attr(self):
+        # Skulpt:  Complex Numbers Currently unsupported
+        # c = 3-5j
+        # self.assertEqual('The complex number (3-5j) is formed from the real part 3.0 and the imaginary part -5.0.', ('The complex number {0} is formed from the real part {0.real} and the imaginary part {0.imag}.').format(c))
+
+        class Point(object):
+            def __init__(self, x, y):
+                self.x, self.y = x, y
+            def __str__(self):
+                return 'Point({self.x}, {self.y})'.format(self=self)
+        self.assertEqual('Point(4, 2)', str(Point(4, 2)))
+
+        self.assertEqual('4, 2', "{0.x}, {0.y}".format(Point(4, 2)))
+        self.assertEqual('4, 2', "{.x}, {.y}".format(Point(4, 3), Point(3, 2)))
 
     def test_arg_items(self):
         coord = (3, 5)
         self.assertEqual('X: 3;  Y: 5','X: {0[0]};  Y: {0[1]}'.format(coord))
         self.assertEqual('My name is Fred',"My name is {0[name]}".format({'name':'Fred'}))
 
-# TODO:  make these pass
-#    def test_width(self):
-#        self.assertEqual('         2,2',"{0:10},{0}".format(2))
-#        self.assertEqual('foo bar baz ',"{0:4}{1:4}{2:4}".format("foo","bar","baz")) 
+    def test_width(self):
+        self.assertEqual('         2,2',"{0:10},{0}".format(2))
+        self.assertEqual('foo bar baz ',"{0:4}{1:4}{2:4}".format("foo","bar","baz")) 
         
 
     def test_conversion(self):
@@ -70,12 +72,10 @@ class string_format(unittest.TestCase):
         self.assertEqual('(1, 2, 3)', '{}'.format((1, 2, 3)))
         self.assertEqual('[1, 2, 3]', '{}'.format([1, 2, 3]))
 
-    ## Datetime requires more work.
-    
-    # def test_datetome(self):
-    #     import datetime
-    #     d = datetime.datetime(2010, 7, 4, 12, 15, 58)
-    #     self.assertEqual('2010-07-04 12:15:58', '{:%Y-%m-%d %H:%M:%S}'.format(d))
+    def test_datetime(self):
+        import datetime
+        d = datetime.datetime(2010, 7, 4, 12, 15, 58)
+        self.assertEqual('2010-07-04 12:15:58', '{:%Y-%m-%d %H:%M:%S}'.format(d))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_compare.py
+++ b/test/unit3/test_compare.py
@@ -197,9 +197,18 @@ class ComparisonTest(unittest.TestCase):
         self.assertRaises(TypeError, helper, A(-1), A(1), -1)
 
         # Built-in type comparisons should no longer work in python 3
+        # (but equality should)
         self.assertRaises(TypeError, lambda: (1,2) > [3,4])
+        self.assertFalse((1,2) == [3,4])
+        self.assertTrue((1,2) != [3,4])
+
         self.assertRaises(TypeError, lambda: None > (1,2))
+        self.assertFalse(None == (1,2))
+        self.assertTrue(None != (1,2))
+
         self.assertRaises(TypeError, lambda: 2 > "2")
+        self.assertFalse(2 == "2")
+        self.assertTrue(2 != "2")
 ##
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_fstring.py
+++ b/test/unit3/test_fstring.py
@@ -420,8 +420,7 @@ class TestCase(unittest.TestCase):
         x = 'def'
         self.assertEqual('abc' f'## {x}ghi', 'abc## defghi')
         self.assertEqual('abc' f'{x}' 'ghi', 'abcdefghi')
-        # Skulpt: Format specifiers not yet supported
-        # self.assertEqual('abc' f'{x}' 'gh' f'i{x:4}', 'abcdefghidef ')
+        self.assertEqual('abc' f'{x}' 'gh' f'i{x:4}', 'abcdefghidef ')
         self.assertEqual('{x}' f'{x}', '{x}def')
         self.assertEqual('{x' f'{x}', '{xdef')
         self.assertEqual('{x}' f'{x}', '{x}def')
@@ -490,44 +489,45 @@ class TestCase(unittest.TestCase):
     #     s = "f'{1}' 'x' 'y'" * 1024
     #     self.assertEqual(eval(s), '1xy' * 1024)
 
-    # # Skulpt: Neither common format specifiers nor the decimal module are yet implemented
-    # def test_format_specifier_expressions(self):
-    #     width = 10
-    #     precision = 4
-    #     value = decimal.Decimal('12.34567')
-    #     self.assertEqual(f'result: {value:{width}.{precision}}', 'result:      12.35')
-    #     self.assertEqual(f'result: {value:{width!r}.{precision}}', 'result:      12.35')
-    #     self.assertEqual(f'result: {value:{width:0}.{precision:1}}', 'result:      12.35')
-    #     self.assertEqual(f'result: {value:{1}{0:0}.{precision:1}}', 'result:      12.35')
-    #     self.assertEqual(f'result: {value:{ 1}{ 0:0}.{ precision:1}}', 'result:      12.35')
-    #     self.assertEqual(f'{10:#{1}0x}', '       0xa')
-    #     self.assertEqual(f'{10:{"#"}1{0}{"x"}}', '       0xa')
-    #     self.assertEqual(f'{-10:-{"#"}1{0}x}', '      -0xa')
-    #     self.assertEqual(f'{-10:{"-"}#{1}0{"x"}}', '      -0xa')
-    #     self.assertEqual(f'{10:#{3 != {4:5} and width}x}', '       0xa')
+    def test_format_specifier_expressions(self):
+        width = 10
+        precision = 4
+        # Skulpt: The decimal module is not yet implemented
+        #value = decimal.Decimal('12.34567')
+        value = 12.34567
+        self.assertEqual(f'result: {value:{width}.{precision}}', 'result:      12.35')
+        self.assertEqual(f'result: {value:{width!r}.{precision}}', 'result:      12.35')
+        self.assertEqual(f'result: {value:{width:0}.{precision:1}}', 'result:      12.35')
+        self.assertEqual(f'result: {value:{1}{0:0}.{precision:1}}', 'result:      12.35')
+        self.assertEqual(f'result: {value:{ 1}{ 0:0}.{ precision:1}}', 'result:      12.35')
+        self.assertEqual(f'{10:#{1}0x}', '       0xa')
+        self.assertEqual(f'{10:{"#"}1{0}{"x"}}', '       0xa')
+        self.assertEqual(f'{-10:-{"#"}1{0}x}', '      -0xa')
+        self.assertEqual(f'{-10:{"-"}#{1}0{"x"}}', '      -0xa')
+        self.assertEqual(f'{10:#{3 != {4:5} and width}x}', '       0xa')
 
-    #     # Skulpt: unittest functionality not implemented
-    #     # self.assertAllRaise(SyntaxError, "f-string: expecting '}'",
-    #     #                     ["""f'{"s"!r{":10"}}'""",
+        # Skulpt: unittest functionality not implemented
+        # self.assertAllRaise(SyntaxError, "f-string: expecting '}'",
+        #                     ["""f'{"s"!r{":10"}}'""",
 
-    #     #                      # This looks like a nested format spec.
-    #     #                      ])
+        #                      # This looks like a nested format spec.
+        #                      ])
 
-    #     # self.assertAllRaise(SyntaxError, "invalid syntax",
-    #     #                     [# Invalid syntax inside a nested spec.
-    #     #                      "f'{4:{/5}}'",
-    #     #                      ])
+        # self.assertAllRaise(SyntaxError, "invalid syntax",
+        #                     [# Invalid syntax inside a nested spec.
+        #                      "f'{4:{/5}}'",
+        #                      ])
 
-    #     # self.assertAllRaise(SyntaxError, "f-string: expressions nested too deeply",
-    #     #                     [# Can't nest format specifiers.
-    #     #                      "f'result: {value:{width:{0}}.{precision:1}}'",
-    #     #                      ])
+        # self.assertAllRaise(SyntaxError, "f-string: expressions nested too deeply",
+        #                     [# Can't nest format specifiers.
+        #                      "f'result: {value:{width:{0}}.{precision:1}}'",
+        #                      ])
 
-    #     # self.assertAllRaise(SyntaxError, 'f-string: invalid conversion character',
-    #     #                     [# No expansion inside conversion or for
-    #     #                      #  the : or ! itself.
-    #     #                      """f'{"s"!{"r"}}'""",
-    #     #                      ])
+        # self.assertAllRaise(SyntaxError, 'f-string: invalid conversion character',
+        #                     [# No expansion inside conversion or for
+        #                      #  the : or ! itself.
+        #                      """f'{"s"!{"r"}}'""",
+        #                      ])
 
     def test_side_effect_order(self):
         class X:
@@ -714,9 +714,8 @@ class TestCase(unittest.TestCase):
     def test_lambda(self):
         x = 5
         self.assertEqual(f'{(lambda y:x*y)("8")!r}', "'88888'")
-        # Skulpt: Format strings not yet implemented
-        # self.assertEqual(f'{(lambda y:x*y)("8")!r:10}', "'88888'   ")
-        # self.assertEqual(f'{(lambda y:x*y)("8"):10}', "88888     ")
+        self.assertEqual(f'{(lambda y:x*y)("8")!r:10}', "'88888'   ")
+        self.assertEqual(f'{(lambda y:x*y)("8"):10}', "88888     ")
 
         # Skulpt: unittest functionality not implemented
         # # lambda doesn't work without parens, because the colon
@@ -780,15 +779,14 @@ class TestCase(unittest.TestCase):
         self.assertEqual(outer('987')(), 'x:987')
         self.assertEqual(outer(7)(), 'x:7')
 
-    # Skulpt TODO: Format spec is not yet implemented
-    # def test_arguments(self):
-    #     y = 2
-    #     def f(x, width):
-    #         return f'x={x*y:{width}}'
+    def test_arguments(self):
+        y = 2
+        def f(x, width):
+            return f'x={x*y:{width}}'
 
-    #     self.assertEqual(f('foo', 10), 'x=foofoo    ')
-    #     x = 'bar'
-    #     self.assertEqual(f(10, 10), 'x=        20')
+        self.assertEqual(f('foo', 10), 'x=foofoo    ')
+        x = 'bar'
+        self.assertEqual(f(10, 10), 'x=        20')
 
     def test_locals(self):
         value = 123
@@ -895,42 +893,41 @@ class TestCase(unittest.TestCase):
         self.assertEqual(f'{3!=4}', 'True')
         self.assertEqual(f'{3!=4:}', 'True')
         self.assertEqual(f'{3!=4!s}', 'True')
-        # Skulpt: Format strings not implemented
-        # self.assertEqual(f'{3!=4!s:.3}', 'Tru')
+        self.assertEqual(f'{3!=4!s:.3}', 'Tru')
 
-    # Skulpt: Format specs not yet implemented
-    # def test_conversions(self):
-    #     self.assertEqual(f'{3.14:10.10}', '      3.14')
-    #     self.assertEqual(f'{3.14!s:10.10}', '3.14      ')
-    #     self.assertEqual(f'{3.14!r:10.10}', '3.14      ')
-    #     self.assertEqual(f'{3.14!a:10.10}', '3.14      ')
+    def test_conversions(self):
+        self.assertEqual(f'{3.14:10.10}', '      3.14')
+        self.assertEqual(f'{3.14!s:10.10}', '3.14      ')
+        self.assertEqual(f'{3.14!r:10.10}', '3.14      ')
+        self.assertEqual(f'{3.14!a:10.10}', '3.14      ')
 
-    #     self.assertEqual(f'{"a"}', 'a')
-    #     self.assertEqual(f'{"a"!r}', "'a'")
-    #     self.assertEqual(f'{"a"!a}', "'a'")
+        self.assertEqual(f'{"a"}', 'a')
+        self.assertEqual(f'{"a"!r}', "'a'")
+        self.assertEqual(f'{"a"!a}', "'a'")
 
-    #     # Not a conversion.
-    #     self.assertEqual(f'{"a!r"}', "a!r")
+        # Not a conversion.
+        self.assertEqual(f'{"a!r"}', "a!r")
 
-    #     # Not a conversion, but show that ! is allowed in a format spec.
-    #     self.assertEqual(f'{3.14:!<10.10}', '3.14!!!!!!')
+        # Not a conversion, but show that ! is allowed in a format spec.
+        self.assertEqual(f'{3.14:!<10.10}', '3.14!!!!!!')
 
-    #     self.assertAllRaise(SyntaxError, 'f-string: invalid conversion character',
-    #                         ["f'{3!g}'",
-    #                          "f'{3!A}'",
-    #                          "f'{3!3}'",
-    #                          "f'{3!G}'",
-    #                          "f'{3!!}'",
-    #                          "f'{3!:}'",
-    #                          "f'{3! s}'",  # no space before conversion char
-    #                          ])
+        # Skulpt: unittest functionality not yet implemented
+        # self.assertAllRaise(SyntaxError, 'f-string: invalid conversion character',
+        #                     ["f'{3!g}'",
+        #                      "f'{3!A}'",
+        #                      "f'{3!3}'",
+        #                      "f'{3!G}'",
+        #                      "f'{3!!}'",
+        #                      "f'{3!:}'",
+        #                      "f'{3! s}'",  # no space before conversion char
+        #                      ])
 
-    #     self.assertAllRaise(SyntaxError, "f-string: expecting '}'",
-    #                         ["f'{x!s{y}}'",
-    #                          "f'{3!ss}'",
-    #                          "f'{3!ss:}'",
-    #                          "f'{3!ss:s}'",
-    #                          ])
+        # self.assertAllRaise(SyntaxError, "f-string: expecting '}'",
+        #                     ["f'{x!s{y}}'",
+        #                      "f'{3!ss}'",
+        #                      "f'{3!ss:}'",
+        #                      "f'{3!ss:s}'",
+        #                      ])
 
     # Skulpt: This unittest functionality (and, indeed, eval()) is not yet implemented
     # def test_assignment(self):
@@ -981,9 +978,8 @@ class TestCase(unittest.TestCase):
         # But these are just normal strings.
         self.assertEqual(f'{"{"}', '{')
         self.assertEqual(f'{"}"}', '}')
-        # Skulpt: Format strings not implemented
-        # self.assertEqual(f'{3:{"}"}>10}', '}}}}}}}}}3')
-        # self.assertEqual(f'{2:{"{"}>10}', '{{{{{{{{{2')
+        self.assertEqual(f'{3:{"}"}>10}', '}}}}}}}}}3')
+        self.assertEqual(f'{2:{"{"}>10}', '{{{{{{{{{2')
 
     def test_if_conditional(self):
         # There's special logic in compile.c to test if the
@@ -1039,8 +1035,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(f'{d["a"]}', 'string')
         self.assertEqual(f'{d[a]}', 'integer')
         self.assertEqual('{d[a]}'.format(d=d), 'string')
-        # Skulpt: .format() is broken with regard to integers
-        # self.assertEqual('{d[0]}'.format(d=d), 'integer')
+        self.assertEqual('{d[0]}'.format(d=d), 'integer')
 
     # Skulpt: unittest functionality not implemented
     # def test_invalid_expressions(self):

--- a/test/unit3/test_fstring.py
+++ b/test/unit3/test_fstring.py
@@ -664,14 +664,6 @@ class TestCase(unittest.TestCase):
         # self.assertEqual(f'\\N{AMPERSAND}', '\\Nspam')
         # self.assertEqual(fr'\N{AMPERSAND}', '\\Nspam')
         # self.assertEqual(f'\\\N{AMPERSAND}', '\\&')
-
-        # Skulpt: This will be easier to fix after PR#983 lands
-        # (This is a Skulpt-compatible version of the test above)
-        # AMPERSAND = '26'
-        # self.assertEqual(f'\x{AMPERSAND}', '&')
-        # self.assertEqual(f'\\x{AMPERSAND}', '\\x26')
-        # self.assertEqual(fr'\x{AMPERSAND}', '\\x26')
-        # self.assertEqual(f'\\\x{AMPERSAND}', '\\&')
                 
 
     # Skulpt: \N escapes (named Unicode chars) not implemented

--- a/test/unit3/test_fstring.py
+++ b/test/unit3/test_fstring.py
@@ -1,0 +1,1095 @@
+# These tests are taken from Python 3.7:
+# https://raw.githubusercontent.com/python/cpython/3.7/Lib/test/test_fstring.py
+
+# The AST module is not yet implemeted in Skulpt
+# import ast
+import types
+# The decimal module is not yet implemented in Skulpt
+#import decimal
+import unittest
+
+a_global = 'global variable'
+
+# You could argue that I'm too strict in looking for specific error
+#  values with assertRaisesRegex, but without it it's way too easy to
+#  make a syntax error in the test strings. Especially with all of the
+#  triple quotes, raw strings, backslashes, etc. I think it's a
+#  worthwhile tradeoff. When I switched to this method, I found many
+#  examples where I wasn't testing what I thought I was.
+
+class TestCase(unittest.TestCase):
+    def assertAllRaise(self, exception_type, regex, error_strings):
+        for str in error_strings:
+            with self.subTest(str=str):
+                with self.assertRaisesRegex(exception_type, regex):
+                    eval(str)
+
+
+    # Skulpt TODO: We look up __format__ on the instance, not the type,
+    # and instantiating types.MethodType() doesn't work properly.
+    #
+    # def test__format__lookup(self):
+    #     # Make sure __format__ is looked up on the type, not the instance.
+    #     class X:
+    #         def __format__(self, spec):
+    #             return 'class'
+
+    #     x = X()
+
+    #     # Add a bound __format__ method to the 'y' instance, but not
+    #     #  the 'x' instance.
+    #     y = X()
+    #     y.__format__ = types.MethodType(lambda self, spec: 'instance', y)
+
+    #     self.assertEqual(f'{y}', format(y))
+    #     self.assertEqual(f'{y}', 'class')
+    #     self.assertEqual(format(x), format(y))
+
+    #     # __format__ is not called this way, but still make sure it
+    #     #  returns what we expect (so we can make sure we're bypassing
+    #     #  it).
+    #     self.assertEqual(x.__format__(''), 'class')
+    #     self.assertEqual(y.__format__(''), 'instance')
+
+    #     # This is how __format__ is actually called.
+    #     self.assertEqual(type(x).__format__(x, ''), 'class')
+    #     self.assertEqual(type(y).__format__(y, ''), 'class')
+
+
+# Skulpt does not yet support the 'ast' module
+#     def test_ast(self):
+#         # Inspired by http://bugs.python.org/issue24975
+#         class X:
+#             def __init__(self):
+#                 self.called = False
+#             def __call__(self):
+#                 self.called = True
+#                 return 4
+#         x = X()
+#         expr = """
+# a = 10
+# f'{a * x()}'"""
+#         t = ast.parse(expr)
+#         c = compile(t, '', 'exec')
+
+#         # Make sure x was not called.
+#         self.assertFalse(x.called)
+
+#         # Actually run the code.
+#         exec(c)
+
+#         # Make sure x was called.
+#         self.assertTrue(x.called)
+
+#     def test_ast_line_numbers(self):
+#         expr = """
+# a = 10
+# f'{a * x()}'"""
+#         t = ast.parse(expr)
+#         self.assertEqual(type(t), ast.Module)
+#         self.assertEqual(len(t.body), 2)
+#         # check `a = 10`
+#         self.assertEqual(type(t.body[0]), ast.Assign)
+#         self.assertEqual(t.body[0].lineno, 2)
+#         # check `f'...'`
+#         self.assertEqual(type(t.body[1]), ast.Expr)
+#         self.assertEqual(type(t.body[1].value), ast.JoinedStr)
+#         self.assertEqual(len(t.body[1].value.values), 1)
+#         self.assertEqual(type(t.body[1].value.values[0]), ast.FormattedValue)
+#         self.assertEqual(t.body[1].lineno, 3)
+#         self.assertEqual(t.body[1].value.lineno, 3)
+#         self.assertEqual(t.body[1].value.values[0].lineno, 3)
+#         # check the binop location
+#         binop = t.body[1].value.values[0].value
+#         self.assertEqual(type(binop), ast.BinOp)
+#         self.assertEqual(type(binop.left), ast.Name)
+#         self.assertEqual(type(binop.op), ast.Mult)
+#         self.assertEqual(type(binop.right), ast.Call)
+#         self.assertEqual(binop.lineno, 3)
+#         self.assertEqual(binop.left.lineno, 3)
+#         self.assertEqual(binop.right.lineno, 3)
+#         self.assertEqual(binop.col_offset, 3)
+#         self.assertEqual(binop.left.col_offset, 3)
+#         self.assertEqual(binop.right.col_offset, 7)
+
+#     def test_ast_line_numbers_multiple_formattedvalues(self):
+#         expr = """
+# f'no formatted values'
+# f'eggs {a * x()} spam {b + y()}'"""
+#         t = ast.parse(expr)
+#         self.assertEqual(type(t), ast.Module)
+#         self.assertEqual(len(t.body), 2)
+#         # check `f'no formatted value'`
+#         self.assertEqual(type(t.body[0]), ast.Expr)
+#         self.assertEqual(type(t.body[0].value), ast.JoinedStr)
+#         self.assertEqual(t.body[0].lineno, 2)
+#         # check `f'...'`
+#         self.assertEqual(type(t.body[1]), ast.Expr)
+#         self.assertEqual(type(t.body[1].value), ast.JoinedStr)
+#         self.assertEqual(len(t.body[1].value.values), 4)
+#         self.assertEqual(type(t.body[1].value.values[0]), ast.Str)
+#         self.assertEqual(type(t.body[1].value.values[1]), ast.FormattedValue)
+#         self.assertEqual(type(t.body[1].value.values[2]), ast.Str)
+#         self.assertEqual(type(t.body[1].value.values[3]), ast.FormattedValue)
+#         self.assertEqual(t.body[1].lineno, 3)
+#         self.assertEqual(t.body[1].value.lineno, 3)
+#         self.assertEqual(t.body[1].value.values[0].lineno, 3)
+#         self.assertEqual(t.body[1].value.values[1].lineno, 3)
+#         self.assertEqual(t.body[1].value.values[2].lineno, 3)
+#         self.assertEqual(t.body[1].value.values[3].lineno, 3)
+#         # check the first binop location
+#         binop1 = t.body[1].value.values[1].value
+#         self.assertEqual(type(binop1), ast.BinOp)
+#         self.assertEqual(type(binop1.left), ast.Name)
+#         self.assertEqual(type(binop1.op), ast.Mult)
+#         self.assertEqual(type(binop1.right), ast.Call)
+#         self.assertEqual(binop1.lineno, 3)
+#         self.assertEqual(binop1.left.lineno, 3)
+#         self.assertEqual(binop1.right.lineno, 3)
+#         self.assertEqual(binop1.col_offset, 8)
+#         self.assertEqual(binop1.left.col_offset, 8)
+#         self.assertEqual(binop1.right.col_offset, 12)
+#         # check the second binop location
+#         binop2 = t.body[1].value.values[3].value
+#         self.assertEqual(type(binop2), ast.BinOp)
+#         self.assertEqual(type(binop2.left), ast.Name)
+#         self.assertEqual(type(binop2.op), ast.Add)
+#         self.assertEqual(type(binop2.right), ast.Call)
+#         self.assertEqual(binop2.lineno, 3)
+#         self.assertEqual(binop2.left.lineno, 3)
+#         self.assertEqual(binop2.right.lineno, 3)
+#         self.assertEqual(binop2.col_offset, 23)
+#         self.assertEqual(binop2.left.col_offset, 23)
+#         self.assertEqual(binop2.right.col_offset, 27)
+
+#     def test_ast_line_numbers_nested(self):
+#         expr = """
+# a = 10
+# f'{a * f"-{x()}-"}'"""
+#         t = ast.parse(expr)
+#         self.assertEqual(type(t), ast.Module)
+#         self.assertEqual(len(t.body), 2)
+#         # check `a = 10`
+#         self.assertEqual(type(t.body[0]), ast.Assign)
+#         self.assertEqual(t.body[0].lineno, 2)
+#         # check `f'...'`
+#         self.assertEqual(type(t.body[1]), ast.Expr)
+#         self.assertEqual(type(t.body[1].value), ast.JoinedStr)
+#         self.assertEqual(len(t.body[1].value.values), 1)
+#         self.assertEqual(type(t.body[1].value.values[0]), ast.FormattedValue)
+#         self.assertEqual(t.body[1].lineno, 3)
+#         self.assertEqual(t.body[1].value.lineno, 3)
+#         self.assertEqual(t.body[1].value.values[0].lineno, 3)
+#         # check the binop location
+#         binop = t.body[1].value.values[0].value
+#         self.assertEqual(type(binop), ast.BinOp)
+#         self.assertEqual(type(binop.left), ast.Name)
+#         self.assertEqual(type(binop.op), ast.Mult)
+#         self.assertEqual(type(binop.right), ast.JoinedStr)
+#         self.assertEqual(binop.lineno, 3)
+#         self.assertEqual(binop.left.lineno, 3)
+#         self.assertEqual(binop.right.lineno, 3)
+#         self.assertEqual(binop.col_offset, 3)
+#         self.assertEqual(binop.left.col_offset, 3)
+#         self.assertEqual(binop.right.col_offset, 7)
+#         # check the nested call location
+#         self.assertEqual(len(binop.right.values), 3)
+#         self.assertEqual(type(binop.right.values[0]), ast.Str)
+#         self.assertEqual(type(binop.right.values[1]), ast.FormattedValue)
+#         self.assertEqual(type(binop.right.values[2]), ast.Str)
+#         self.assertEqual(binop.right.values[0].lineno, 3)
+#         self.assertEqual(binop.right.values[1].lineno, 3)
+#         self.assertEqual(binop.right.values[2].lineno, 3)
+#         call = binop.right.values[1].value
+#         self.assertEqual(type(call), ast.Call)
+#         self.assertEqual(call.lineno, 3)
+#         self.assertEqual(call.col_offset, 11)
+
+#     def test_ast_line_numbers_duplicate_expression(self):
+#         """Duplicate expression
+
+#         NOTE: this is currently broken, always sets location of the first
+#         expression.
+#         """
+#         expr = """
+# a = 10
+# f'{a * x()} {a * x()} {a * x()}'
+# """
+#         t = ast.parse(expr)
+#         self.assertEqual(type(t), ast.Module)
+#         self.assertEqual(len(t.body), 2)
+#         # check `a = 10`
+#         self.assertEqual(type(t.body[0]), ast.Assign)
+#         self.assertEqual(t.body[0].lineno, 2)
+#         # check `f'...'`
+#         self.assertEqual(type(t.body[1]), ast.Expr)
+#         self.assertEqual(type(t.body[1].value), ast.JoinedStr)
+#         self.assertEqual(len(t.body[1].value.values), 5)
+#         self.assertEqual(type(t.body[1].value.values[0]), ast.FormattedValue)
+#         self.assertEqual(type(t.body[1].value.values[1]), ast.Str)
+#         self.assertEqual(type(t.body[1].value.values[2]), ast.FormattedValue)
+#         self.assertEqual(type(t.body[1].value.values[3]), ast.Str)
+#         self.assertEqual(type(t.body[1].value.values[4]), ast.FormattedValue)
+#         self.assertEqual(t.body[1].lineno, 3)
+#         self.assertEqual(t.body[1].value.lineno, 3)
+#         self.assertEqual(t.body[1].value.values[0].lineno, 3)
+#         self.assertEqual(t.body[1].value.values[1].lineno, 3)
+#         self.assertEqual(t.body[1].value.values[2].lineno, 3)
+#         self.assertEqual(t.body[1].value.values[3].lineno, 3)
+#         self.assertEqual(t.body[1].value.values[4].lineno, 3)
+#         # check the first binop location
+#         binop = t.body[1].value.values[0].value
+#         self.assertEqual(type(binop), ast.BinOp)
+#         self.assertEqual(type(binop.left), ast.Name)
+#         self.assertEqual(type(binop.op), ast.Mult)
+#         self.assertEqual(type(binop.right), ast.Call)
+#         self.assertEqual(binop.lineno, 3)
+#         self.assertEqual(binop.left.lineno, 3)
+#         self.assertEqual(binop.right.lineno, 3)
+#         self.assertEqual(binop.col_offset, 3)
+#         self.assertEqual(binop.left.col_offset, 3)
+#         self.assertEqual(binop.right.col_offset, 7)
+#         # check the second binop location
+#         binop = t.body[1].value.values[2].value
+#         self.assertEqual(type(binop), ast.BinOp)
+#         self.assertEqual(type(binop.left), ast.Name)
+#         self.assertEqual(type(binop.op), ast.Mult)
+#         self.assertEqual(type(binop.right), ast.Call)
+#         self.assertEqual(binop.lineno, 3)
+#         self.assertEqual(binop.left.lineno, 3)
+#         self.assertEqual(binop.right.lineno, 3)
+#         self.assertEqual(binop.col_offset, 3)  # FIXME: this is wrong
+#         self.assertEqual(binop.left.col_offset, 3)  # FIXME: this is wrong
+#         self.assertEqual(binop.right.col_offset, 7)  # FIXME: this is wrong
+#         # check the third binop location
+#         binop = t.body[1].value.values[4].value
+#         self.assertEqual(type(binop), ast.BinOp)
+#         self.assertEqual(type(binop.left), ast.Name)
+#         self.assertEqual(type(binop.op), ast.Mult)
+#         self.assertEqual(type(binop.right), ast.Call)
+#         self.assertEqual(binop.lineno, 3)
+#         self.assertEqual(binop.left.lineno, 3)
+#         self.assertEqual(binop.right.lineno, 3)
+#         self.assertEqual(binop.col_offset, 3)  # FIXME: this is wrong
+#         self.assertEqual(binop.left.col_offset, 3)  # FIXME: this is wrong
+#         self.assertEqual(binop.right.col_offset, 7)  # FIXME: this is wrong
+
+#     def test_ast_line_numbers_multiline_fstring(self):
+#         # FIXME: This test demonstrates invalid behavior due to JoinedStr's
+#         # immediate child nodes containing the wrong lineno.  The enclosed
+#         # expressions have valid line information and column offsets.
+#         # See bpo-16806 and bpo-30465 for details.
+#         expr = """
+# a = 10
+# f'''
+#   {a
+#      *
+#        x()}
+# non-important content
+# '''
+# """
+#         t = ast.parse(expr)
+#         self.assertEqual(type(t), ast.Module)
+#         self.assertEqual(len(t.body), 2)
+#         # check `a = 10`
+#         self.assertEqual(type(t.body[0]), ast.Assign)
+#         self.assertEqual(t.body[0].lineno, 2)
+#         # check `f'...'`
+#         self.assertEqual(type(t.body[1]), ast.Expr)
+#         self.assertEqual(type(t.body[1].value), ast.JoinedStr)
+#         self.assertEqual(len(t.body[1].value.values), 3)
+#         self.assertEqual(type(t.body[1].value.values[0]), ast.Str)
+#         self.assertEqual(type(t.body[1].value.values[1]), ast.FormattedValue)
+#         self.assertEqual(type(t.body[1].value.values[2]), ast.Str)
+#         # NOTE: the following invalid behavior is described in bpo-16806.
+#         # - line number should be the *first* line (3), not the *last* (8)
+#         # - column offset should not be -1
+#         self.assertEqual(t.body[1].lineno, 8)
+#         self.assertEqual(t.body[1].value.lineno, 8)
+#         self.assertEqual(t.body[1].value.values[0].lineno, 8)
+#         self.assertEqual(t.body[1].value.values[1].lineno, 8)
+#         self.assertEqual(t.body[1].value.values[2].lineno, 8)
+#         self.assertEqual(t.body[1].col_offset, -1)
+#         self.assertEqual(t.body[1].value.col_offset, -1)
+#         self.assertEqual(t.body[1].value.values[0].col_offset, -1)
+#         self.assertEqual(t.body[1].value.values[1].col_offset, -1)
+#         self.assertEqual(t.body[1].value.values[2].col_offset, -1)
+#         # NOTE: the following lineno information and col_offset is correct for
+#         # expressions within FormattedValues.
+#         binop = t.body[1].value.values[1].value
+#         self.assertEqual(type(binop), ast.BinOp)
+#         self.assertEqual(type(binop.left), ast.Name)
+#         self.assertEqual(type(binop.op), ast.Mult)
+#         self.assertEqual(type(binop.right), ast.Call)
+#         self.assertEqual(binop.lineno, 4)
+#         self.assertEqual(binop.left.lineno, 4)
+#         self.assertEqual(binop.right.lineno, 6)
+#         self.assertEqual(binop.col_offset, 3)
+#         self.assertEqual(binop.left.col_offset, 3)
+#         self.assertEqual(binop.right.col_offset, 7)
+
+    # Skulpt: __doc__ attribute not implemented
+    # def test_docstring(self):
+    #     def f():
+    #         f'''Not a docstring'''
+    #     self.assertIsNone(f.__doc__)
+    #     def g():
+    #         '''Not a docstring''' \
+    #         f''
+    #     self.assertIsNone(g.__doc__)
+
+
+    # Skulpt: ast module not yet implemented
+    # def test_literal_eval(self):
+    #     with self.assertRaisesRegex(ValueError, 'malformed node or string'):
+    #         ast.literal_eval("f'x'")
+
+    # def test_ast_compile_time_concat(self):
+    #     x = ['']
+
+    #     expr = """x[0] = 'foo' f'{3}'"""
+    #     t = ast.parse(expr)
+    #     c = compile(t, '', 'exec')
+    #     exec(c)
+    #     self.assertEqual(x[0], 'foo3')
+
+    # Skulpt: unittest functionality not yet implemented
+    # def test_compile_time_concat_errors(self):
+    #     self.assertAllRaise(SyntaxError,
+    #                         'cannot mix bytes and nonbytes literals',
+    #                         [r"""f'' b''""",
+    #                          r"""b'' f''""",
+    #                          ])
+
+    def test_literal(self):
+        self.assertEqual(f'', '')
+        self.assertEqual(f'a', 'a')
+        self.assertEqual(f' ', ' ')
+
+    # Skulpt: unittest functionality not yet implemented
+    # def test_unterminated_string(self):
+    #     self.assertAllRaise(SyntaxError, 'f-string: unterminated string',
+    #                         [r"""f'{"x'""",
+    #                          r"""f'{"x}'""",
+    #                          r"""f'{("x'""",
+    #                          r"""f'{("x}'""",
+    #                          ])
+
+    # def test_mismatched_parens(self):
+    #     self.assertAllRaise(SyntaxError, 'f-string: mismatched',
+    #                         ["f'{((}'",
+    #                          ])
+
+    def test_double_braces(self):
+        self.assertEqual(f'{{', '{')
+        self.assertEqual(f'a{{', 'a{')
+        self.assertEqual(f'{{b', '{b')
+        self.assertEqual(f'a{{b', 'a{b')
+        self.assertEqual(f'}}', '}')
+        self.assertEqual(f'a}}', 'a}')
+        self.assertEqual(f'}}b', '}b')
+        self.assertEqual(f'a}}b', 'a}b')
+        self.assertEqual(f'{{}}', '{}')
+        self.assertEqual(f'a{{}}', 'a{}')
+        self.assertEqual(f'{{b}}', '{b}')
+        self.assertEqual(f'{{}}c', '{}c')
+        self.assertEqual(f'a{{b}}', 'a{b}')
+        self.assertEqual(f'a{{}}c', 'a{}c')
+        self.assertEqual(f'{{b}}c', '{b}c')
+        self.assertEqual(f'a{{b}}c', 'a{b}c')
+
+        self.assertEqual(f'{{{10}', '{10')
+        self.assertEqual(f'}}{10}', '}10')
+        self.assertEqual(f'}}{{{10}', '}{10')
+        self.assertEqual(f'}}a{{{10}', '}a{10')
+
+        self.assertEqual(f'{10}{{', '10{')
+        self.assertEqual(f'{10}}}', '10}')
+        self.assertEqual(f'{10}}}{{', '10}{')
+        self.assertEqual(f'{10}}}a{{' '}', '10}a{}')
+
+        # Inside of strings, don't interpret doubled brackets.
+        self.assertEqual(f'{"{{}}"}', '{{}}')
+
+        # Skulpt: unittest functionality not implemented
+        # self.assertAllRaise(TypeError, 'unhashable type',
+        #                     ["f'{ {{}} }'", # dict in a set
+        #                      ])
+
+    def test_compile_time_concat(self):
+        x = 'def'
+        self.assertEqual('abc' f'## {x}ghi', 'abc## defghi')
+        self.assertEqual('abc' f'{x}' 'ghi', 'abcdefghi')
+        # Skulpt: Format specifiers not yet supported
+        # self.assertEqual('abc' f'{x}' 'gh' f'i{x:4}', 'abcdefghidef ')
+        self.assertEqual('{x}' f'{x}', '{x}def')
+        self.assertEqual('{x' f'{x}', '{xdef')
+        self.assertEqual('{x}' f'{x}', '{x}def')
+        self.assertEqual('{{x}}' f'{x}', '{{x}}def')
+        self.assertEqual('{{x' f'{x}', '{{xdef')
+        self.assertEqual('x}}' f'{x}', 'x}}def')
+        self.assertEqual(f'{x}' 'x}}', 'defx}}')
+        self.assertEqual(f'{x}' '', 'def')
+        self.assertEqual('' f'{x}' '', 'def')
+        self.assertEqual('' f'{x}', 'def')
+        self.assertEqual(f'{x}' '2', 'def2')
+        self.assertEqual('1' f'{x}' '2', '1def2')
+        self.assertEqual('1' f'{x}', '1def')
+        self.assertEqual(f'{x}' f'-{x}', 'def-def')
+        self.assertEqual('' f'', '')
+        self.assertEqual('' f'' '', '')
+        self.assertEqual('' f'' '' f'', '')
+        self.assertEqual(f'', '')
+        self.assertEqual(f'' '', '')
+        self.assertEqual(f'' '' f'', '')
+        self.assertEqual(f'' '' f'' '', '')
+
+        # Skulpt: This unittest functionality isn't implemented
+        # self.assertAllRaise(SyntaxError, "f-string: expecting '}'",
+        #                     ["f'{3' f'}'",  # can't concat to get a valid f-string
+        #                      ])
+
+    def test_comments(self):
+        # These aren't comments, since they're in strings.
+        d = {'#': 'hash'}
+        self.assertEqual(f'{"#"}', '#')
+        self.assertEqual(f'{d["#"]}', 'hash')
+
+        # Skulpt: This unittest functionality isn't implemented
+        # self.assertAllRaise(SyntaxError, "f-string expression part cannot include '#'",
+        #                     ["f'{1#}'",   # error because the expression becomes "(1#)"
+        #                      "f'{3(#)}'",
+        #                      "f'{#}'",
+        #                      "f'{)#}'",   # When wrapped in parens, this becomes
+        #                                   #  '()#)'.  Make sure that doesn't compile.
+        #                      ])
+
+    # Skulpt: "eval" not implemented
+    # def test_many_expressions(self):
+    #     # Create a string with many expressions in it. Note that
+    #     #  because we have a space in here as a literal, we're actually
+    #     #  going to use twice as many ast nodes: one for each literal
+    #     #  plus one for each expression.
+    #     def build_fstr(n, extra=''):
+    #         return "f'" + ('{x} ' * n) + extra + "'"
+
+    #     x = 'X'
+    #     width = 1
+
+    #     # Test around 256.
+    #     for i in range(250, 260):
+    #         self.assertEqual(eval(build_fstr(i)), (x+' ')*i)
+
+    #     # Test concatenating 2 largs fstrings.
+    #     self.assertEqual(eval(build_fstr(255)*256), (x+' ')*(255*256))
+
+    #     s = build_fstr(253, '{x:{width}} ')
+    #     self.assertEqual(eval(s), (x+' ')*254)
+
+    #     # Test lots of expressions and constants, concatenated.
+    #     s = "f'{1}' 'x' 'y'" * 1024
+    #     self.assertEqual(eval(s), '1xy' * 1024)
+
+    # # Skulpt: Neither common format specifiers nor the decimal module are yet implemented
+    # def test_format_specifier_expressions(self):
+    #     width = 10
+    #     precision = 4
+    #     value = decimal.Decimal('12.34567')
+    #     self.assertEqual(f'result: {value:{width}.{precision}}', 'result:      12.35')
+    #     self.assertEqual(f'result: {value:{width!r}.{precision}}', 'result:      12.35')
+    #     self.assertEqual(f'result: {value:{width:0}.{precision:1}}', 'result:      12.35')
+    #     self.assertEqual(f'result: {value:{1}{0:0}.{precision:1}}', 'result:      12.35')
+    #     self.assertEqual(f'result: {value:{ 1}{ 0:0}.{ precision:1}}', 'result:      12.35')
+    #     self.assertEqual(f'{10:#{1}0x}', '       0xa')
+    #     self.assertEqual(f'{10:{"#"}1{0}{"x"}}', '       0xa')
+    #     self.assertEqual(f'{-10:-{"#"}1{0}x}', '      -0xa')
+    #     self.assertEqual(f'{-10:{"-"}#{1}0{"x"}}', '      -0xa')
+    #     self.assertEqual(f'{10:#{3 != {4:5} and width}x}', '       0xa')
+
+    #     # Skulpt: unittest functionality not implemented
+    #     # self.assertAllRaise(SyntaxError, "f-string: expecting '}'",
+    #     #                     ["""f'{"s"!r{":10"}}'""",
+
+    #     #                      # This looks like a nested format spec.
+    #     #                      ])
+
+    #     # self.assertAllRaise(SyntaxError, "invalid syntax",
+    #     #                     [# Invalid syntax inside a nested spec.
+    #     #                      "f'{4:{/5}}'",
+    #     #                      ])
+
+    #     # self.assertAllRaise(SyntaxError, "f-string: expressions nested too deeply",
+    #     #                     [# Can't nest format specifiers.
+    #     #                      "f'result: {value:{width:{0}}.{precision:1}}'",
+    #     #                      ])
+
+    #     # self.assertAllRaise(SyntaxError, 'f-string: invalid conversion character',
+    #     #                     [# No expansion inside conversion or for
+    #     #                      #  the : or ! itself.
+    #     #                      """f'{"s"!{"r"}}'""",
+    #     #                      ])
+
+    def test_side_effect_order(self):
+        class X:
+            def __init__(self):
+                self.i = 0
+            def __format__(self, spec):
+                self.i += 1
+                return str(self.i)
+
+        x = X()
+        self.assertEqual(f'{x} {x}', '1 2')
+
+    # Skulpt: unittest functionality not implemented
+    # def test_missing_expression(self):
+    #     self.assertAllRaise(SyntaxError, 'f-string: empty expression not allowed',
+    #                         ["f'{}'",
+    #                          "f'{ }'"
+    #                          "f' {} '",
+    #                          "f'{!r}'",
+    #                          "f'{ !r}'",
+    #                          "f'{10:{ }}'",
+    #                          "f' { } '",
+
+    #                          # The Python parser ignores also the following
+    #                          # whitespace characters in additional to a space.
+    #                          "f'''{\t\f\r\n}'''",
+
+    #                          # Catch the empty expression before the
+    #                          #  invalid conversion.
+    #                          "f'{!x}'",
+    #                          "f'{ !xr}'",
+    #                          "f'{!x:}'",
+    #                          "f'{!x:a}'",
+    #                          "f'{ !xr:}'",
+    #                          "f'{ !xr:a}'",
+
+    #                          "f'{!}'",
+    #                          "f'{:}'",
+
+    #                          # We find the empty expression before the
+    #                          #  missing closing brace.
+    #                          "f'{!'",
+    #                          "f'{!s:'",
+    #                          "f'{:'",
+    #                          "f'{:x'",
+    #                          ])
+
+    #     # Different error message is raised for other whitespace characters.
+    #     self.assertAllRaise(SyntaxError, 'invalid character in identifier',
+    #                         ["f'''{\xa0}'''",
+    #                          "\xa0",
+    #                          ])
+
+    def test_parens_in_expressions(self):
+        self.assertEqual(f'{3,}', '(3,)')
+
+        # Skulpt: unittest functionality not implemented
+
+        # # Add these because when an expression is evaluated, parens
+        # #  are added around it. But we shouldn't go from an invalid
+        # #  expression to a valid one. The added parens are just
+        # #  supposed to allow whitespace (including newlines).
+        # self.assertAllRaise(SyntaxError, 'invalid syntax',
+        #                     ["f'{,}'",
+        #                      "f'{,}'",  # this is (,), which is an error
+        #                      ])
+
+        # self.assertAllRaise(SyntaxError, "f-string: expecting '}'",
+        #                     ["f'{3)+(4}'",
+        #                      ])
+
+        # self.assertAllRaise(SyntaxError, 'EOL while scanning string literal',
+        #                     ["f'{\n}'",
+        #                      ])
+
+    def test_backslashes_in_string_part(self):
+        self.assertEqual(f'\t', '\t')
+        self.assertEqual(r'\t', '\\t')
+        self.assertEqual(rf'\t', '\\t')
+        self.assertEqual(f'{2}\t', '2\t')
+        self.assertEqual(f'{2}\t{3}', '2\t3')
+        self.assertEqual(f'\t{3}', '\t3')
+
+        # Skulpt TODO: These will work after PR#983 (real unicode strings) lands
+        # self.assertEqual(f'\u0394', '\u0394')
+        # self.assertEqual(r'\u0394', '\\u0394')
+        # self.assertEqual(rf'\u0394', '\\u0394')
+        # self.assertEqual(f'{2}\u0394', '2\u0394')
+        # self.assertEqual(f'{2}\u0394{3}', '2\u03943')
+        # self.assertEqual(f'\u0394{3}', '\u03943')
+
+        # self.assertEqual(f'\U00000394', '\u0394')
+        # self.assertEqual(r'\U00000394', '\\U00000394')
+        # self.assertEqual(rf'\U00000394', '\\U00000394')
+        # self.assertEqual(f'{2}\U00000394', '2\u0394')
+        # self.assertEqual(f'{2}\U00000394{3}', '2\u03943')
+        # self.assertEqual(f'\U00000394{3}', '\u03943')
+
+        # Skulpt doesn't support \N{} escapes, because we don't bundle the
+        # Unicode database
+        #
+        # self.assertEqual(f'\N{GREEK CAPITAL LETTER DELTA}', '\u0394')
+        # self.assertEqual(f'{2}\N{GREEK CAPITAL LETTER DELTA}', '2\u0394')
+        # self.assertEqual(f'{2}\N{GREEK CAPITAL LETTER DELTA}{3}', '2\u03943')
+        # self.assertEqual(f'\N{GREEK CAPITAL LETTER DELTA}{3}', '\u03943')
+        # self.assertEqual(f'2\N{GREEK CAPITAL LETTER DELTA}', '2\u0394')
+        # self.assertEqual(f'2\N{GREEK CAPITAL LETTER DELTA}3', '2\u03943')
+        # self.assertEqual(f'\N{GREEK CAPITAL LETTER DELTA}3', '\u03943')
+
+        self.assertEqual(f'\x20', ' ')
+        self.assertEqual(r'\x20', '\\x20')
+        self.assertEqual(rf'\x20', '\\x20')
+        self.assertEqual(f'{2}\x20', '2 ')
+        self.assertEqual(f'{2}\x20{3}', '2 3')
+        self.assertEqual(f'\x20{3}', ' 3')
+
+        self.assertEqual(f'2\x20', '2 ')
+        self.assertEqual(f'2\x203', '2 3')
+        self.assertEqual(f'\x203', ' 3')
+
+        # Skulpt: This warning, and all warnings, are not implemented
+        # with self.assertWarns(DeprecationWarning):  # invalid escape sequence
+        #     value = eval(r"f'\{6*7}'")
+        value = f'\{6*7}'
+        self.assertEqual(value, '\\42')
+        self.assertEqual(f'\\{6*7}', '\\42')
+        self.assertEqual(fr'\{6*7}', '\\42')
+
+        # Skulpt: \N escapes (named Unicode chars) not supported 
+        # AMPERSAND = 'spam'
+        # # Get the right unicode character (&), or pick up local variable
+        # # depending on the number of backslashes.
+        # self.assertEqual(f'\N{AMPERSAND}', '&')
+        # self.assertEqual(f'\\N{AMPERSAND}', '\\Nspam')
+        # self.assertEqual(fr'\N{AMPERSAND}', '\\Nspam')
+        # self.assertEqual(f'\\\N{AMPERSAND}', '\\&')
+
+        # Skulpt: This will be easier to fix after PR#983 lands
+        # (This is a Skulpt-compatible version of the test above)
+        # AMPERSAND = '26'
+        # self.assertEqual(f'\x{AMPERSAND}', '&')
+        # self.assertEqual(f'\\x{AMPERSAND}', '\\x26')
+        # self.assertEqual(fr'\x{AMPERSAND}', '\\x26')
+        # self.assertEqual(f'\\\x{AMPERSAND}', '\\&')
+                
+
+    # Skulpt: \N escapes (named Unicode chars) not implemented
+    # def test_misformed_unicode_character_name(self):
+    #     # These test are needed because unicode names are parsed
+    #     # differently inside f-strings.
+    #     self.assertAllRaise(SyntaxError, r"\(unicode error\) 'unicodeescape' codec can't decode bytes in position .*: malformed \\N character escape",
+    #                         [r"f'\N'",
+    #                          r"f'\N{'",
+    #                          r"f'\N{GREEK CAPITAL LETTER DELTA'",
+
+    #                          # Here are the non-f-string versions,
+    #                          #  which should give the same errors.
+    #                          r"'\N'",
+    #                          r"'\N{'",
+    #                          r"'\N{GREEK CAPITAL LETTER DELTA'",
+    #                          ])
+
+    # Skulpt: unittest functionality not implemented
+    # def test_no_backslashes_in_expression_part(self):
+    #     self.assertAllRaise(SyntaxError, 'f-string expression part cannot include a backslash',
+    #                         [r"f'{\'a\'}'",
+    #                          r"f'{\t3}'",
+    #                          r"f'{\}'",
+    #                          r"rf'{\'a\'}'",
+    #                          r"rf'{\t3}'",
+    #                          r"rf'{\}'",
+    #                          r"""rf'{"\N{LEFT CURLY BRACKET}"}'""",
+    #                          r"f'{\n}'",
+    #                          ])
+
+    # TODO fixing this will be much easier once we merge PR#983
+    # def test_no_escapes_for_braces(self):
+    #     """
+    #     Only literal curly braces begin an expression.
+    #     """
+    #     # \x7b is '{'.
+    #     self.assertEqual(f'\x7b1+1}}', '{1+1}')
+    #     self.assertEqual(f'\x7b1+1', '{1+1')
+    #     self.assertEqual(f'\u007b1+1', '{1+1')
+    #     self.assertEqual(f'\N{LEFT CURLY BRACKET}1+1\N{RIGHT CURLY BRACKET}', '{1+1}')
+
+    def test_newlines_in_expressions(self):
+        self.assertEqual(f'{0}', '0')
+        self.assertEqual(rf'''{3+
+4}''', '7')
+
+    def test_lambda(self):
+        x = 5
+        self.assertEqual(f'{(lambda y:x*y)("8")!r}', "'88888'")
+        # Skulpt: Format strings not yet implemented
+        # self.assertEqual(f'{(lambda y:x*y)("8")!r:10}', "'88888'   ")
+        # self.assertEqual(f'{(lambda y:x*y)("8"):10}', "88888     ")
+
+        # Skulpt: unittest functionality not implemented
+        # # lambda doesn't work without parens, because the colon
+        # #  makes the parser think it's a format_spec
+        # self.assertAllRaise(SyntaxError, 'unexpected EOF while parsing',
+        #                     ["f'{lambda x:x}'",
+        #                      ])
+
+    def test_yield(self):
+        # Not terribly useful, but make sure the yield turns
+        #  a function into a generator
+        def fn(y):
+            f'y:{yield y*2}'
+
+        g = fn(4)
+        self.assertEqual(next(g), 8)
+
+    # Skulpt: The closure/free-var stuff here is badly broken
+    # def test_yield_send(self):
+    #     def fn(x):
+    #         yield f'x:{yield (lambda i: x * i)}'
+
+    #     g = fn(10)
+    #     the_lambda = next(g)
+    #     self.assertEqual(the_lambda(4), 40)
+    #     self.assertEqual(g.send('string'), 'x:string')
+
+    def test_expressions_with_triple_quoted_strings(self):
+        self.assertEqual(f"{'''x'''}", 'x')
+        self.assertEqual(f"{'''eric's'''}", "eric's")
+
+        # Test concatenation within an expression
+        self.assertEqual(f'{"x" """eric"s""" "y"}', 'xeric"sy')
+        self.assertEqual(f'{"x" """eric"s"""}', 'xeric"s')
+        self.assertEqual(f'{"""eric"s""" "y"}', 'eric"sy')
+        self.assertEqual(f'{"""x""" """eric"s""" "y"}', 'xeric"sy')
+        self.assertEqual(f'{"""x""" """eric"s""" """y"""}', 'xeric"sy')
+        self.assertEqual(f'{r"""x""" """eric"s""" """y"""}', 'xeric"sy')
+
+    def test_multiple_vars(self):
+        x = 98
+        y = 'abc'
+        self.assertEqual(f'{x}{y}', '98abc')
+
+        self.assertEqual(f'X{x}{y}', 'X98abc')
+        self.assertEqual(f'{x}X{y}', '98Xabc')
+        self.assertEqual(f'{x}{y}X', '98abcX')
+
+        self.assertEqual(f'X{x}Y{y}', 'X98Yabc')
+        self.assertEqual(f'X{x}{y}Y', 'X98abcY')
+        self.assertEqual(f'{x}X{y}Y', '98XabcY')
+
+        self.assertEqual(f'X{x}Y{y}Z', 'X98YabcZ')
+
+    def test_closure(self):
+        def outer(x):
+            def inner():
+                return f'x:{x}'
+            return inner
+
+        self.assertEqual(outer('987')(), 'x:987')
+        self.assertEqual(outer(7)(), 'x:7')
+
+    # Skulpt TODO: Format spec is not yet implemented
+    # def test_arguments(self):
+    #     y = 2
+    #     def f(x, width):
+    #         return f'x={x*y:{width}}'
+
+    #     self.assertEqual(f('foo', 10), 'x=foofoo    ')
+    #     x = 'bar'
+    #     self.assertEqual(f(10, 10), 'x=        20')
+
+    def test_locals(self):
+        value = 123
+        self.assertEqual(f'v:{value}', 'v:123')
+
+    def test_missing_variable(self):
+        self.assertRaises(NameError, lambda: f'v:{value}')
+
+    def test_missing_format_spec(self):
+        class O:
+            def __format__(self, spec):
+                if not spec:
+                    return '*'
+                return spec
+
+        self.assertEqual(f'{O():x}', 'x')
+        self.assertEqual(f'{O()}', '*')
+        self.assertEqual(f'{O():}', '*')
+
+        self.assertEqual(f'{3:}', '3')
+        self.assertEqual(f'{3!s:}', '3')
+
+    def test_global(self):
+        self.assertEqual(f'g:{a_global}', 'g:global variable')
+        self.assertEqual(f'g:{a_global!r}', "g:'global variable'")
+
+        a_local = 'local variable'
+        self.assertEqual(f'g:{a_global} l:{a_local}',
+                         'g:global variable l:local variable')
+        self.assertEqual(f'g:{a_global!r}',
+                         "g:'global variable'")
+        self.assertEqual(f'g:{a_global} l:{a_local!r}',
+                         "g:global variable l:'local variable'")
+
+        self.assertIn("module 'unittest' from", f'{unittest}')
+
+    def test_shadowed_global(self):
+        a_global = 'really a local'
+        self.assertEqual(f'g:{a_global}', 'g:really a local')
+        self.assertEqual(f'g:{a_global!r}', "g:'really a local'")
+
+        a_local = 'local variable'
+        self.assertEqual(f'g:{a_global} l:{a_local}',
+                         'g:really a local l:local variable')
+        self.assertEqual(f'g:{a_global!r}',
+                         "g:'really a local'")
+        self.assertEqual(f'g:{a_global} l:{a_local!r}',
+                         "g:really a local l:'local variable'")
+
+    def test_call(self):
+        def foo(x):
+            return 'x=' + str(x)
+
+        self.assertEqual(f'{foo(10)}', 'x=10')
+
+    def test_nested_fstrings(self):
+        y = 5
+        self.assertEqual(f'{f"{0}"*3}', '000')
+        self.assertEqual(f'{f"{y}"*3}', '555')
+
+    # Skulpt: unittest functionality not implemented
+    # def test_invalid_string_prefixes(self):
+    #     self.assertAllRaise(SyntaxError, 'unexpected EOF while parsing',
+    #                         ["fu''",
+    #                          "uf''",
+    #                          "Fu''",
+    #                          "fU''",
+    #                          "Uf''",
+    #                          "uF''",
+    #                          "ufr''",
+    #                          "urf''",
+    #                          "fur''",
+    #                          "fru''",
+    #                          "rfu''",
+    #                          "ruf''",
+    #                          "FUR''",
+    #                          "Fur''",
+    #                          "fb''",
+    #                          "fB''",
+    #                          "Fb''",
+    #                          "FB''",
+    #                          "bf''",
+    #                          "bF''",
+    #                          "Bf''",
+    #                          "BF''",
+    #                          ])
+
+    def test_leading_trailing_spaces(self):
+        self.assertEqual(f'{ 3}', '3')
+        self.assertEqual(f'{  3}', '3')
+        self.assertEqual(f'{3 }', '3')
+        self.assertEqual(f'{3  }', '3')
+
+        self.assertEqual(f'expr={ {x: y for x, y in [(1, 2), ]}}',
+                         'expr={1: 2}')
+        self.assertEqual(f'expr={ {x: y for x, y in [(1, 2), ]} }',
+                         'expr={1: 2}')
+
+    def test_not_equal(self):
+        # There's a special test for this because there's a special
+        #  case in the f-string parser to look for != as not ending an
+        #  expression. Normally it would, while looking for !s or !r.
+
+        self.assertEqual(f'{3!=4}', 'True')
+        self.assertEqual(f'{3!=4:}', 'True')
+        self.assertEqual(f'{3!=4!s}', 'True')
+        # Skulpt: Format strings not implemented
+        # self.assertEqual(f'{3!=4!s:.3}', 'Tru')
+
+    # Skulpt: Format specs not yet implemented
+    # def test_conversions(self):
+    #     self.assertEqual(f'{3.14:10.10}', '      3.14')
+    #     self.assertEqual(f'{3.14!s:10.10}', '3.14      ')
+    #     self.assertEqual(f'{3.14!r:10.10}', '3.14      ')
+    #     self.assertEqual(f'{3.14!a:10.10}', '3.14      ')
+
+    #     self.assertEqual(f'{"a"}', 'a')
+    #     self.assertEqual(f'{"a"!r}', "'a'")
+    #     self.assertEqual(f'{"a"!a}', "'a'")
+
+    #     # Not a conversion.
+    #     self.assertEqual(f'{"a!r"}', "a!r")
+
+    #     # Not a conversion, but show that ! is allowed in a format spec.
+    #     self.assertEqual(f'{3.14:!<10.10}', '3.14!!!!!!')
+
+    #     self.assertAllRaise(SyntaxError, 'f-string: invalid conversion character',
+    #                         ["f'{3!g}'",
+    #                          "f'{3!A}'",
+    #                          "f'{3!3}'",
+    #                          "f'{3!G}'",
+    #                          "f'{3!!}'",
+    #                          "f'{3!:}'",
+    #                          "f'{3! s}'",  # no space before conversion char
+    #                          ])
+
+    #     self.assertAllRaise(SyntaxError, "f-string: expecting '}'",
+    #                         ["f'{x!s{y}}'",
+    #                          "f'{3!ss}'",
+    #                          "f'{3!ss:}'",
+    #                          "f'{3!ss:s}'",
+    #                          ])
+
+    # Skulpt: This unittest functionality (and, indeed, eval()) is not yet implemented
+    # def test_assignment(self):
+    #     self.assertAllRaise(SyntaxError, 'invalid syntax',
+    #                         ["f'' = 3",
+    #                          "f'{0}' = x",
+    #                          "f'{x}' = x",
+    #                          ])
+
+    # def test_del(self):
+    #     self.assertAllRaise(SyntaxError, 'invalid syntax',
+    #                         ["del f''",
+    #                          "del '' f''",
+    #                          ])
+
+    def test_mismatched_braces(self):
+        # Skulpt: This unittest functionality (and, indeed, eval()) is not yet implemented
+        # self.assertAllRaise(SyntaxError, "f-string: single '}' is not allowed",
+        #                     ["f'{{}'",
+        #                      "f'{{}}}'",
+        #                      "f'}'",
+        #                      "f'x}'",
+        #                      "f'x}x'",
+        #                      r"f'\u007b}'",
+
+        #                      # Can't have { or } in a format spec.
+        #                      "f'{3:}>10}'",
+        #                      "f'{3:}}>10}'",
+        #                      ])
+
+        # self.assertAllRaise(SyntaxError, "f-string: expecting '}'",
+        #                     ["f'{3:{{>10}'",
+        #                      "f'{3'",
+        #                      "f'{3!'",
+        #                      "f'{3:'",
+        #                      "f'{3!s'",
+        #                      "f'{3!s:'",
+        #                      "f'{3!s:3'",
+        #                      "f'x{'",
+        #                      "f'x{x'",
+        #                      "f'{x'",
+        #                      "f'{3:s'",
+        #                      "f'{{{'",
+        #                      "f'{{}}{'",
+        #                      "f'{'",
+        #                      ])
+
+        # But these are just normal strings.
+        self.assertEqual(f'{"{"}', '{')
+        self.assertEqual(f'{"}"}', '}')
+        # Skulpt: Format strings not implemented
+        # self.assertEqual(f'{3:{"}"}>10}', '}}}}}}}}}3')
+        # self.assertEqual(f'{2:{"{"}>10}', '{{{{{{{{{2')
+
+    def test_if_conditional(self):
+        # There's special logic in compile.c to test if the
+        #  conditional for an if (and while) are constants. Exercise
+        #  that code.
+
+        def test_fstring(x, expected):
+            flag = 0
+            if f'{x}':
+                flag = 1
+            else:
+                flag = 2
+            self.assertEqual(flag, expected)
+
+        def test_concat_empty(x, expected):
+            flag = 0
+            if '' f'{x}':
+                flag = 1
+            else:
+                flag = 2
+            self.assertEqual(flag, expected)
+
+        def test_concat_non_empty(x, expected):
+            flag = 0
+            if ' ' f'{x}':
+                flag = 1
+            else:
+                flag = 2
+            self.assertEqual(flag, expected)
+
+        test_fstring('', 2)
+        test_fstring(' ', 1)
+
+        test_concat_empty('', 2)
+        test_concat_empty(' ', 1)
+
+        test_concat_non_empty('', 1)
+        test_concat_non_empty(' ', 1)
+
+    def test_empty_format_specifier(self):
+        x = 'test'
+        self.assertEqual(f'{x}', 'test')
+        self.assertEqual(f'{x:}', 'test')
+        self.assertEqual(f'{x!s:}', 'test')
+        self.assertEqual(f'{x!r:}', "'test'")
+
+    def test_str_format_differences(self):
+        d = {'a': 'string',
+             0: 'integer',
+             }
+        a = 0
+        self.assertEqual(f'{d[0]}', 'integer')
+        self.assertEqual(f'{d["a"]}', 'string')
+        self.assertEqual(f'{d[a]}', 'integer')
+        self.assertEqual('{d[a]}'.format(d=d), 'string')
+        # Skulpt: .format() is broken with regard to integers
+        # self.assertEqual('{d[0]}'.format(d=d), 'integer')
+
+    # Skulpt: unittest functionality not implemented
+    # def test_invalid_expressions(self):
+    #     self.assertAllRaise(SyntaxError, 'invalid syntax',
+    #                         [r"f'{a[4)}'",
+    #                          r"f'{a(4]}'",
+    #                         ])
+
+    # def test_errors(self):
+    #     # see issue 26287
+    #     self.assertAllRaise(TypeError, 'unsupported',
+    #                         [r"f'{(lambda: 0):x}'",
+    #                          r"f'{(0,):x}'",
+    #                          ])
+    #     self.assertAllRaise(ValueError, 'Unknown format code',
+    #                         [r"f'{1000:j}'",
+    #                          r"f'{1000:j}'",
+    #                         ])
+
+    def test_loop(self):
+        for i in range(1000):
+            self.assertEqual(f'i:{i}', 'i:' + str(i))
+
+    def test_dict(self):
+        d = {'"': 'dquote',
+             "'": 'squote',
+             'foo': 'bar',
+             }
+        self.assertEqual(f'''{d["'"]}''', 'squote')
+        self.assertEqual(f"""{d['"']}""", 'dquote')
+
+        self.assertEqual(f'{d["foo"]}', 'bar')
+        self.assertEqual(f"{d['foo']}", 'bar')
+
+    # Skulpt: eval not yet implemented
+    # def test_backslash_char(self):
+    #     # Check eval of a backslash followed by a control char.
+    #     # See bpo-30682: this used to raise an assert in pydebug mode.
+    #     self.assertEqual(eval('f"\\\n"'), '')
+    #     self.assertEqual(eval('f"\\\r"'), '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_strformat.py
+++ b/test/unit3/test_strformat.py
@@ -76,6 +76,7 @@ class string_format(unittest.TestCase):
 
     def test_comma_sep(self):
         self.assertEqual('1,234,567,890',  '{:,}'.format(1234567890))
+        self.assertEqual('1,234,567.89',  '{:,.2f}'.format(1234567.888))
 
     def test_percentage(self):
         points = 19.5

--- a/test/unit3/test_strformat.py
+++ b/test/unit3/test_strformat.py
@@ -10,35 +10,37 @@ class string_format(unittest.TestCase):
         self.assertEqual('c, b, a', '{2}, {1}, {0}'.format(*'abc'))
         self.assertEqual('abracadabra', '{0}{1}{0}'.format('abra', 'cad'))
 
-    #Kwargs don't work
     def test_arg_names(self):
         self.assertEqual('Coordinates: 37.24N, -115.81W', 'Coordinates: {latitude}, {longitude}'.format(latitude='37.24N', longitude='-115.81W'))
-        ## **kwargs does not work properly in Skulpt
-        # coord = {'latitude': '37.24N', 'longitude': '-115.81W'}
-        # self.assertEqual('Coordinates: 37.24N, -115.81W', 'Coordinates: {latitude}, {longitude}'.format(**coord))
+        coord = {'latitude': '37.24N', 'longitude': '-115.81W'}
+        self.assertEqual('Coordinates: 37.24N, -115.81W', 'Coordinates: {latitude}, {longitude}'.format(**coord))
     
-    ## Complex Numbers Currently unsupported
-    
-    # def test_arg_attr(self):
-    #     c = 3-5j
-    #     self.assertEqual('The complex number (3-5j) is formed from the real part 3.0 and the imaginary part -5.0.', ('The complex number {0} is formed from the real part {0.real} and the imaginary part {0.imag}.').format(c))
-    #     class Point(object):
-    #         def __init__(self, x, y):
-    #             self.x, self.y = x, y
-    #         def __str__(self):
-    #             return 'Point({self.x}, {self.y})'.format(self=self)
-    #     self.assertEqual('Point(4, 2)', str(Point(4, 2)))
+    def test_arg_attr(self):
+        # Skulpt:  Complex Numbers Currently unsupported
+        # c = 3-5j
+        # self.assertEqual('The complex number (3-5j) is formed from the real part 3.0 and the imaginary part -5.0.', ('The complex number {0} is formed from the real part {0.real} and the imaginary part {0.imag}.').format(c))
+
+        class Point(object):
+            def __init__(self, x, y):
+                self.x, self.y = x, y
+            def __str__(self):
+                return 'Point({self.x}, {self.y})'.format(self=self)
+        self.assertEqual('Point(4, 2)', str(Point(4, 2)))
+
+        self.assertEqual('4, 2', "{0.x}, {0.y}".format(Point(4, 2)))
+        self.assertEqual('4, 2', "{.x}, {.y}".format(Point(4, 3), Point(3, 2)))
 
     def test_arg_items(self):
         coord = (3, 5)
         self.assertEqual('X: 3;  Y: 5','X: {0[0]};  Y: {0[1]}'.format(coord))
-#        self.assertEqual('My name is Fred',"My name is {0[name]}".format({'name':'Fred'}))
+        self.assertEqual('My name is Fred',"My name is {0[name]}".format({'name':'Fred'}))
 
-# TODO:  make these pass
-#    def test_width(self):
-#        self.assertEqual('         2,2',"{0:10},{0}".format(2))
-#        self.assertEqual('foo bar baz ',"{0:4}{1:4}{2:4}".format("foo","bar","baz")) 
-        
+    def test_width(self):
+        self.assertEqual('         2,2',"{0:10},{0}".format(2))
+        self.assertEqual('foo bar baz ',"{0:4}{1:4}{2:4}".format("foo","bar","baz")) 
+        self.assertEqual('Fo', "{:.2}".format("Foo bar"))
+        self.assertEqual('Fo  ', "{:4.2}".format("Foo bar"))
+
 
     def test_conversion(self):
         self.assertEqual("repr() shows quotes: 'test1'; str() doesn't: test2", "repr() shows quotes: {!r}; str() doesn't: {!s}".format('test1', 'test2'))
@@ -49,10 +51,24 @@ class string_format(unittest.TestCase):
         self.assertEqual('           centered           ', '{:^30}'.format('centered'))
         self.assertEqual('***********centered***********', '{:*^30}'.format('centered'))
 
+        # Make sure it works with numbers too
+        self.assertEqual('2         ',"{:<10}".format(2))
+        self.assertEqual('    2     ',"{:^10}".format(2))
+        self.assertEqual('-        2',"{:=10}".format(-2))
+        self.assertEqual('+000000002',"{:+010}".format(2))
+
     def test_fixed_point(self):
         self.assertEqual('+3.140000; -3.140000', '{:+f}; {:+f}'.format(3.14, -3.14))
         self.assertEqual(' 3.140000; -3.140000', '{: f}; {: f}'.format(3.14, -3.14))
         self.assertEqual('3.140000; -3.140000',  '{:-f}; {:-f}'.format(3.14, -3.14))
+
+    def test_zeroes(self):
+        self.assertEqual('3.14', "{}".format(3.14))
+        self.assertEqual('3.1', "{:.2}".format(3.14))
+        self.assertEqual('3.14', "{:.5}".format(3.14))
+        self.assertEqual('3.14', "{:.5g}".format(3.14))
+        self.assertEqual('3', "{:.5g}".format(3.0))
+        self.assertEqual('3.0', "{:.5}".format(3.0))
 
     def test_hex_oct(self):
         self.assertEqual('int: 42;  hex: 2a;  oct: 52;  bin: 101010', "int: {0:d};  hex: {0:x};  oct: {0:o};  bin: {0:b}".format(42))
@@ -66,12 +82,10 @@ class string_format(unittest.TestCase):
         total = 22
         self.assertEqual('Correct answers: 88.64%', 'Correct answers: {:.2%}'.format(points/total))
 
-    ## Datetime requires more work.
-    
-    #def test_datetime(self):
-    #    import datetime
-    #    d = datetime.datetime(2010, 7, 4, 12, 15, 58)
-    #    self.assertEqual('2010-07-04 12:15:58', '{:%Y-%m-%d %H:%M:%S}'.format(d))
+    def test_datetime(self):
+       import datetime
+       d = datetime.datetime(2010, 7, 4, 12, 15, 58)
+       self.assertEqual('2010-07-04 12:15:58', '{:%Y-%m-%d %H:%M:%S}'.format(d))
 
     def test_fstrings(self):
         self.assertEqual('1 + 2 = 3', f'1 + 2 = {1+2}')

--- a/test/unit3/test_strformat.py
+++ b/test/unit3/test_strformat.py
@@ -84,5 +84,12 @@ class string_format(unittest.TestCase):
         # Make sure we can format multiple objects next to each other (bug regression)
         self.assertEqual('2010-07-04 12:15:58 TIME', f'{d:%Y-%m-%d %H:%M:%S} {"TIME"}')
 
+        class Dummy:
+            def __format__(self, fmtstring):
+                return fmtstring
+        x = Dummy()
+        self.assertEqual('hello world!', f'hello {x:world}!')
+        self.assertEqual('hello world!!', f'{x:hello {x:world}!}!')
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_strformat.py
+++ b/test/unit3/test_strformat.py
@@ -68,10 +68,19 @@ class string_format(unittest.TestCase):
 
     ## Datetime requires more work.
     
-    # def test_datetome(self):
-    #     import datetime
-    #     d = datetime.datetime(2010, 7, 4, 12, 15, 58)
-    #     self.assertEqual('2010-07-04 12:15:58', '{:%Y-%m-%d %H:%M:%S}'.format(d))
+    #def test_datetime(self):
+    #    import datetime
+    #    d = datetime.datetime(2010, 7, 4, 12, 15, 58)
+    #    self.assertEqual('2010-07-04 12:15:58', '{:%Y-%m-%d %H:%M:%S}'.format(d))
+
+    def test_fstrings(self):
+        self.assertEqual('1 + 2 = 3', f'1 + 2 = {1+2}')
+        self.assertEqual("'hello'", F'{"hello"!r}')
+        self.assertEqual("hi{there}", f"hi{{{'there'}}}")
+
+        import datetime
+        d = datetime.datetime(2010, 7, 4, 12, 15, 58)
+        self.assertEqual('2010-07-04 12:15:58', f'{d:%Y-%m-%d %H:%M:%S}')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_strformat.py
+++ b/test/unit3/test_strformat.py
@@ -81,6 +81,8 @@ class string_format(unittest.TestCase):
         import datetime
         d = datetime.datetime(2010, 7, 4, 12, 15, 58)
         self.assertEqual('2010-07-04 12:15:58', f'{d:%Y-%m-%d %H:%M:%S}')
+        # Make sure we can format multiple objects next to each other (bug regression)
+        self.assertEqual('2010-07-04 12:15:58 TIME', f'{d:%Y-%m-%d %H:%M:%S} {"TIME"}')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a follow-up to #975, which refactors the string formatting code so that it can be used by f-strings (and the built-in `format()` function too).

In other words, formatting like `f"{4+5:.2f}"` now works :-D

I took the opportunity to do a bunch of cleanup and bugfixing in our `str.format()` implementation, and re-enable/add a couple more tests to `test_strformat.py`, as well as enabling all the format-string-related tests in `test_fstring.py`.

(All the changes for this PR are in the most recent commit - everything else GitHub is showing us is part of #975.)