### PR TITLE
chr() python3 mode awareness

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -500,6 +500,10 @@ Sk.builtin.ord = function ord (x) {
 };
 
 Sk.builtin.chr = function chr (x) {
+    if (Sk.__future__.python3) {
+        return Sk.builtin.unichr(x);
+    }
+    
     Sk.builtin.pyCheckArgsLen("chr", arguments.length, 1, 1);
     if (!Sk.builtin.checkInt(x)) {
         throw new Sk.builtin.TypeError("an integer is required");
@@ -515,7 +519,7 @@ Sk.builtin.chr = function chr (x) {
 };
 
 Sk.builtin.unichr = function unichr (x) {
-    Sk.builtin.pyCheckArgsLen("chr", arguments.length, 1, 1);
+    Sk.builtin.pyCheckArgsLen("unichr", arguments.length, 1, 1);
     if (!Sk.builtin.checkInt(x)) {
         throw new Sk.builtin.TypeError("an integer is required");
     }


### PR DESCRIPTION
Making possible to use chr() with unicode characters in python3 mode