### PR TITLE
AST module

### DIFF
--- a/gen/astnodes.js
+++ b/gen/astnodes.js
@@ -136,10 +136,14 @@ Sk.astnodes.FunctionDef = function FunctionDef(/* {identifier} */ name, /*
                                                     {expr_ty} */ returns, /*
                                                     {string} */ docstring, /*
                                                     {int} */ lineno, /* {int}
-                                                    */ col_offset)
+                                                    */ col_offset, /* {int} */
+                                                    end_lineno, /* {int} */
+                                                    end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.name = name;
     this.args = args;
     this.body = body;
@@ -148,6 +152,8 @@ Sk.astnodes.FunctionDef = function FunctionDef(/* {identifier} */ name, /*
     this.docstring = docstring;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -166,10 +172,16 @@ Sk.astnodes.AsyncFunctionDef = function AsyncFunctionDef(/* {identifier} */
                                                               docstring, /*
                                                               {int} */ lineno,
                                                               /* {int} */
-                                                              col_offset)
+                                                              col_offset, /*
+                                                              {int} */
+                                                              end_lineno, /*
+                                                              {int} */
+                                                              end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.name = name;
     this.args = args;
     this.body = body;
@@ -178,6 +190,8 @@ Sk.astnodes.AsyncFunctionDef = function AsyncFunctionDef(/* {identifier} */
     this.docstring = docstring;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -188,10 +202,14 @@ Sk.astnodes.ClassDef = function ClassDef(/* {identifier} */ name, /* {asdl_seq
                                               body, /* {asdl_seq *} */
                                               decorator_list, /* {string} */
                                               docstring, /* {int} */ lineno, /*
-                                              {int} */ col_offset)
+                                              {int} */ col_offset, /* {int} */
+                                              end_lineno, /* {int} */
+                                              end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.name = name;
     this.bases = bases;
     this.keywords = keywords;
@@ -200,44 +218,64 @@ Sk.astnodes.ClassDef = function ClassDef(/* {identifier} */ name, /* {asdl_seq
     this.docstring = docstring;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Return = function Return(/* {expr_ty} */ value, /* {int} */ lineno,
-                                          /* {int} */ col_offset)
+                                          /* {int} */ col_offset, /* {int} */
+                                          end_lineno, /* {int} */
+                                          end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Delete = function Delete(/* {asdl_seq *} */ targets, /* {int} */
-                                          lineno, /* {int} */ col_offset)
+                                          lineno, /* {int} */ col_offset, /*
+                                          {int} */ end_lineno, /* {int} */
+                                          end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.targets = targets;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Assign = function Assign(/* {asdl_seq *} */ targets, /* {expr_ty}
                                           */ value, /* {int} */ lineno, /*
-                                          {int} */ col_offset)
+                                          {int} */ col_offset, /* {int} */
+                                          end_lineno, /* {int} */
+                                          end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.targets = targets;
     this.value = value;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -245,15 +283,21 @@ Sk.astnodes.Assign = function Assign(/* {asdl_seq *} */ targets, /* {expr_ty}
 Sk.astnodes.AugAssign = function AugAssign(/* {expr_ty} */ target, /*
                                                 {operator_ty} */ op, /*
                                                 {expr_ty} */ value, /* {int} */
-                                                lineno, /* {int} */ col_offset)
+                                                lineno, /* {int} */ col_offset,
+                                                /* {int} */ end_lineno, /*
+                                                {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.target = target;
     this.op = op;
     this.value = value;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -262,16 +306,22 @@ Sk.astnodes.AnnAssign = function AnnAssign(/* {expr_ty} */ target, /* {expr_ty}
                                                 */ annotation, /* {expr_ty} */
                                                 value, /* {int} */ simple, /*
                                                 {int} */ lineno, /* {int} */
-                                                col_offset)
+                                                col_offset, /* {int} */
+                                                end_lineno, /* {int} */
+                                                end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.target = target;
     this.annotation = annotation;
     this.value = value;
     this.simple = simple;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -279,16 +329,21 @@ Sk.astnodes.AnnAssign = function AnnAssign(/* {expr_ty} */ target, /* {expr_ty}
 Sk.astnodes.For = function For(/* {expr_ty} */ target, /* {expr_ty} */ iter, /*
                                     {asdl_seq *} */ body, /* {asdl_seq *} */
                                     orelse, /* {int} */ lineno, /* {int} */
-                                    col_offset)
+                                    col_offset, /* {int} */ end_lineno, /*
+                                    {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.target = target;
     this.iter = iter;
     this.body = body;
     this.orelse = orelse;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -297,60 +352,82 @@ Sk.astnodes.AsyncFor = function AsyncFor(/* {expr_ty} */ target, /* {expr_ty}
                                               */ iter, /* {asdl_seq *} */ body,
                                               /* {asdl_seq *} */ orelse, /*
                                               {int} */ lineno, /* {int} */
-                                              col_offset)
+                                              col_offset, /* {int} */
+                                              end_lineno, /* {int} */
+                                              end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.target = target;
     this.iter = iter;
     this.body = body;
     this.orelse = orelse;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.While = function While(/* {expr_ty} */ test, /* {asdl_seq *} */
                                         body, /* {asdl_seq *} */ orelse, /*
-                                        {int} */ lineno, /* {int} */ col_offset)
+                                        {int} */ lineno, /* {int} */
+                                        col_offset, /* {int} */ end_lineno, /*
+                                        {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.test = test;
     this.body = body;
     this.orelse = orelse;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.If = function If(/* {expr_ty} */ test, /* {asdl_seq *} */ body, /*
                                   {asdl_seq *} */ orelse, /* {int} */ lineno,
-                                  /* {int} */ col_offset)
+                                  /* {int} */ col_offset, /* {int} */
+                                  end_lineno, /* {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.test = test;
     this.body = body;
     this.orelse = orelse;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.With = function With(/* {asdl_seq *} */ items, /* {asdl_seq *} */
                                       body, /* {int} */ lineno, /* {int} */
-                                      col_offset)
+                                      col_offset, /* {int} */ end_lineno, /*
+                                      {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.items = items;
     this.body = body;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -358,14 +435,20 @@ Sk.astnodes.With = function With(/* {asdl_seq *} */ items, /* {asdl_seq *} */
 Sk.astnodes.AsyncWith = function AsyncWith(/* {asdl_seq *} */ items, /*
                                                 {asdl_seq *} */ body, /* {int}
                                                 */ lineno, /* {int} */
-                                                col_offset)
+                                                col_offset, /* {int} */
+                                                end_lineno, /* {int} */
+                                                end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.items = items;
     this.body = body;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -373,16 +456,21 @@ Sk.astnodes.AsyncWith = function AsyncWith(/* {asdl_seq *} */ items, /*
 Sk.astnodes.Raise = function Raise(/* {expr_ty} */ exc, /* {expr_ty} */ cause,
                                         /* {expr_ty} */ inst, /* {expr_ty} */
                                         tback, /* {int} */ lineno, /* {int} */
-                                        col_offset)
+                                        col_offset, /* {int} */ end_lineno, /*
+                                        {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.exc = exc;
     this.cause = cause;
     this.inst = inst;
     this.tback = tback;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -390,42 +478,58 @@ Sk.astnodes.Raise = function Raise(/* {expr_ty} */ exc, /* {expr_ty} */ cause,
 Sk.astnodes.Try = function Try(/* {asdl_seq *} */ body, /* {asdl_seq *} */
                                     handlers, /* {asdl_seq *} */ orelse, /*
                                     {asdl_seq *} */ finalbody, /* {int} */
-                                    lineno, /* {int} */ col_offset)
+                                    lineno, /* {int} */ col_offset, /* {int} */
+                                    end_lineno, /* {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.body = body;
     this.handlers = handlers;
     this.orelse = orelse;
     this.finalbody = finalbody;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Assert = function Assert(/* {expr_ty} */ test, /* {expr_ty} */ msg,
                                           /* {int} */ lineno, /* {int} */
-                                          col_offset)
+                                          col_offset, /* {int} */ end_lineno,
+                                          /* {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.test = test;
     this.msg = msg;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Import = function Import(/* {asdl_seq *} */ names, /* {int} */
