### PR TITLE
Un-break string equality in Python 2

### DIFF
--- a/src/str.js
+++ b/src/str.js
@@ -156,11 +156,7 @@ Sk.builtin.str.prototype.tp$iter = function () {
 
 Sk.builtin.str.prototype.tp$richcompare = function (other, op) {
     if (!(other instanceof Sk.builtin.str)) {
-        if (Sk.__future__.python3) {
-            return Sk.builtin.NotImplemented.NotImplemented$;
-        } else {
-            return false;
-        }
+        return Sk.builtin.NotImplemented.NotImplemented$;
     }
 
     switch (op) {

--- a/test/unit/test_regressions.py
+++ b/test/unit/test_regressions.py
@@ -1,0 +1,16 @@
+"""Tests for bug regressions."""
+
+import unittest
+
+class RegressionTest(unittest.TestCase):
+    def test_string_equality(self):
+        self.assertTrue("1" == "1")
+        self.assertFalse("1" != "1")
+        self.assertFalse("1" == "2")
+        self.assertTrue("1" != "2")
+        self.assertFalse("1" == 1)
+        self.assertTrue("1" != 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_compare.py
+++ b/test/unit3/test_compare.py
@@ -197,9 +197,18 @@ class ComparisonTest(unittest.TestCase):
         self.assertRaises(TypeError, helper, A(-1), A(1), -1)
 
         # Built-in type comparisons should no longer work in python 3
+        # (but equality should)
         self.assertRaises(TypeError, lambda: (1,2) > [3,4])
+        self.assertFalse((1,2) == [3,4])
+        self.assertTrue((1,2) != [3,4])
+
         self.assertRaises(TypeError, lambda: None > (1,2))
+        self.assertFalse(None == (1,2))
+        self.assertTrue(None != (1,2))
+
         self.assertRaises(TypeError, lambda: 2 > "2")
+        self.assertFalse(2 == "2")
+        self.assertTrue(2 != "2")
 ##
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
PR #986 broke string equality in Python 2 (doh). This PR adds tests to replicate and then fixes.

I'd like to fast-track this in; it's a small, tested fix to something previously accepted.