-                                          lineno, /* {int} */ col_offset)
+                                          lineno, /* {int} */ col_offset, /*
+                                          {int} */ end_lineno, /* {int} */
+                                          end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.names = names;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -434,234 +538,339 @@ Sk.astnodes.ImportFrom = function ImportFrom(/* {identifier} */ module, /*
                                                   {asdl_seq *} */ names, /*
                                                   {int} */ level, /* {int} */
                                                   lineno, /* {int} */
-                                                  col_offset)
+                                                  col_offset, /* {int} */
+                                                  end_lineno, /* {int} */
+                                                  end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.module = module;
     this.names = names;
     this.level = level;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Global = function Global(/* {asdl_seq *} */ names, /* {int} */
-                                          lineno, /* {int} */ col_offset)
+                                          lineno, /* {int} */ col_offset, /*
+                                          {int} */ end_lineno, /* {int} */
+                                          end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.names = names;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Nonlocal = function Nonlocal(/* {asdl_seq *} */ names, /* {int} */
-                                              lineno, /* {int} */ col_offset)
+                                              lineno, /* {int} */ col_offset,
+                                              /* {int} */ end_lineno, /* {int}
+                                              */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.names = names;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Expr = function Expr(/* {expr_ty} */ value, /* {int} */ lineno, /*
-                                      {int} */ col_offset)
+                                      {int} */ col_offset, /* {int} */
+                                      end_lineno, /* {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
-Sk.astnodes.Pass = function Pass(/* {int} */ lineno, /* {int} */ col_offset)
+Sk.astnodes.Pass = function Pass(/* {int} */ lineno, /* {int} */ col_offset, /*
+                                      {int} */ end_lineno, /* {int} */
+                                      end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
-Sk.astnodes.Break = function Break(/* {int} */ lineno, /* {int} */ col_offset)
+Sk.astnodes.Break = function Break(/* {int} */ lineno, /* {int} */ col_offset,
+                                        /* {int} */ end_lineno, /* {int} */
+                                        end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Continue = function Continue(/* {int} */ lineno, /* {int} */
-                                              col_offset)
+                                              col_offset, /* {int} */
+                                              end_lineno, /* {int} */
+                                              end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Print = function Print(/* {expr_ty} */ dest, /* {asdl_seq *} */
                                         values, /* {int} */ nl, /* {int} */
-                                        lineno, /* {int} */ col_offset)
+                                        lineno, /* {int} */ col_offset, /*
+                                        {int} */ end_lineno, /* {int} */
+                                        end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.dest = dest;
     this.values = values;
     this.nl = nl;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Debugger = function Debugger(/* {int} */ lineno, /* {int} */
-                                              col_offset)
+                                              col_offset, /* {int} */
+                                              end_lineno, /* {int} */
+                                              end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.BoolOp = function BoolOp(/* {boolop_ty} */ op, /* {asdl_seq *} */
                                           values, /* {int} */ lineno, /* {int}
-                                          */ col_offset)
+                                          */ col_offset, /* {int} */
+                                          end_lineno, /* {int} */
+                                          end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.op = op;
     this.values = values;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.BinOp = function BinOp(/* {expr_ty} */ left, /* {operator_ty} */
                                         op, /* {expr_ty} */ right, /* {int} */
-                                        lineno, /* {int} */ col_offset)
+                                        lineno, /* {int} */ col_offset, /*
+                                        {int} */ end_lineno, /* {int} */
+                                        end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.left = left;
     this.op = op;
     this.right = right;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.UnaryOp = function UnaryOp(/* {unaryop_ty} */ op, /* {expr_ty} */
                                             operand, /* {int} */ lineno, /*
-                                            {int} */ col_offset)
+                                            {int} */ col_offset, /* {int} */
+                                            end_lineno, /* {int} */
+                                            end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.op = op;
     this.operand = operand;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Lambda = function Lambda(/* {arguments__ty} */ args, /* {expr_ty}
                                           */ body, /* {int} */ lineno, /* {int}
-                                          */ col_offset)
+                                          */ col_offset, /* {int} */
+                                          end_lineno, /* {int} */
+                                          end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.args = args;
     this.body = body;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.IfExp = function IfExp(/* {expr_ty} */ test, /* {expr_ty} */ body,
                                         /* {expr_ty} */ orelse, /* {int} */
-                                        lineno, /* {int} */ col_offset)
+                                        lineno, /* {int} */ col_offset, /*
+                                        {int} */ end_lineno, /* {int} */
+                                        end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.test = test;
     this.body = body;
     this.orelse = orelse;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Dict = function Dict(/* {asdl_seq *} */ keys, /* {asdl_seq *} */
                                       values, /* {int} */ lineno, /* {int} */
-                                      col_offset)
+                                      col_offset, /* {int} */ end_lineno, /*
+                                      {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.keys = keys;
     this.values = values;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Set = function Set(/* {asdl_seq *} */ elts, /* {int} */ lineno, /*
-                                    {int} */ col_offset)
+                                    {int} */ col_offset, /* {int} */
+                                    end_lineno, /* {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.elts = elts;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.ListComp = function ListComp(/* {expr_ty} */ elt, /* {asdl_seq *}
                                               */ generators, /* {int} */
-                                              lineno, /* {int} */ col_offset)
+                                              lineno, /* {int} */ col_offset,
+                                              /* {int} */ end_lineno, /* {int}
+                                              */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.elt = elt;
     this.generators = generators;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.SetComp = function SetComp(/* {expr_ty} */ elt, /* {asdl_seq *} */
                                             generators, /* {int} */ lineno, /*
-                                            {int} */ col_offset)
+                                            {int} */ col_offset, /* {int} */
+                                            end_lineno, /* {int} */
+                                            end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.elt = elt;
     this.generators = generators;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -669,15 +878,21 @@ Sk.astnodes.SetComp = function SetComp(/* {expr_ty} */ elt, /* {asdl_seq *} */
 Sk.astnodes.DictComp = function DictComp(/* {expr_ty} */ key, /* {expr_ty} */
                                               value, /* {asdl_seq *} */
                                               generators, /* {int} */ lineno,
-                                              /* {int} */ col_offset)
+                                              /* {int} */ col_offset, /* {int}
+                                              */ end_lineno, /* {int} */
+                                              end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.key = key;
     this.value = value;
     this.generators = generators;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -686,50 +901,72 @@ Sk.astnodes.GeneratorExp = function GeneratorExp(/* {expr_ty} */ elt, /*
                                                       {asdl_seq *} */
                                                       generators, /* {int} */
                                                       lineno, /* {int} */
-                                                      col_offset)
+                                                      col_offset, /* {int} */
+                                                      end_lineno, /* {int} */
+                                                      end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.elt = elt;
     this.generators = generators;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Await = function Await(/* {expr_ty} */ value, /* {int} */ lineno,
-                                        /* {int} */ col_offset)
+                                        /* {int} */ col_offset, /* {int} */
+                                        end_lineno, /* {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Yield = function Yield(/* {expr_ty} */ value, /* {int} */ lineno,
-                                        /* {int} */ col_offset)
+                                        /* {int} */ col_offset, /* {int} */
+                                        end_lineno, /* {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.YieldFrom = function YieldFrom(/* {expr_ty} */ value, /* {int} */
-                                                lineno, /* {int} */ col_offset)
+                                                lineno, /* {int} */ col_offset,
+                                                /* {int} */ end_lineno, /*
+                                                {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -737,54 +974,75 @@ Sk.astnodes.YieldFrom = function YieldFrom(/* {expr_ty} */ value, /* {int} */
 Sk.astnodes.Compare = function Compare(/* {expr_ty} */ left, /* {asdl_int_seq
                                             *} */ ops, /* {asdl_seq *} */
                                             comparators, /* {int} */ lineno, /*
-                                            {int} */ col_offset)
+                                            {int} */ col_offset, /* {int} */
+                                            end_lineno, /* {int} */
+                                            end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.left = left;
     this.ops = ops;
     this.comparators = comparators;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Call = function Call(/* {expr_ty} */ func, /* {asdl_seq *} */ args,
                                       /* {asdl_seq *} */ keywords, /* {int} */
-                                      lineno, /* {int} */ col_offset)
+                                      lineno, /* {int} */ col_offset, /* {int}
+                                      */ end_lineno, /* {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.func = func;
     this.args = args;
     this.keywords = keywords;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Num = function Num(/* {object} */ n, /* {int} */ lineno, /* {int}
-                                    */ col_offset)
+                                    */ col_offset, /* {int} */ end_lineno, /*
+                                    {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.n = n;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Str = function Str(/* {string} */ s, /* {int} */ lineno, /* {int}
-                                    */ col_offset)
+                                    */ col_offset, /* {int} */ end_lineno, /*
+                                    {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.s = s;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -794,76 +1052,112 @@ Sk.astnodes.FormattedValue = function FormattedValue(/* {expr_ty} */ value, /*
                                                           /* {expr_ty} */
                                                           format_spec, /* {int}
                                                           */ lineno, /* {int}
-                                                          */ col_offset)
+                                                          */ col_offset, /*
+                                                          {int} */ end_lineno,
+                                                          /* {int} */
+                                                          end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.conversion = conversion;
     this.format_spec = format_spec;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.JoinedStr = function JoinedStr(/* {asdl_seq *} */ values, /* {int}
                                                 */ lineno, /* {int} */
-                                                col_offset)
+                                                col_offset, /* {int} */
+                                                end_lineno, /* {int} */
+                                                end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.values = values;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Bytes = function Bytes(/* {bytes} */ s, /* {int} */ lineno, /*
-                                        {int} */ col_offset)
+                                        {int} */ col_offset, /* {int} */
+                                        end_lineno, /* {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.s = s;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.NameConstant = function NameConstant(/* {singleton} */ value, /*
                                                       {int} */ lineno, /* {int}
-                                                      */ col_offset)
+                                                      */ col_offset, /* {int}
+                                                      */ end_lineno, /* {int}
+                                                      */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Ellipsis = function Ellipsis(/* {int} */ lineno, /* {int} */
-                                              col_offset)
+                                              col_offset, /* {int} */
+                                              end_lineno, /* {int} */
+                                              end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Constant = function Constant(/* {constant} */ value, /* {int} */
-                                              lineno, /* {int} */ col_offset)
+                                              lineno, /* {int} */ col_offset,
+                                              /* {int} */ end_lineno, /* {int}
+                                              */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -872,15 +1166,21 @@ Sk.astnodes.Attribute = function Attribute(/* {expr_ty} */ value, /*
                                                 {identifier} */ attr, /*
                                                 {expr_context_ty} */ ctx, /*
                                                 {int} */ lineno, /* {int} */
-                                                col_offset)
+                                                col_offset, /* {int} */
+                                                end_lineno, /* {int} */
+                                                end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.attr = attr;
     this.ctx = ctx;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -888,71 +1188,99 @@ Sk.astnodes.Attribute = function Attribute(/* {expr_ty} */ value, /*
 Sk.astnodes.Subscript = function Subscript(/* {expr_ty} */ value, /* {slice_ty}
                                                 */ slice, /* {expr_context_ty}
                                                 */ ctx, /* {int} */ lineno, /*
-                                                {int} */ col_offset)
+                                                {int} */ col_offset, /* {int}
+                                                */ end_lineno, /* {int} */
+                                                end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.slice = slice;
     this.ctx = ctx;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Starred = function Starred(/* {expr_ty} */ value, /*
                                             {expr_context_ty} */ ctx, /* {int}
-                                            */ lineno, /* {int} */ col_offset)
+                                            */ lineno, /* {int} */ col_offset,
+                                            /* {int} */ end_lineno, /* {int} */
+                                            end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.value = value;
     this.ctx = ctx;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Name = function Name(/* {identifier} */ id, /* {expr_context_ty} */
                                       ctx, /* {int} */ lineno, /* {int} */
-                                      col_offset)
+                                      col_offset, /* {int} */ end_lineno, /*
+                                      {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.id = id;
     this.ctx = ctx;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.List = function List(/* {asdl_seq *} */ elts, /* {expr_context_ty}
                                       */ ctx, /* {int} */ lineno, /* {int} */
-                                      col_offset)
+                                      col_offset, /* {int} */ end_lineno, /*
+                                      {int} */ end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.elts = elts;
     this.ctx = ctx;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
 /** @constructor */
 Sk.astnodes.Tuple = function Tuple(/* {asdl_seq *} */ elts, /*
                                         {expr_context_ty} */ ctx, /* {int} */
-                                        lineno, /* {int} */ col_offset)
+                                        lineno, /* {int} */ col_offset, /*
+                                        {int} */ end_lineno, /* {int} */
+                                        end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.elts = elts;
     this.ctx = ctx;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 
@@ -999,15 +1327,21 @@ Sk.astnodes.ExceptHandler = function ExceptHandler(/* {expr_ty} */ type, /*
                                                         /* {asdl_seq *} */
                                                         body, /* {int} */
                                                         lineno, /* {int} */
-                                                        col_offset)
+                                                        col_offset, /* {int} */
+                                                        end_lineno, /* {int} */
+                                                        end_col_offset)
 {
     Sk.asserts.assert(lineno !== null && lineno !== undefined);
     Sk.asserts.assert(col_offset !== null && col_offset !== undefined);
+    Sk.asserts.assert(end_lineno !== null && end_lineno !== undefined);
+    Sk.asserts.assert(end_col_offset !== null && end_col_offset !== undefined);
     this.type = type;
     this.name = name;
     this.body = body;
     this.lineno = lineno;
     this.col_offset = col_offset;
+    this.end_lineno = end_lineno;
+    this.end_col_offset = end_col_offset;
     return this;
 }
 

--- a/src/ast.js
+++ b/src/ast.js
@@ -402,10 +402,10 @@ function astForExceptClause (c, exc, body) {
     REQ(exc, SYM.except_clause);
     REQ(body, SYM.suite);
     if (NCH(exc) === 1) {
-        return new Sk.astnodes.ExceptHandler(null, null, astForSuite(c, body), exc.lineno, exc.col_offset);
+        return new Sk.astnodes.ExceptHandler(null, null, astForSuite(c, body), exc.lineno, exc.col_offset, exc.end_lineno, exc.end_col_offset);
     }
     else if (NCH(exc) === 2) {
-        return new Sk.astnodes.ExceptHandler(ast_for_expr(c, CHILD(exc, 1)), null, astForSuite(c, body), exc.lineno, exc.col_offset);
+        return new Sk.astnodes.ExceptHandler(ast_for_expr(c, CHILD(exc, 1)), null, astForSuite(c, body), exc.lineno, exc.col_offset, exc.end_lineno, exc.end_col_offset);
     }
     else if (NCH(exc) === 4) {
         if (Sk.__future__.python3 && CHILD(exc, 2).value == ",") {
@@ -415,7 +415,7 @@ function astForExceptClause (c, exc, body) {
         var expression = ast_for_expr(c, CHILD(exc, 1));
         e = ast_for_expr(c, CHILD(exc, 3));
         setContext(c, e, Sk.astnodes.Store, CHILD(exc, 3));
-        return new Sk.astnodes.ExceptHandler(ast_for_expr(c, CHILD(exc, 1)), e, astForSuite(c, body), exc.lineno, exc.col_offset);
+        return new Sk.astnodes.ExceptHandler(ast_for_expr(c, CHILD(exc, 1)), e, astForSuite(c, body), exc.lineno, exc.col_offset, exc.end_lineno, exc.end_col_offset);
     }
     Sk.asserts.fail("wrong number of children for except clause");
 }
@@ -463,7 +463,7 @@ function astForTryStmt (c, n) {
     }
 
     Sk.asserts.assert(!!finally_ || handlers.length != 0);
-    return new Sk.astnodes.Try(body, handlers, orelse, finally_, n.lineno, n.col_offset);
+    return new Sk.astnodes.Try(body, handlers, orelse, finally_, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 function astForDottedName (c, n) {
@@ -476,10 +476,10 @@ function astForDottedName (c, n) {
     lineno = n.lineno;
     col_offset = n.col_offset;
     id = strobj(CHILD(n, 0).value);
-    e = new Sk.astnodes.Name(id, Sk.astnodes.Load, lineno, col_offset);
+    e = new Sk.astnodes.Name(id, Sk.astnodes.Load, lineno, col_offset, n.end_lineno, n.end_col_offset);
     for (i = 2; i < NCH(n); i += 2) {
         id = strobj(CHILD(n, i).value);
-        e = new Sk.astnodes.Attribute(e, id, Sk.astnodes.Load, lineno, col_offset);
+        e = new Sk.astnodes.Attribute(e, id, Sk.astnodes.Load, lineno, col_offset, n.end_lineno, n.end_col_offset);
     }
     return e;
 }
@@ -497,7 +497,7 @@ function astForDecorator (c, n) {
     }
     else if (NCH(n) === 5) // call with no args
     {
-        return new Sk.astnodes.Call(nameExpr, [], [], null, null, n.lineno, n.col_offset);
+        return new Sk.astnodes.Call(nameExpr, [], [], null, null, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
     else {
         return ast_for_call(c, CHILD(n, 3), nameExpr);
@@ -572,9 +572,9 @@ function ast_for_with_stmt(c, n0, is_async) {
     body = astForSuite(c, CHILD(n, NCH(n) - 1));
 
     if (is_async) {
-        return new Sk.astnodes.AsyncWith(items, body, LINENO(n0), n0.col_offset);
+        return new Sk.astnodes.AsyncWith(items, body, LINENO(n0), n0.col_offset, n0.end_lineno, n0.end_col_offset);
     } else {
-        return new Sk.astnodes.With(items, body, LINENO(n), n.col_offset);
+        return new Sk.astnodes.With(items, body, LINENO(n), n.col_offset, n.end_lineno, n.end_col_offset);
     }
 }
 
@@ -592,7 +592,7 @@ function astForExecStmt (c, n) {
     if (nchildren === 6) {
         locals = ast_for_expr(c, CHILD(n, 5));
     }
-    return new Sk.astnodes.Exec(expr1, globals, locals, n.lineno, n.col_offset);
+    return new Sk.astnodes.Exec(expr1, globals, locals, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 function astForIfStmt (c, n) {
@@ -611,7 +611,7 @@ function astForIfStmt (c, n) {
         return new Sk.astnodes.If(
             ast_for_expr(c, CHILD(n, 1)),
             astForSuite(c, CHILD(n, 3)),
-            [], n.lineno, n.col_offset);
+            [], n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
 
     s = CHILD(n, 4).value;
@@ -621,7 +621,7 @@ function astForIfStmt (c, n) {
             ast_for_expr(c, CHILD(n, 1)),
             astForSuite(c, CHILD(n, 3)),
             astForSuite(c, CHILD(n, 6)),
-            n.lineno, n.col_offset);
+            n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
     else if (decider === "i") {
         nElif = NCH(n) - 4;
@@ -644,7 +644,9 @@ function astForIfStmt (c, n) {
                     astForSuite(c, CHILD(n, NCH(n) - 4)),
                     astForSuite(c, CHILD(n, NCH(n) - 1)),
                     CHILD(n, NCH(n) - 6).lineno,
-                    CHILD(n, NCH(n) - 6).col_offset)];
+                    CHILD(n, NCH(n) - 6).col_offset,
+                    CHILD(n, NCH(n) - 6).end_lineno,
+                    CHILD(n, NCH(n) - 6).end_col_offset)];
             nElif--;
         }
 
@@ -656,12 +658,14 @@ function astForIfStmt (c, n) {
                     astForSuite(c, CHILD(n, off + 2)),
                     orelse,
                     CHILD(n, off).lineno,
-                    CHILD(n, off).col_offset)];
+                    CHILD(n, off).col_offset,
+                    CHILD(n, NCH(n) - 6).end_lineno, 
+                    CHILD(n, NCH(n) - 6).end_col_offset)];
         }
         return new Sk.astnodes.If(
             ast_for_expr(c, CHILD(n, 1)),
             astForSuite(c, CHILD(n, 3)),
-            orelse, n.lineno, n.col_offset);
+            orelse, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
 
     Sk.asserts.fail("unexpected token in 'if' statement");
@@ -686,7 +690,7 @@ function ast_for_exprlist (c, n, context) {
 function astForDelStmt (c, n) {
     /* del_stmt: 'del' exprlist */
     REQ(n, SYM.del_stmt);
-    return new Sk.astnodes.Delete(ast_for_exprlist(c, CHILD(n, 1), Sk.astnodes.Del), n.lineno, n.col_offset);
+    return new Sk.astnodes.Delete(ast_for_exprlist(c, CHILD(n, 1), Sk.astnodes.Del), n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 function astForGlobalStmt (c, n) {
@@ -697,17 +701,17 @@ function astForGlobalStmt (c, n) {
     for (i = 1; i < NCH(n); i += 2) {
         s[(i - 1) / 2] = strobj(CHILD(n, i).value);
     }
-    return new Sk.astnodes.Global(s, n.lineno, n.col_offset);
+    return new Sk.astnodes.Global(s, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 function astForAssertStmt (c, n) {
     /* assert_stmt: 'assert' test [',' test] */
     REQ(n, SYM.assert_stmt);
     if (NCH(n) === 2) {
-        return new Sk.astnodes.Assert(ast_for_expr(c, CHILD(n, 1)), null, n.lineno, n.col_offset);
+        return new Sk.astnodes.Assert(ast_for_expr(c, CHILD(n, 1)), null, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
     else if (NCH(n) === 4) {
-        return new Sk.astnodes.Assert(ast_for_expr(c, CHILD(n, 1)), ast_for_expr(c, CHILD(n, 3)), n.lineno, n.col_offset);
+        return new Sk.astnodes.Assert(ast_for_expr(c, CHILD(n, 1)), ast_for_expr(c, CHILD(n, 3)), n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
     Sk.asserts.fail("improper number of parts to assert stmt");
 }
@@ -782,9 +786,13 @@ function astForImportStmt (c, n) {
     var aliases;
     var col_offset;
     var lineno;
+    var end_lineno;
+    var end_col_offset;
     REQ(n, SYM.import_stmt);
     lineno = n.lineno;
     col_offset = n.col_offset;
+    end_lineno = n.end_lineno;
+    end_col_offset = n.end_col_offset
     n = CHILD(n, 0);
     if (n.type === SYM.import_name) {
         n = CHILD(n, 1);
@@ -793,7 +801,7 @@ function astForImportStmt (c, n) {
         for (i = 0; i < NCH(n); i += 2) {
             aliases[i / 2] = aliasForImportName(c, CHILD(n, i));
         }
-        return new Sk.astnodes.Import(aliases, lineno, col_offset);
+        return new Sk.astnodes.Import(aliases, lineno, col_offset, end_lineno, end_col_offset);
     }
     else if (n.type === SYM.import_from) {
         mod = null;
@@ -848,7 +856,7 @@ function astForImportStmt (c, n) {
             }
         }
         modname = mod ? mod.name.v : "";
-        return new Sk.astnodes.ImportFrom(strobj(modname), aliases, ndots, lineno, col_offset);
+        return new Sk.astnodes.ImportFrom(strobj(modname), aliases, ndots, lineno, col_offset, end_lineno, end_col_offset);
     }
     throw new Sk.builtin.SyntaxError("unknown import statement", c.c_filename, n.lineno);
 }
@@ -900,11 +908,11 @@ function astForFactor (c, n) {
     expression = ast_for_expr(c, CHILD(n, 1));
     switch (CHILD(n, 0).type) {
         case TOK.T_PLUS:
-            return new Sk.astnodes.UnaryOp(Sk.astnodes.UAdd, expression, n.lineno, n.col_offset);
+            return new Sk.astnodes.UnaryOp(Sk.astnodes.UAdd, expression, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
         case TOK.T_MINUS:
-            return new Sk.astnodes.UnaryOp(Sk.astnodes.USub, expression, n.lineno, n.col_offset);
+            return new Sk.astnodes.UnaryOp(Sk.astnodes.USub, expression, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
         case TOK.T_TILDE:
-            return new Sk.astnodes.UnaryOp(Sk.astnodes.Invert, expression, n.lineno, n.col_offset);
+            return new Sk.astnodes.UnaryOp(Sk.astnodes.Invert, expression, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
 
     Sk.asserts.fail("unhandled factor");
@@ -926,13 +934,13 @@ function astForForStmt (c, n) {
         target = _target[0];
     }
     else {
-        target = new Sk.astnodes.Tuple(_target, Sk.astnodes.Store, n.lineno, n.col_offset);
+        target = new Sk.astnodes.Tuple(_target, Sk.astnodes.Store, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
 
     return new Sk.astnodes.For(target,
         ast_for_testlist(c, CHILD(n, 3)),
         astForSuite(c, CHILD(n, 5)),
-        seq, n.lineno, n.col_offset);
+        seq, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 function ast_for_call(c, n, func, allowgen)
@@ -1016,7 +1024,7 @@ function ast_for_call(c, n, func, allowgen)
                     return NULL;
                 }
                 starred = new Sk.astnodes.Starred(e, Sk.astnodes.Load, LINENO(chch),
-                        chch.col_offset);
+                        chch.col_offset, chch.end_lineno, chch.end_col_offset);
                 args[nargs++] = starred;
             } else if (TYPE(chch) == TOK.T_DOUBLESTAR) {
                 /* a keyword argument unpacking */
@@ -1083,7 +1091,7 @@ function ast_for_call(c, n, func, allowgen)
         }
     }
 
-    return new Sk.astnodes.Call(func, args, keywords, func.lineno, func.col_offset);
+    return new Sk.astnodes.Call(func, args, keywords, func.lineno, func.col_offset, func.end_lineno, func.end_col_offset);
 }
 
 function ast_for_trailer(c, n, left_expr) {
@@ -1095,7 +1103,7 @@ function ast_for_trailer(c, n, left_expr) {
     if (TYPE(CHILD(n, 0)) == TOK.T_LPAR) {
         if (NCH(n) == 2)
             return new Sk.astnodes.Call(left_expr, NULL, NULL, LINENO(n),
-                        n.col_offset);
+                        n.col_offset, n.end_lineno, n.end_col_offset);
         else
             return ast_for_call(c, CHILD(n, 1), left_expr, true);
     }
@@ -1104,7 +1112,7 @@ function ast_for_trailer(c, n, left_expr) {
         if (!attr_id)
             return NULL;
         return new Sk.astnodes.Attribute(left_expr, attr_id, Sk.astnodes.Load,
-                         LINENO(n), n.col_offset);
+                         LINENO(n), n.col_offset, n.end_lineno, n.end_col_offset);
     }
     else {
         REQ(CHILD(n, 0), TOK.T_LSQB);
@@ -1115,7 +1123,8 @@ function ast_for_trailer(c, n, left_expr) {
             if (!slc) {
                 return NULL;
             }
-            return new Sk.astnodes.Subscript(left_expr, slc, Sk.astnodes.Load, LINENO(n), n.col_offset);
+            return new Sk.astnodes.Subscript(left_expr, slc, Sk.astnodes.Load,
+                        LINENO(n), n.col_offset, n.end_lineno, n.end_col_offset);
         }
         else {
             /* The grammar is ambiguous here. The ambiguity is resolved
@@ -1140,7 +1149,8 @@ function ast_for_trailer(c, n, left_expr) {
             }
             if (!simple) {
                 return new Sk.astnodes.Subscript(left_expr, new Sk.astnodes.ExtSlice(slices),
-                                Sk.astnodes.Load, LINENO(n), n.col_offset);
+                                Sk.astnodes.Load, LINENO(n), n.col_offset,
+                                n.end_lineno, n.end_col_offset);
             }
             /* extract Index values and put them in a Tuple */
             elts = [];
@@ -1150,10 +1160,10 @@ function ast_for_trailer(c, n, left_expr) {
                 Sk.asserts.assert(slc.kind == _slice_kind.Index_kind  && slc.v.Index.value);
                 elts[j] = slc.v.Index.value;
             }
-            e = new Sk.astnodes.Tuple(elts, Sk.astnodes.Load, LINENO(n), n.col_offset);
+            e = new Sk.astnodes.Tuple(elts, Sk.astnodes.Load, LINENO(n), n.col_offset, n.end_lineno, n.end_col_offset);
 
             return new Sk.astnodes.Subscript(left_expr, new Sk.astnodes.Index(e),
-                             Sk.astnodes.Load, LINENO(n), n.col_offset);
+                             Sk.astnodes.Load, LINENO(n), n.col_offset, n.end_lineno, n.end_col_offset);
         }
     }
 }
@@ -1255,7 +1265,7 @@ function astForArg(c, n)
         annotation = ast_for_expr(c, CHILD(n, 2));
     }
 
-    return new Sk.astnodes.arg(name, annotation, n.lineno, n.col_offset);
+    return new Sk.astnodes.arg(name, annotation, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 /* returns -1 if failed to handle keyword only arguments
@@ -1300,7 +1310,7 @@ function handleKeywordonlyArgs(c, n, start, kwonlyargs, kwdefaults)
                 ch = CHILD(ch, 0);
                 forbiddenCheck(c, ch, ch.value, ch.lineno);
                 argname = strobj(ch.value);
-                kwonlyargs[j++] = new Sk.astnodes.arg(argname, annotation, ch.lineno, ch.col_offset);
+                kwonlyargs[j++] = new Sk.astnodes.arg(argname, annotation, ch.lineno, ch.col_offset, ch.end_lineno, ch.end_col_offset);
                 i += 2; /* the name and the comma */
                 break;
             case TOK.T_DOUBLESTAR:
@@ -1504,10 +1514,10 @@ function ast_for_funcdef_impl(c, n0, decorator_seq, is_async) {
 
     if (is_async)
         return new Sk.astnodes.AsyncFunctionDef(name, args, body, decorator_seq, returns, type_comment,
-                                LINENO(n0), n0.col_offset, end_lineno, end_col_offset);
+                                LINENO(n0), n0.col_offset, n0.end_lineno, n0.end_col_offset);
     else
         return new Sk.astnodes.FunctionDef(name, args, body, decorator_seq, returns, type_comment,
-                           LINENO(n), n.col_offset, end_lineno, end_col_offset);
+                           LINENO(n), n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 function astForClassBases (c, n) {
@@ -1534,7 +1544,8 @@ function astForClassdef (c, n, decoratorSeq) {
         forbiddenCheck(c, CHILD(n,3), classname, n.lineno);
 
         return new Sk.astnodes.ClassDef(classname, [], [], s, decoratorSeq,
-                                    /*TODO docstring*/null, LINENO(n), n.col_offset);
+                                    /*TODO docstring*/null, LINENO(n), n.col_offset,
+                                    n.end_lineno, n.end_col_offset);
     }
 
     if (TYPE(CHILD(n, 3)) === TOK.T_RPAR) { /* class NAME '(' ')' ':' suite */
@@ -1542,7 +1553,8 @@ function astForClassdef (c, n, decoratorSeq) {
         classname = new_identifier(CHILD(n, 1).value);
         forbiddenCheck(c, CHILD(n, 3), classname, CHILD(n, 3).lineno);
         return new Sk.astnodes.ClassDef(classname, [], [], s, decoratorSeq,
-                                    /*TODO docstring*/null, LINENO(n), n.col_offset);
+                                    /*TODO docstring*/null, LINENO(n), n.col_offset,
+                                    n.end_lineno, n.end_col_offset);
     }
 
     /* class NAME '(' arglist ')' ':' suite */
@@ -1551,7 +1563,8 @@ function astForClassdef (c, n, decoratorSeq) {
         var dummy_name;
         var dummy;
         dummy_name = new_identifier(CHILD(n, 1));
-        dummy = new Sk.astnodes.Name(dummy_name, Sk.astnodes.Load, LINENO(n), n.col_offset);
+        dummy = new Sk.astnodes.Name(dummy_name, Sk.astnodes.Load, LINENO(n), n.col_offset,
+                                      n.end_lineno, n.end_col_offset);
         call = ast_for_call(c, CHILD(n, 3), dummy, false);
     }
     s = astForSuite(c, CHILD(n, 6));
@@ -1559,7 +1572,8 @@ function astForClassdef (c, n, decoratorSeq) {
     forbiddenCheck(c, CHILD(n,1), classname, CHILD(n,1).lineno);
 
     return new Sk.astnodes.ClassDef(classname, call.args, call.keywords, s,
-                               decoratorSeq, /*TODO docstring*/null, LINENO(n), n.col_offset);
+                               decoratorSeq, /*TODO docstring*/null, LINENO(n), n.col_offset,
+                               n.end_lineno, n.end_col_offset);
 }
 
 function astForLambdef (c, n) {
@@ -1574,7 +1588,7 @@ function astForLambdef (c, n) {
         args = astForArguments(c, CHILD(n, 1));
         expression = ast_for_expr(c, CHILD(n, 3));
     }
-    return new Sk.astnodes.Lambda(args, expression, n.lineno, n.col_offset);
+    return new Sk.astnodes.Lambda(args, expression, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 function astForComprehension(c, n) {
@@ -1653,7 +1667,7 @@ function astForComprehension(c, n) {
         if (NCH(forch) === 1) {
             comp = new Sk.astnodes.comprehension(t[0], expression, []);
         } else {
-            comp = new Sk.astnodes.comprehension(new Sk.astnodes.Tuple(t, Sk.astnodes.Store, n.lineno, n.col_offset), expression, []);
+            comp = new Sk.astnodes.comprehension(new Sk.astnodes.Tuple(t, Sk.astnodes.Store, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset), expression, []);
         }
         if (NCH(n) === 5) {
             n = CHILD(n, 4);
@@ -1685,9 +1699,9 @@ function astForIterComp(c, n, type) {
     elt = ast_for_expr(c, CHILD(n, 0));
     comps = astForComprehension(c, CHILD(n, 1));
     if (type === COMP_GENEXP) {
-        return new Sk.astnodes.GeneratorExp(elt, comps, n.lineno, n.col_offset);
+        return new Sk.astnodes.GeneratorExp(elt, comps, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     } else if (type === COMP_SETCOMP) {
-        return new Sk.astnodes.SetComp(elt, comps, n.lineno, n.col_offset);
+        return new Sk.astnodes.SetComp(elt, comps, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
 }
 
@@ -1967,7 +1981,7 @@ function ast_for_dictcomp(c, n) {
     key = ast_for_expr(c, CHILD(n, 0));
     value = ast_for_expr(c, CHILD(n, 2));
     comps = astForComprehension(c, CHILD(n, 3));
-    return new Sk.astnodes.DictComp(key, value, comps, n.lineno, n.col_offset);
+    return new Sk.astnodes.DictComp(key, value, comps, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 function ast_for_dictdisplay(c, n)
@@ -2003,10 +2017,10 @@ function astForWhileStmt (c, n) {
     /* while_stmt: 'while' test ':' suite ['else' ':' suite] */
     REQ(n, SYM.while_stmt);
     if (NCH(n) === 4) {
-        return new Sk.astnodes.While(ast_for_expr(c, CHILD(n, 1)), astForSuite(c, CHILD(n, 3)), [], n.lineno, n.col_offset);
+        return new Sk.astnodes.While(ast_for_expr(c, CHILD(n, 1)), astForSuite(c, CHILD(n, 3)), [], n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
     else if (NCH(n) === 7) {
-        return new Sk.astnodes.While(ast_for_expr(c, CHILD(n, 1)), astForSuite(c, CHILD(n, 3)), astForSuite(c, CHILD(n, 6)), n.lineno, n.col_offset);
+        return new Sk.astnodes.While(ast_for_expr(c, CHILD(n, 1)), astForSuite(c, CHILD(n, 3)), astForSuite(c, CHILD(n, 6)), n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
     Sk.asserts.fail("wrong number of tokens for 'while' stmt");
 }
@@ -2063,13 +2077,13 @@ function astForBinop (c, n) {
         ast_for_expr(c, CHILD(n, 0)),
         getOperator(CHILD(n, 1)),
         ast_for_expr(c, CHILD(n, 2)),
-        n.lineno, n.col_offset);
+        n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     var nops = (NCH(n) - 1) / 2;
     for (i = 1; i < nops; ++i) {
         nextOper = CHILD(n, i * 2 + 1);
         newoperator = getOperator(nextOper);
         tmp = ast_for_expr(c, CHILD(n, i * 2 + 2));
-        result = new Sk.astnodes.BinOp(result, newoperator, tmp, nextOper.lineno, nextOper.col_offset);
+        result = new Sk.astnodes.BinOp(result, newoperator, tmp, nextOper.lineno, nextOper.col_offset, nextOper.end_lineno, nextOper.end_col_offset);
     }
     return result;
 }
@@ -2091,7 +2105,7 @@ function ast_for_testlist (c, n) {
         return ast_for_expr(c, CHILD(n, 0));
     }
     else {
-        return new Sk.astnodes.Tuple(seq_for_testlist(c, n), Sk.astnodes.Load, n.lineno, n.col_offset/*, c.c_arena */);
+        return new Sk.astnodes.Tuple(seq_for_testlist(c, n), Sk.astnodes.Load, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset/*, c.c_arena */);
     }
 }
 
@@ -2105,9 +2119,9 @@ function ast_for_exprStmt (c, n) {
     var varName;
     var expr1;
     var ch;
+    var deep;
     var ann;
     var simple;
-    var deep;
     var expr3;
     REQ(n, SYM.expr_stmt);
     /* expr_stmt: testlist_star_expr (annassign | augassign (yield_expr|testlist) |
@@ -2119,7 +2133,7 @@ function ast_for_exprStmt (c, n) {
        test: ... here starts the operator precedence dance
      */
     if (NCH(n) === 1) {
-        return new Sk.astnodes.Expr(ast_for_testlist(c, CHILD(n, 0)), n.lineno, n.col_offset);
+        return new Sk.astnodes.Expr(ast_for_testlist(c, CHILD(n, 0)), n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
     else if (CHILD(n, 1).type === SYM.augassign) {
         ch = CHILD(n, 0);
@@ -2149,7 +2163,7 @@ function ast_for_exprStmt (c, n) {
             expr2 = ast_for_expr(c, ch);
         }
 
-        return new Sk.astnodes.AugAssign(expr1, astForAugassign(c, CHILD(n, 1)), expr2, n.lineno, n.col_offset);
+        return new Sk.astnodes.AugAssign(expr1, astForAugassign(c, CHILD(n, 1)), expr2, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
     else if (CHILD(n, 1).type === SYM.annassign) {
         if (!Sk.__future__.python3) {
@@ -2196,11 +2210,11 @@ function ast_for_exprStmt (c, n) {
         ch = CHILD(ann, 1);
         expr2 = ast_for_expr(c, ch);
         if (NCH(ann) == 2) {
-            return new Sk.astnodes.AnnAssign(expr1, expr2, null, simple, n.lineno, n.col_offset);
+            return new Sk.astnodes.AnnAssign(expr1, expr2, null, simple, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
         } else {
             ch = CHILD(ann, 3);
             expr3 = ast_for_expr(c, ch);
-            return new Sk.astnodes.AnnAssign(expr1, expr2, expr3, simple, n.lineno, n.col_offset);
+            return new Sk.astnodes.AnnAssign(expr1, expr2, expr3, simple, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
         }
     }
     else {
@@ -2223,7 +2237,7 @@ function ast_for_exprStmt (c, n) {
         else {
             expression = ast_for_expr(c, value);
         }
-        return new Sk.astnodes.Assign(targets, expression, n.lineno, n.col_offset);
+        return new Sk.astnodes.Assign(targets, expression, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
 }
 
@@ -2234,7 +2248,7 @@ function astForIfexpr (c, n) {
         ast_for_expr(c, CHILD(n, 2)),
         ast_for_expr(c, CHILD(n, 0)),
         ast_for_expr(c, CHILD(n, 4)),
-        n.lineno, n.col_offset);
+        n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 /**
@@ -2493,7 +2507,7 @@ function astForSlice (c, n) {
     if (ch.type === SYM.sliceop) {
         if (NCH(ch) === 1) {
             ch = CHILD(ch, 0);
-            step = new Sk.astnodes.NameConstant(Sk.builtin.none.none$, Sk.astnodes.Load, ch.lineno, ch.col_offset);
+            step = new Sk.astnodes.NameConstant(Sk.builtin.none.none$, Sk.astnodes.Load, ch.lineno, ch.col_offset, ch.end_lineno, ch.end_col_offset);
         }
         else {
             ch = CHILD(ch, 1);
@@ -2519,15 +2533,15 @@ function ast_for_atom(c, n)
             var s = STR(ch);
             if (s.length >= 4 && s.length <= 5) {
                 if (s === "None") {
-                    return new Sk.astnodes.NameConstant(Sk.builtin.none.none$, n.lineno, n.col_offset);
+                    return new Sk.astnodes.NameConstant(Sk.builtin.none.none$, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
                 }
 
                 if (s === "True") {
-                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.true$, n.lineno, n.col_offset);
+                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.true$, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
                 }
 
                 if (s === "False") {
-                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.false$, n.lineno, n.col_offset);
+                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.false$, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
                 }
             }
             name = new_identifier(s, c);
@@ -2561,10 +2575,10 @@ function ast_for_atom(c, n)
             //     }
             //     return NULL;
             // }
-            return new Sk.astnodes.Str(str, LINENO(n), n.col_offset, c.end_lineno, n.end_col_offset);
+            return new Sk.astnodes.Str(str, LINENO(n), n.col_offset, n.end_lineno, n.end_col_offset);
         }
         case TOK.T_NUMBER:
-            return new Sk.astnodes.Num(parsenumber(c, ch.value, n.lineno), n.lineno, n.col_offset);
+            return new Sk.astnodes.Num(parsenumber(c, ch.value, n.lineno), n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
         case TOK.T_ELLIPSIS: /* Ellipsis */
             return new Sk.astnodes.Ellipsis(LINENO(n), n.col_offset,
                             n.end_lineno, n.end_col_offset);
@@ -2669,7 +2683,7 @@ function ast_for_setdisplay(c, n) {
         elts[i / 2] = expression;
     }
 
-    return new Sk.astnodes.Set(elts, LINENO(n), n.col_offset);
+    return new Sk.astnodes.Set(elts, LINENO(n), n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 
@@ -2690,30 +2704,30 @@ function astForAtom(c, n) {
             // All names start in Load context, but may be changed later
             if (s.length >= 4 && s.length <= 5) {
                 if (s === "None") {
-                    return new Sk.astnodes.NameConstant(Sk.builtin.none.none$, n.lineno, n.col_offset /* c.c_arena*/);
+                    return new Sk.astnodes.NameConstant(Sk.builtin.none.none$, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset /* c.c_arena*/);
                 }
 
                 if (s === "True") {
-                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.true$, n.lineno, n.col_offset /* c.c_arena*/);
+                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.true$, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset /* c.c_arena*/);
                 }
 
                 if (s === "False") {
-                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.false$, n.lineno, n.col_offset /* c.c_arena*/);
+                    return new Sk.astnodes.NameConstant(Sk.builtin.bool.false$, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset /* c.c_arena*/);
                 }
 
             }
             var name = new_identifier(s, c)
 
             /* All names start in Load context, but may later be changed. */
-            return new Sk.astnodes.Name(name, Sk.astnodes.Load, n.lineno, n.col_offset);
+            return new Sk.astnodes.Name(name, Sk.astnodes.Load, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
         case TOK.T_STRING:
-            return new Sk.astnodes.Str(parsestrplus(c, n), n.lineno, n.col_offset);
+            return new Sk.astnodes.Str(parsestrplus(c, n), n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
         case TOK.T_NUMBER:
-            return new Sk.astnodes.Num(parsenumber(c, ch.value, n.lineno), n.lineno, n.col_offset);
+            return new Sk.astnodes.Num(parsenumber(c, ch.value, n.lineno), n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
         case TOK.T_LPAR: // various uses for parens
             ch = CHILD(n, 1);
             if (ch.type === TOK.T_RPAR) {
-                return new Sk.astnodes.Tuple([], Sk.astnodes.Load, n.lineno, n.col_offset);
+                return new Sk.astnodes.Tuple([], Sk.astnodes.Load, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             }
             if (ch.type === SYM.yield_expr) {
                 return ast_for_expr(c, ch);
@@ -2725,11 +2739,11 @@ function astForAtom(c, n) {
         case TOK.T_LSQB: // list or listcomp
             ch = CHILD(n, 1);
             if (ch.type === TOK.T_RSQB) {
-                return new Sk.astnodes.List([], Sk.astnodes.Load, n.lineno, n.col_offset);
+                return new Sk.astnodes.List([], Sk.astnodes.Load, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             }
             REQ(ch, SYM.listmaker);
             if (NCH(ch) === 1 || CHILD(ch, 1).type === TOK.T_COMMA) {
-                return new Sk.astnodes.List(seq_for_testlist(c, ch), Sk.astnodes.Load, n.lineno, n.col_offset);
+                return new Sk.astnodes.List(seq_for_testlist(c, ch), Sk.astnodes.Load, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             }
             return ast_for_listcomp(c, ch);
 
@@ -2743,7 +2757,7 @@ function astForAtom(c, n) {
             ch = CHILD(n, 1);
             if (n.type === TOK.T_RBRACE) {
                 //it's an empty dict
-                return new Sk.astnodes.Dict([], null, n.lineno, n.col_offset);
+                return new Sk.astnodes.Dict([], null, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             }
             else if (NCH(ch) === 1 || (NCH(ch) !== 0 && CHILD(ch, 1).type === TOK.T_COMMA)) {
                 //it's a simple set
@@ -2753,7 +2767,7 @@ function astForAtom(c, n) {
                     var expression = ast_for_expr(c, CHILD(ch, i));
                     elts[i / 2] = expression;
                 }
-                return new Sk.astnodes.Set(elts, n.lineno, n.col_offset);
+                return new Sk.astnodes.Set(elts, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             }
             else if (NCH(ch) !== 0 && CHILD(ch, 1).type == SYM.comp_for) {
                 //it's a set comprehension
@@ -2769,11 +2783,11 @@ function astForAtom(c, n) {
                     keys[i / 4] = ast_for_expr(c, CHILD(ch, i));
                     values[i / 4] = ast_for_expr(c, CHILD(ch, i + 2));
                 }
-                return new Sk.astnodes.Dict(keys, values, n.lineno, n.col_offset);
+                return new Sk.astnodes.Dict(keys, values, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             }
         case TOK.T_BACKQUOTE:
             //throw new Sk.builtin.SyntaxError("backquote not supported, use repr()", c.c_filename, n.lineno);
-            return new Sk.astnodes.Repr(ast_for_testlist(c, CHILD(n, 1)), n.lineno, n.col_offset);
+            return new Sk.astnodes.Repr(ast_for_testlist(c, CHILD(n, 1)), n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
         default:
             Sk.asserts.fail("unhandled atom", ch.type);
 
@@ -2802,7 +2816,7 @@ function astForAtomExpr(c, n) {
     }
 
     if (start && nch === 2) {
-        return new Sk.astnodes.Await(e, n.lineno, n.col_offset /*, c->c_arena*/);
+        return new Sk.astnodes.Await(e, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset /*, c->c_arena*/);
     }
 
     for (i = start + 1; i < nch; i++) {
@@ -2822,7 +2836,7 @@ function astForAtomExpr(c, n) {
 
     if (start) {
         /* there was an AWAIT */
-        return new Sk.astnodes.Await(e, n.line, n.col_offset /*, c->c_arena*/);
+        return new Sk.astnodes.Await(e, n.line, n.col_offset, n.end_lineno, n.end_col_offset /*, c->c_arena*/);
     }
     else {
         return e;
@@ -2844,7 +2858,7 @@ function astForPower (c, n) {
     }
     if (CHILD(n, NCH(n) - 1).type === SYM.factor) {
         f = ast_for_expr(c, CHILD(n, NCH(n) - 1));
-        e = new Sk.astnodes.BinOp(e, Sk.astnodes.Pow, f, n.lineno, n.col_offset);
+        e = new Sk.astnodes.BinOp(e, Sk.astnodes.Pow, f, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
     }
     return e;
 }
@@ -2853,7 +2867,7 @@ function astForStarred(c, n) {
     REQ(n, SYM.star_expr);
 
     /* The Load context is changed later */
-    return new Sk.astnodes.Starred(ast_for_expr(c, CHILD(n ,1)), Sk.astnodes.Load, n.lineno, n.col_offset /*, c.c_arena */)
+    return new Sk.astnodes.Starred(ast_for_expr(c, CHILD(n ,1)), Sk.astnodes.Load, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset /*, c.c_arena */)
 }
 
 function ast_for_expr (c, n) {
@@ -2904,17 +2918,17 @@ function ast_for_expr (c, n) {
                     seq[i / 2] = ast_for_expr(c, CHILD(n, i));
                 }
                 if (CHILD(n, 1).value === "and") {
-                    return new Sk.astnodes.BoolOp(Sk.astnodes.And, seq, n.lineno, n.col_offset /*, c.c_arena*/);
+                    return new Sk.astnodes.BoolOp(Sk.astnodes.And, seq, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset /*, c.c_arena*/);
                 }
                 Sk.asserts.assert(CHILD(n, 1).value === "or");
-                return new Sk.astnodes.BoolOp(Sk.astnodes.Or, seq, n.lineno, n.col_offset);
+                return new Sk.astnodes.BoolOp(Sk.astnodes.Or, seq, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             case SYM.not_test:
                 if (NCH(n) === 1) {
                     n = CHILD(n, 0);
                     continue LOOP;
                 }
                 else {
-                    return new Sk.astnodes.UnaryOp(Sk.astnodes.Not, ast_for_expr(c, CHILD(n, 1)), n.lineno, n.col_offset);
+                    return new Sk.astnodes.UnaryOp(Sk.astnodes.Not, ast_for_expr(c, CHILD(n, 1)), n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
                 }
                 break;
             case SYM.comparison:
@@ -2929,7 +2943,7 @@ function ast_for_expr (c, n) {
                         ops[(i - 1) / 2] = astForCompOp(c, CHILD(n, i));
                         cmps[(i - 1) / 2] = ast_for_expr(c, CHILD(n, i + 1));
                     }
-                    return new Sk.astnodes.Compare(ast_for_expr(c, CHILD(n, 0)), ops, cmps, n.lineno, n.col_offset);
+                    return new Sk.astnodes.Compare(ast_for_expr(c, CHILD(n, 0)), ops, cmps, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
                 }
                 break;
             case SYM.star_expr:
@@ -2969,10 +2983,10 @@ function ast_for_expr (c, n) {
                 }
 
                 if (is_from) {
-                    return new Sk.astnodes.YieldFrom(exp, n.lineno, n.col_offset);
+                    return new Sk.astnodes.YieldFrom(exp, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
                 }
 
-                return new Sk.astnodes.Yield(exp, n.lineno, n.col_offset);
+                return new Sk.astnodes.Yield(exp, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             case SYM.factor:
                 if (NCH(n) === 1) {
                     n = CHILD(n, 0);
@@ -3021,7 +3035,7 @@ function astForPrintStmt (c, n) {
         seq[j] = ast_for_expr(c, CHILD(n, i));
     }
     nl = (CHILD(n, NCH(n) - 1)).type === TOK.T_COMMA ? false : true;
-    return new Sk.astnodes.Print(dest, seq, nl, n.lineno, n.col_offset);
+    return new Sk.astnodes.Print(dest, seq, nl, n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
 }
 
 function astForStmt (c, n) {
@@ -3046,7 +3060,7 @@ function astForStmt (c, n) {
             case SYM.del_stmt:
                 return astForDelStmt(c, n);
             case SYM.pass_stmt:
-                return new Sk.astnodes.Pass(n.lineno, n.col_offset);
+                return new Sk.astnodes.Pass(n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             case SYM.flow_stmt:
                 return ast_for_flow_stmt(c, n);
             case SYM.import_stmt:
@@ -3060,7 +3074,7 @@ function astForStmt (c, n) {
             case SYM.print_stmt:
                 return astForPrintStmt(c, n);
             case SYM.debugger_stmt:
-                return new Sk.astnodes.Debugger(n.lineno, n.col_offset);
+                return new Sk.astnodes.Debugger(n.lineno, n.col_offset, n.end_lineno, n.end_col_offset);
             default:
                 Sk.asserts.fail("unhandled small_stmt");
         }
@@ -3216,5 +3230,115 @@ Sk.astDump = function (node) {
     return _format(node, "");
 };
 
+
+Sk.INHERITANCE_MAP = {
+    'mod': [Sk.astnodes.Module,
+            Sk.astnodes.Interactive,
+            Sk.astnodes.Expression,
+            Sk.astnodes.Suite],
+    'stmt': [Sk.astnodes.FunctionDef,
+             Sk.astnodes.AsyncFunctionDef,
+             Sk.astnodes.ClassDef,
+             Sk.astnodes.Return,
+             Sk.astnodes.Delete,
+             Sk.astnodes.Assign,
+             Sk.astnodes.AugAssign,
+             Sk.astnodes.AnnAssign,
+             Sk.astnodes.For,
+             Sk.astnodes.AsyncFor,
+             Sk.astnodes.While,
+             Sk.astnodes.If,
+             Sk.astnodes.With,
+             Sk.astnodes.AsyncWith,
+             Sk.astnodes.Raise,
+             Sk.astnodes.Try,
+             Sk.astnodes.Assert,
+             Sk.astnodes.Import,
+             Sk.astnodes.ImportFrom,
+             Sk.astnodes.Global,
+             Sk.astnodes.Nonlocal,
+             Sk.astnodes.Expr,
+             Sk.astnodes.Pass,
+             Sk.astnodes.Break,
+             Sk.astnodes.Continue,
+             Sk.astnodes.Print,
+             Sk.astnodes.Debugger],
+    'expr': [Sk.astnodes.BoolOp,
+             Sk.astnodes.BinOp,
+             Sk.astnodes.UnaryOp,
+             Sk.astnodes.Lambda,
+             Sk.astnodes.IfExp,
+             Sk.astnodes.Dict,
+             Sk.astnodes.Set,
+             Sk.astnodes.ListComp,
+             Sk.astnodes.SetComp,
+             Sk.astnodes.DictComp,
+             Sk.astnodes.GeneratorExp,
+             Sk.astnodes.Await,
+             Sk.astnodes.Yield,
+             Sk.astnodes.YieldFrom,
+             Sk.astnodes.Compare,
+             Sk.astnodes.Call,
+             Sk.astnodes.Num,
+             Sk.astnodes.Str,
+             Sk.astnodes.FormattedValue,
+             Sk.astnodes.JoinedStr,
+             Sk.astnodes.Bytes,
+             Sk.astnodes.Ellipsis,
+             Sk.astnodes.NameConstant,
+             Sk.astnodes.Constant,
+             Sk.astnodes.Attribute,
+             Sk.astnodes.Subscript,
+             Sk.astnodes.Starred,
+             Sk.astnodes.Name,
+             Sk.astnodes.List,
+             Sk.astnodes.Tuple],
+    'expr_context': [Sk.astnodes.Load,
+                     Sk.astnodes.Store,
+                     Sk.astnodes.Del,
+                     Sk.astnodes.AugLoad,
+                     Sk.astnodes.AugStore,
+                     Sk.astnodes.Param],
+    'slice': [Sk.astnodes.Slice,
+              Sk.astnodes.ExtSlice,
+              Sk.astnodes.Index],
+    'boolop': [Sk.astnodes.And, Sk.astnodes.Or],
+    'operator': [Sk.astnodes.Add,
+                 Sk.astnodes.Sub,
+                 Sk.astnodes.Mult,
+                 Sk.astnodes.MatMult,
+                 Sk.astnodes.Div,
+                 Sk.astnodes.Mod,
+                 Sk.astnodes.Pow,
+                 Sk.astnodes.LShift,
+                 Sk.astnodes.RShift,
+                 Sk.astnodes.BitOr,
+                 Sk.astnodes.BitXor,
+                 Sk.astnodes.BitAnd,
+                 Sk.astnodes.FloorDiv],
+    'unaryop': [Sk.astnodes.Invert,
+                Sk.astnodes.Not, 
+                Sk.astnodes.UAdd, 
+                Sk.astnodes.USub],
+    'cmpop': [Sk.astnodes.Eq,
+              Sk.astnodes.NotEq,
+              Sk.astnodes.Lt,
+              Sk.astnodes.LtE,
+              Sk.astnodes.Gt,
+              Sk.astnodes.GtE,
+              Sk.astnodes.Is,
+              Sk.astnodes.IsNot,
+              Sk.astnodes.In,
+              Sk.astnodes.NotIn],
+    'comprehension': [],
+    'excepthandler': [Sk.astnodes.ExceptHandler],
+    'arguments_': [],
+    'arg': [],
+    'keyword': [],
+    'alias': [],
+    'withitem': []
+};
+
 Sk.exportSymbol("Sk.astFromParse", Sk.astFromParse);
 Sk.exportSymbol("Sk.astDump", Sk.astDump);
+Sk.exportSymbol("Sk.INHERITANCE_MAP", Sk.INHERITANCE_MAP);

--- a/src/compile.js
+++ b/src/compile.js
@@ -993,7 +993,7 @@ Compiler.prototype.caugassign = function (s) {
     switch (e.constructor) {
         case Sk.astnodes.Attribute:
             to = this.vexpr(e.value);
-            auge = new Sk.astnodes.Attribute(e.value, e.attr, Sk.astnodes.AugLoad, e.lineno, e.col_offset);
+            auge = new Sk.astnodes.Attribute(e.value, e.attr, Sk.astnodes.AugLoad, e.lineno, e.col_offset, e.end_lineno, e.end_col_offset);
             aug = this.vexpr(auge, undefined, to);
             val = this.vexpr(s.value);
             res = this._gr("inplbinopattr", "Sk.abstr.numberInplaceBinOp(", aug, ",", val, ",'", s.op.prototype._astname, "')");
@@ -1003,7 +1003,7 @@ Compiler.prototype.caugassign = function (s) {
             // Only compile the subscript value once
             to = this.vexpr(e.value);
             augsub = this.vslicesub(e.slice);
-            auge = new Sk.astnodes.Subscript(e.value, augsub, Sk.astnodes.AugLoad, e.lineno, e.col_offset);
+            auge = new Sk.astnodes.Subscript(e.value, augsub, Sk.astnodes.AugLoad, e.lineno, e.col_offset, e.end_lineno, e.end_col_offset);
             aug = this.vexpr(auge, undefined, to, augsub);
             val = this.vexpr(s.value);
             res = this._gr("inplbinopsubscr", "Sk.abstr.numberInplaceBinOp(", aug, ",", val, ",'", s.op.prototype._astname, "')");

--- a/src/lib/ast.js
+++ b/src/lib/ast.js
@@ -1,0 +1,400 @@
+var $builtinmodule = function (name) {
+    var mod = {__name__: Sk.builtin.str("_ast")};
+
+    function mangleAppropriately(name) {
+        switch (name) {
+            case "name": return "name_$rn$";
+            default: return name;
+        }
+    }
+    
+    /**
+     * Consumes an AST Node (JS version). Return a list of tuples of 
+     * ``(fieldname, value)`` for each field in ``node._fields`` that is
+     * present on *node*.
+     */
+    var iter_fieldsJs = function(node) {
+        var fieldList = [];
+        for (var i = 0; i < node._fields.length; i += 2) {
+            var field = node._fields[i];
+            if (field in node) {
+                fieldList.push([field, node[field]]);
+            }
+        }
+        return fieldList;
+    };
+    
+    mod.iter_fields = function(node) {
+        return node._fields;
+    };
+    
+    var convertValue = function(value) {
+        // acbart: kwarg field for lambdas (and functions perhaps?) can be undefined
+        if (value === null || value === undefined) {
+            return Sk.builtin.none.none$;
+        } else if (isSpecialPyAst(value)) {
+            var constructorName = functionName(value);
+            return Sk.misceval.callsim(mod[constructorName], constructorName, true);
+        } else if (typeof value == "number") {
+            return Sk.builtin.assk$(value);
+        } else if (Array === value.constructor) {
+            var subvalues = [];
+            for (var j = 0; j < value.length; j += 1) {
+                var subvalue = value[j];
+                if (isSpecialPyAst(subvalue)) {
+                    var constructorName = functionName(subvalue);
+                    subvalue = Sk.misceval.callsim(mod[constructorName], constructorName, true);
+                    subvalues.push(subvalue);
+                } else if (isJsAst(subvalue)) {
+                    var constructorName = functionName(subvalue.constructor);
+                    subvalue = Sk.misceval.callsim(mod[constructorName], subvalue);
+                    subvalues.push(subvalue);
+                }
+                // No AST nodes have primitive list values, just
+                //  lists of AST nodes
+            }
+            return Sk.builtin.list(subvalues);
+        } else if (isJsAst(value)) {
+            var constructorName = functionName(value.constructor);
+            return Sk.misceval.callsim(mod[constructorName], value);
+        } else {// Else already a Python value
+            return value;
+        }
+    };
+    
+    var isJsAst = function(jsNode) {
+        return jsNode instanceof Object && "_astname" in jsNode;
+    };
+    var isSpecialPyAst = function(val) {
+        if (typeof val == "function") {
+            switch (functionName(val)) {
+                case "Add": case "Add": case "Sub": case "Mult": case "Div": 
+                case "Mod": case "Pow": case "LShift": case "RShift": 
+                case "BitOr": case "BitXor": case "BitAnd": case "FloorDiv":
+                case "Store": case "Load": case "Del": case "Param":
+                case "And": case "Or": case "Xor": case "Not":
+                case "Invert": case "UAdd": case "USub":
+                case "Lt": case "Gt": case "LtE": case "GtE":
+                case "NotEq": case "Eq": case "Is": case "IsNot":
+                case "In":  case "NotIn":
+                    return true;
+                default: return false;
+            }
+        } else {
+            return false;
+        }
+    };
+    var isPyAst = function(pyValue) {
+        return Sk.misceval.isTrue(Sk.builtin.isinstance(pyValue, mod.AST));
+    };
+    var isPyList = function(pyValue) {
+        return Sk.misceval.isTrue(Sk.builtin.isinstance(pyValue, Sk.builtin.list));
+    };
+    
+    var iter_child_nodesJs = function(node) {
+        var fieldList = iter_fieldsJs(node);
+        var resultList = [];
+        for (var i = 0; i < fieldList.length; i += 1) {
+            var field = fieldList[i][0], value = fieldList[i][1];
+            if (value === null) {
+                continue;
+            }
+            if ("_astname" in value) {
+                resultList.push(value);
+            } else if (value.constructor === Array) {
+                for (var j = 0; j < value.length; j += 1) {
+                    var subvalue = value[j];
+                    if ("_astname" in subvalue) {
+                        resultList.push(subvalue);
+                    }
+                }
+            }
+        }
+        return resultList;
+    };
+    
+    // Python node
+    mod.iter_child_nodes = function(node) {
+        var fieldList = node._fields.v;
+        var childFields = [];
+        for (var i = 0; i < fieldList.length; i += 1) {
+            var field = Sk.ffi.remapToJs(fieldList[i].v[0]), 
+                value = fieldList[i].v[1];
+            if (isSpecialPyAst(value)) {
+                childFields.push(value);
+            } else if (isPyAst(value)) {
+                childFields.push(value);
+            } else if (isPyList(value)) {
+                for (var j = 0; j < value.v.length; j += 1) {
+                    var subvalue = value.v[j];
+                    if (isPyAst(subvalue)) {
+                        childFields.push(subvalue);
+                    }
+                }
+            }
+        }
+        return Sk.builtin.list(childFields);
+    };
+    
+    /**
+     * Dump the tree in a pretty format
+    */
+    mod.dump = function(node, annotate_fields, include_attributes) {
+        // Confirm valid arguments
+        Sk.builtin.pyCheckArgs("dump", arguments, 1, 3);
+        // node argument
+        if (!isPyAst(node)) {
+            throw new Sk.builtin.TypeError("expected AST, got "+Sk.abstr.typeName(node));
+        }
+        // annotate_fields argument
+        if (annotate_fields === undefined) {
+            annotate_fields = true;
+        } else {
+            Sk.builtin.pyCheckType("annotate_fields", "boolean", Sk.builtin.checkBool(annotate_fields));
+            annotate_fields = Sk.ffi.remapToJs(annotate_fields);
+        }
+        // include_attributes argument
+        if (include_attributes === undefined) {
+            include_attributes = true;
+        } else {
+            Sk.builtin.pyCheckType("include_attributes", "boolean", Sk.builtin.checkBool(include_attributes));
+            include_attributes = Sk.ffi.remapToJs(include_attributes);
+        }
+        // recursive dump
+        var _format = function(node) {
+            //console.log(node.astname, node);
+            if (isSpecialPyAst(node)) {
+                return functionName(node)+"()";
+            } else if (isPyAst(node)) {
+                var rv = node.jsNode._astname+"(";
+                var fieldList = node._fields.v;
+                var fieldArgs = [];
+                for (var i = 0; i < fieldList.length; i += 1) {
+                    var field = Sk.ffi.remapToJs(fieldList[i].v[0]), 
+                        value = fieldList[i].v[1];
+                    value = _format(value);
+                    if (annotate_fields) {
+                        fieldArgs.push(field+"="+value);
+                    } else {
+                        fieldArgs.push(value);
+                    }
+                }
+                var attributeList = node._attributes.v;
+                if (include_attributes) {
+                    for (var i = 0; i < attributeList.length; i += 1) {
+                        var field = Sk.ffi.remapToJs(attributeList[i]);
+                        var value = Sk.ffi.remapToJs(node.jsNode[field]);
+                        fieldArgs.push(field+"="+value);
+                    }
+                }
+                fieldArgs = fieldArgs.join(", ");
+                return rv + fieldArgs + ")";
+            } else if (isPyList(node)) {
+                var nodes = node.v.map(_format);
+                nodes = nodes.join(", ");
+                return "["+nodes+"]";
+            } else {
+                return Sk.ffi.remapToJs(node.$r());
+            }
+        };
+        return Sk.ffi.remapToPy(_format(node, 0));
+    };
+
+    var depth = 0;
+    var NodeVisitor = function($gbl, $loc) {
+        // Takes in Python Nodes, not JS Nodes
+        $loc.visit = new Sk.builtin.func(function(self, node) {
+            depth += 1;
+            /** Visit a node. **/
+            //print(" ".repeat(depth), "VISIT", node.jsNode._astname)
+            var method_name = "visit_" + node.jsNode._astname;
+            //print(" ".repeat(depth), "I'm looking for", method_name)
+            method_name = Sk.ffi.remapToPy(method_name);
+            method = Sk.builtin.getattr(self, method_name, $loc.generic_visit);
+            if (method.im_self) {
+                //print(method.im_func.func_code)
+                result = Sk.misceval.callsim(method, node);
+                depth -= 1;
+                return result;
+            }else {
+                result = Sk.misceval.callsim(method, self, node);
+                depth -= 1;
+                return result;
+            }
+            
+        });
+        // Takes in Python Nodes, not JS Nodes
+        $loc.generic_visit = new Sk.builtin.func(function(self, node) {
+            /** Called if no explicit visitor function exists for a node. **/
+            //print(" ".repeat(depth), "Generically checked", node.astname)
+            var fieldList = mod.iter_fields(node).v;
+            for (var i = 0; i < fieldList.length; i += 1) {
+                var field = fieldList[i].v[0].v, value = fieldList[i].v[1];
+                if (value === null) {
+                    continue;
+                } else if (isPyList(value)) {
+                    for (var j = 0; j < value.v.length; j += 1) {
+                        var subvalue = value.v[j];
+                        if (isPyAst(subvalue)) {
+                            //print(self.visit)
+                            Sk.misceval.callsim(self.visit, self, subvalue);
+                        }
+                    }
+                } else if (isPyAst(value)) {
+                    //print(self.visit)
+                    Sk.misceval.callsim(self.visit, self, value);
+                }
+            }
+            return Sk.builtin.none.none$;
+        });
+    };
+    mod.NodeVisitor = Sk.misceval.buildClass(mod, NodeVisitor, "NodeVisitor", []);
+
+    // Python node
+    mod.walk = function(node) {
+        if (isSpecialPyAst(node)) {
+            return Sk.builtin.list([]);
+        }
+        var resultList = [node];
+        var childList = mod.iter_child_nodes(node);
+        for (var i = 0; i < childList.v.length; i += 1) {
+            var child = childList.v[i];
+            var children = mod.walk(child);
+            resultList = resultList.concat(children.v);
+        }
+        return Sk.builtin.list(resultList);
+    };
+
+    /*NodeVisitor.prototype.visitList = function(nodes) {
+        for (var j = 0; j < nodes.length; j += 1) {
+            var node = nodes[j];
+            if ("_astname" in node) {
+                this.visit(node);
+            }
+        }
+    }
+
+    NodeVisitor.prototype.recursive_walk = function(node) {
+        var todo = [node];
+        var result = [];
+        while (todo.length > 0) {
+            node = todo.shift();
+            todo = todo.concat(iter_child_nodes(node))
+            result.push(node);
+        }
+        return result;
+    }*/
+    
+    var depth = 0;
+    AST = function($gbl, $loc) {
+        var copyFromJsNode = function(self, key, jsNode) {
+            if (key in self.jsNode) {
+                Sk.abstr.sattr(self, Sk.builtin.str(key), Sk.ffi.remapToPy(jsNode[key]), true);
+                self._attributes.push(Sk.builtin.str(key));
+            }
+        };
+        $loc.__init__ = new Sk.builtin.func(function (self, jsNode, partial) {
+            depth+=1;
+            if (partial === true) {
+                // Alternative constructor for Skulpt's weird nodes
+                //console.log(" ".repeat(depth)+"S:", jsNode);
+                self.jsNode = {"_astname": jsNode};
+                self.astname = jsNode;
+                self._fields = Sk.builtin.list([]);
+                self._attributes = Sk.builtin.list([]);
+                Sk.abstr.sattr(self, Sk.builtin.str("_fields"), self._fields, true);
+                Sk.abstr.sattr(self, Sk.builtin.str("_attributes"), self._attributes, true);
+                //console.log(" ".repeat(depth)+"--", jsNode);
+            } else {
+                //console.log(" ".repeat(depth)+"P:", jsNode._astname);
+                self.jsNode = jsNode;
+                self.astname = jsNode._astname;
+                var fieldListJs = iter_fieldsJs(jsNode);
+                self._fields = [];
+                self._attributes = [];
+                //console.log(" ".repeat(depth)+"FIELDS");
+                for (var i = 0; i < fieldListJs.length; i += 1) {
+                    var field = fieldListJs[i][0], value = fieldListJs[i][1];
+                    //console.log(" ".repeat(depth+1)+field, value)
+                    if (field === "docstring" && value === undefined) {
+                        value = Sk.builtin.str("");
+                    } else {
+                        value = convertValue(value);
+                    }
+                    field = mangleAppropriately(field);
+                    Sk.abstr.sattr(self, Sk.builtin.str(field), value, true);
+                    // TODO: Figure out why name is getting manged, and make it stop!
+                    self._fields.push(Sk.builtin.tuple([Sk.builtin.str(field), value]));
+                }
+                //console.log(" ".repeat(depth)+"FIELDS")
+                self._fields = Sk.builtin.list(self._fields);
+                Sk.abstr.sattr(self, Sk.builtin.str("_fields"), self._fields, true);
+                copyFromJsNode(self, "lineno", self.jsNode);
+                copyFromJsNode(self, "col_offset", self.jsNode);
+                copyFromJsNode(self, "end_lineno", self.jsNode);
+                copyFromJsNode(self, "end_col_offset", self.jsNode);
+                self._attributes = Sk.builtin.list(self._attributes);
+                Sk.abstr.sattr(self, Sk.builtin.str("_attributes"), self._attributes, true);
+                //console.log(" ".repeat(depth)+"--", jsNode._astname);
+            }
+            depth -= 1;
+        });
+        $loc.__str__ = new Sk.builtin.func(function (self) {
+            return Sk.builtin.str("<_ast."+self.astname+" object>");
+        });
+        $loc.__repr__ = $loc.__str__;
+    };
+    mod.AST = Sk.misceval.buildClass(mod, AST, "AST", []);
+    
+    //mod.literal_eval
+    // Implementation wouldn't be hard, but it does require a lot of Skulpting
+    
+    mod.parse = function parse(source, filename) {
+        if (!(/\S/.test(source))) {
+            return Sk.misceval.callsim(mod.Module, new Sk.INHERITANCE_MAP.mod[0]([]));
+        }
+        if (filename === undefined) {
+            filename = Sk.builtin.str("<unknown>");
+        }
+        var parse = Sk.parse(filename, Sk.ffi.remapToJs(source));
+        ast = Sk.astFromParse(parse.cst, filename, parse.flags);
+        return Sk.misceval.callsim(mod.Module, ast);
+        // Walk tree and create nodes (lazily?)
+    };
+    
+    /*
+    mod.Module = function ($gbl, $loc) {
+        Sk.abstr.superConstructor(mod.OrderedDict, this, items);
+    }*/
+    
+    function functionName(fun) {
+        let astname = fun.prototype._astname;
+        switch (astname) {
+            case "arguments": return "arguments_";
+            default: return astname;
+        }
+        /*
+        var ret = fun.toString();
+        ret = ret.substr("function ".length);
+        ret = ret.substr(0, ret.indexOf("("));
+        if (ret == "In_") {
+            ret = "In";
+        } else if (ret == "Import_") {
+            ret = "Import";
+        }
+        return ret;*/
+    }
+    
+    for (var base in Sk.INHERITANCE_MAP) {
+        var baseClass = function($gbl, $loc) { return this;};
+        mod[base] = Sk.misceval.buildClass(mod, baseClass, base, [mod.AST]);
+        for (var i=0; i < Sk.INHERITANCE_MAP[base].length; i++) {
+            var nodeType = Sk.INHERITANCE_MAP[base][i];
+            var nodeName = nodeType.prototype._astname;
+            var nodeClass = function($gbl, $loc) { return this;};
+            mod[nodeName] = Sk.misceval.buildClass(mod, nodeClass, nodeName, [mod[base]]);
+        }
+    }
+    
+    return mod;
+};

--- a/src/lib/ast.py
+++ b/src/lib/ast.py
@@ -1,1 +1,0 @@
-raise NotImplementedError("ast is not yet implemented in Skulpt")

--- a/src/module.js
+++ b/src/module.js
@@ -1,7 +1,13 @@
 /**
  * @constructor
  */
-Sk.builtin.module = function module () {
+Sk.builtin.module = function module (name) {
+    if (!(this instanceof Sk.builtin.module)) {
+        return new Sk.builtin.module(name);
+    }
+    this["$d"] = {__name__: name};
+    this["$d"]["__dict__"] = this["$d"];
+    return this;
 };
 Sk.exportSymbol("Sk.builtin.module", Sk.builtin.module);
 

--- a/src/pgen/ast/Python.asdl
+++ b/src/pgen/ast/Python.asdl
@@ -62,7 +62,7 @@ module Python
 
           -- XXX Jython will be different
           -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+          attributes (int lineno, int col_offset, int end_lineno, int end_col_offset)
 
           -- BoolOp() can use left & right?
     expr = BoolOp(boolop op, expr* values)
@@ -102,7 +102,7 @@ module Python
          | Tuple(expr* elts, expr_context ctx)
 
           -- col_offset is the byte offset in the utf8 string the parser uses
-          attributes (int lineno, int col_offset)
+          attributes (int lineno, int col_offset, int end_lineno, int end_col_offset)
 
     expr_context = Load | Store | Del | AugLoad | AugStore | Param
 
@@ -122,7 +122,7 @@ module Python
     comprehension = (expr target, expr iter, expr* ifs, int is_async)
 
     excepthandler = ExceptHandler(expr? type, identifier? name, stmt* body)
-                    attributes (int lineno, int col_offset)
+                    attributes (int lineno, int col_offset, int end_lineno, int end_col_offset)
 
     -- Skulpt: added the underscore because aguments is a reserved word in
     -- javascript
@@ -130,7 +130,7 @@ module Python
                  arg? kwarg, expr* defaults)
 
     arg = (identifier arg, expr? annotation)
-           attributes (int lineno, int col_offset)
+           attributes (int lineno, int col_offset, int end_lineno, int end_col_offset)
 
     -- keyword arguments supplied to call (NULL identifier for **kwargs)
     keyword = (identifier? arg, expr value)

--- a/src/pgen/ast/asdl_js.py
+++ b/src/pgen/ast/asdl_js.py
@@ -362,7 +362,7 @@ def main(asdlfile, outputfile):
     if not asdl.check(mod):
         sys.exit(1)
 
-    f = open(outputfile, "wb")
+    f = open(outputfile, "w")
 
     f.write(auto_gen_msg)
     f.write("/* Object that holds all nodes */\n");
@@ -390,6 +390,6 @@ def main(asdlfile, outputfile):
 if __name__ == "__main__":
     import sys
     if len(sys.argv) != 3:
-        print "usage: asdl_js.py input.asdl output.js"
+        print("usage: asdl_js.py input.asdl output.js")
         raise SystemExit()
     main(sys.argv[1], sys.argv[2])

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -1,4 +1,4 @@
-var tokens = Sk.token.tokens
+var tokens = Sk.token.tokens;
 
 const TokenError = Sk.builtin.SyntaxError;
 const IndentationError = Sk.builtin.SyntaxError;

--- a/test/test_ast.py
+++ b/test/test_ast.py
@@ -1,0 +1,94 @@
+import ast
+
+print(dir(ast))
+
+addition = ast.parse("1 + 2")
+
+assert isinstance(addition, ast.Module), "Unable to parse addition"
+assert hasattr(addition, 'body'), "Module has no body"
+print(addition)
+print(addition._fields)
+print(addition.body)
+assert addition.body[0].value.left.n == 1, "Parsed Addition wasn't correct"
+print("lineno", addition.body[0].lineno)
+assert addition.body[0].lineno == 1, "Addition's lineno was not 1"
+assert addition.body[0].col_offset == 0, "Addition's col_offset was not 0"
+assert addition.body[0].end_col_offset == 1, "Addition's end_col_offset was not 1"
+assert addition.body[0].end_lineno == 1, "Addition's end_lineno was not 1"
+
+print("1 + 2")
+#print(ast.dump(addition)
+
+comparison = ast.parse('1 < 1')
+assert isinstance(comparison, ast.Module), "Unable to parse comparison"
+assert isinstance(comparison.body[0].value, ast.Compare), "Could not access Compare object"
+print(comparison.body[0].value.ops)
+assert len(comparison.body[0].value.ops) == 1, "Did not retrieve operations from comparison"
+
+print("*"*20)
+
+ANNASSIGN_CODE = 'a: int = 0'
+ann_assign = ast.parse(ANNASSIGN_CODE)
+print(ast.dump(ann_assign))
+
+FOR_CODE = "for x in y:\n    a = 0"
+for_loop = ast.parse(FOR_CODE)
+print("*"*20)
+print(FOR_CODE)
+print("FOR", for_loop, "should be Module")
+print("FOR", for_loop.body[0], "should be For")
+print("FOR", for_loop.body[0].body[0], "should be Assign")
+#print("FOR", for_loop.body[0].body[0].id, "should not be a")
+print(ast.dump(for_loop))
+
+print("MULTILINE")
+multiline = ast.parse("""for x in y:
+   a + 1 - 3
+if x:
+   try:
+       a = 7
+   except:
+       False
+def T():
+    while Banana():
+        return 7
+class X(basic):
+    def define(apple, banana):
+        this.__init__(7, 3, 4)
+'''HEY''' or (1 and 2)
+assert EXPLODE()
+one += one
+one -= one
+one | one
+a[0] += 100
+5 < 3
+not True
+del apple["Hearted"]
+import garbage
+8 is 7
+""")
+
+print("iter_fields:", ast.iter_fields(multiline.body[0]))
+
+print("iter_child_nodes:", ast.iter_child_nodes(multiline))
+
+print("walk:", ast.walk(multiline))
+
+print(ast.dump(multiline, True, False))
+print("*"*40)
+class VisitStuff(ast.NodeVisitor):
+    def __init__(self):
+        self.nums = 0
+    def visit_Num(self, node):
+        print("Found a ", node.n)
+        self.nums += 1
+vs = VisitStuff()
+p = ast.parse('''a = 0\nprint(a+5) or 5''')
+vs.generic_visit(p)
+assert vs.nums == 3, "Did not find 3 nums, only: "+str(vs.nums)
+
+
+print("All tests complete.")
+
+assert ast.In, "Could not load In ast element"
+

--- a/test/test_ast2.py
+++ b/test/test_ast2.py
@@ -1,0 +1,9 @@
+import ast
+
+func = ast.parse("def alpha(): pass")
+
+assert func.body[0].name == "alpha"
+
+assert func.body[0].__name__ == "FunctionDef"
+
+func = ast.parse("lambda: 0")


### PR DESCRIPTION
With my semester wrapping up, I wanted to make some pull requests for features I added during the semester. This one is probably not the most important, but its a big part of BlockPy's toolchain, so I wanted to get a sense of your interest. Others include `exec`, more info in exceptions, and a fix to special method lookup in classes.

This PR adds in an importable `ast` module that has the most of the core functionality you'd expect from CPython's `ast` library, including AST node classes, a `NodeVisitor` class, and a `parse` function. It also expands nodes to include ending lines and columns in addition to the starting attributes.

If you're interested, I'm willing to spend some time cleaning up some of the code further - I am passing all the test cases I wrote, at least, and none of the existing tests seem to be broken. Not sure how compatible this is with the other pull requests open right now. Probably should merge them in first and then make further modifications as required.