### PR TITLE
Performance improvements

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -830,26 +830,30 @@ Sk.exportSymbol("Sk.abstr.objectSetItem", Sk.abstr.objectSetItem);
 
 
 Sk.abstr.gattr = function (obj, pyName, canSuspend) {
-    var ret, f;
-    var objname = Sk.abstr.typeName(obj);
-    var jsName = pyName.$jsstr();
-
-    if (obj === null) {
+    // TODO is it even valid to pass something this shape in here?
+    // Should this be an assert?
+    if (obj === null || !obj.tp$getattr) {
+        let objname = Sk.abstr.typeName(obj);
+        let jsName = pyName.$jsstr();
         throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
     }
 
-    if (obj.tp$getattr !== undefined) {
-        ret = obj.tp$getattr(pyName, canSuspend);
+    // This function is so hot that we do our own inline suspension checks
+
+    let ret = obj.tp$getattr(pyName, canSuspend);
+
+    if (ret === undefined) {
+        throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + pyName.$jsstr() + "'");
+    } else if (ret.$isSuspension) {
+        return Sk.misceval.chain(ret, function(r) {
+            if (r === undefined) {
+                throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + pyName.$jsstr() + "'");
+            }
+            return r;
+        });
+    } else {
+        return ret;
     }
-
-    ret = Sk.misceval.chain(ret, function(r) {
-        if (r === undefined) {
-            throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
-        }
-        return r;
-    });
-
-    return canSuspend ? ret : Sk.misceval.retryOptionalSuspensionOrThrow(ret);
 };
 Sk.exportSymbol("Sk.abstr.gattr", Sk.abstr.gattr);
 

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -830,29 +830,26 @@ Sk.exportSymbol("Sk.abstr.objectSetItem", Sk.abstr.objectSetItem);
 
 
 Sk.abstr.gattr = function (obj, pyName, canSuspend) {
-    // TODO is this valid usage? You shouldn't be able to get a JS null
-    // into native code. Perhaps this wants to be an assert.
-    if (obj === null || !obj.tp$getattr) {
-        throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + pyName.$jsstr() + "'");
+    var ret, f;
+    var objname = Sk.abstr.typeName(obj);
+    var jsName = pyName.$jsstr();
+
+    if (obj === null) {
+        throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
     }
 
-    // This is a sufficiently hot path to hoist the suspension check
-    // (but even that ends up costing too much, even if we strip this function
-    // down to a tiny number of lines, so we now fast-path the tp$getattr()
-    // call directly in generated code. Seriously surprising and confusing.)
-    let ret = obj.tp$getattr(pyName, canSuspend);
-    if (ret && ret.$isSuspension) {
-        return Sk.misceval.chain(ret, function(r) {
-            if (r === undefined) {
-                throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + pyName.$jsstr() + "'");
-            }
-            return r;
-        });
-    } else if (ret === undefined) {
-        throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + pyName.$jsstr() + "'");
-    } else {
-        return ret;
+    if (obj.tp$getattr !== undefined) {
+        ret = obj.tp$getattr(pyName, canSuspend);
     }
+
+    ret = Sk.misceval.chain(ret, function(r) {
+        if (r === undefined) {
+            throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
+        }
+        return r;
+    });
+
+    return canSuspend ? ret : Sk.misceval.retryOptionalSuspensionOrThrow(ret);
 };
 Sk.exportSymbol("Sk.abstr.gattr", Sk.abstr.gattr);
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -664,13 +664,7 @@ Compiler.prototype.ccall = function (e) {
         out("if (typeof self === \"undefined\" || self.toString().indexOf(\"Window\") > 0) { throw new Sk.builtin.RuntimeError(\"super(): no arguments\") };")
         positionalArgs = "[$gbl.__class__,self]";
     }
-    if (keywordArgs !== "undefined") {
-        out("$ret = Sk.misceval.applyOrSuspend(",func,",undefined,undefined,",keywordArgs,",",positionalArgs,");");
-    } else if (positionalArgs != "[]") {
-        out ("$ret = Sk.misceval.callsimOrSuspendArray(", func, ", ", positionalArgs, ");");
-    } else {
-        out ("$ret = Sk.misceval.callsimOrSuspendArray(", func, ");");
-    }
+    out ("$ret = (",func,".tp$call)?",func,".tp$call(",positionalArgs,",",keywordArgs,") : Sk.misceval.applyOrSuspend(",func,",undefined,undefined,",keywordArgs,",",positionalArgs,");");
 
     this._checkSuspension(e);
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -911,12 +911,8 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
                     this._checkSuspension(e);
                     return this._gr("lattr", "$ret");
                 case Sk.astnodes.Load:
-                    // This was an Sk.abstr.gattr() call, but inlining the
-                    // tp$getattr() call saved us nearly 5% on a benchmark.
-                    // No clue why. -Meredydd, 1/Feb/2020
-                    out("$ret = ", val, ".tp$getattr(", mname, ", true);");
+                    out("$ret = Sk.abstr.gattr(", val, ",", mname, ", true);");
                     this._checkSuspension(e);
-                    out("if ($ret===undefined) { throw new Sk.builtin.AttributeError(\"'\"+Sk.abstr.typeName(",val,")+\"' object has no attribute " + e.attr["$r"]().v + "\"); }");
                     return this._gr("lattr", "$ret");
                 case Sk.astnodes.AugStore:
                     // To be more correct, we shouldn't sattr() again if the in-place update worked.

--- a/src/compile.js
+++ b/src/compile.js
@@ -911,8 +911,12 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
                     this._checkSuspension(e);
                     return this._gr("lattr", "$ret");
                 case Sk.astnodes.Load:
-                    out("$ret = Sk.abstr.gattr(", val, ",", mname, ", true);");
+                    // This was an Sk.abstr.gattr() call, but inlining the
+                    // tp$getattr() call saved us nearly 5% on a benchmark.
+                    // No clue why. -Meredydd, 1/Feb/2020
+                    out("$ret = ", val, ".tp$getattr(", mname, ", true);");
                     this._checkSuspension(e);
+                    out("if ($ret===undefined) { throw new Sk.builtin.AttributeError(\"'\"+Sk.abstr.typeName(",val,")+\"' object has no attribute " + e.attr["$r"]().v + "\"); }");
                     return this._gr("lattr", "$ret");
                 case Sk.astnodes.AugStore:
                     // To be more correct, we shouldn't sattr() again if the in-place update worked.

--- a/src/dict.js
+++ b/src/dict.js
@@ -76,6 +76,18 @@ Sk.builtin.dict.prototype.key$lookup = function (bucket, key) {
     var eq;
     var i;
 
+    // Fast path: We spend a *lot* of time looking up strings
+    // in dictionaries. (Every attribute access, for starters.)
+    if (key.ob$type === Sk.builtin.str) {
+        for (i = 0; i < bucket.items.length; i++) {
+            item = bucket.items[i];
+            if (item.lhs.ob$type === Sk.builtin.str && item.lhs.v === key.v) {
+                return item;
+            }
+        }
+        return null;
+    }
+
     for (i = 0; i < bucket.items.length; i++) {
         item = bucket.items[i];
         eq = Sk.misceval.richCompareBool(item.lhs, key, "Eq");

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -854,9 +854,9 @@ Sk.exportSymbol("Sk.misceval.callsim", Sk.misceval.callsim);
  * Does the same thing as callsim without expensive call to Array.slice.
  * Requires args to be a Javascript array.
  */
-Sk.misceval.callsimArray = function(func, args) {
+Sk.misceval.callsimArray = function(func, args, kws) {
     var argarray = args ? args : [];
-    return Sk.misceval.apply(func, undefined, undefined, undefined, argarray);
+    return Sk.misceval.apply(func, undefined, undefined, kws, argarray);
 };
 Sk.exportSymbol("Sk.misceval.callsimArray", Sk.misceval.callsimArray);
 
@@ -884,14 +884,24 @@ Sk.exportSymbol("Sk.misceval.callsimOrSuspend", Sk.misceval.callsimOrSuspend);
 
 /**
  * @param {Object} func the thing to call
- * @param {Array=} args an array of arguments to pass to the func
+ * @param {Array} args an array of arguments to pass to the func
+ * @param {Array=} kws an array of keyword arguments to pass to the func
  *
  * Does the same thing as callsimOrSuspend without expensive call to
- * Array.slice.  Requires args to be a Javascript array.
+ * Array.slice.  Requires args+kws to be Javascript arrays.
  */
-Sk.misceval.callsimOrSuspendArray = function (func, args) {
-    var argarray = args ? args : [];
-    return Sk.misceval.applyOrSuspend(func, undefined, undefined, undefined, argarray);
+Sk.misceval.callsimOrSuspendArray = function (func, args, kws) {
+    if (!args) {
+        args = [];
+    }
+    if (func.tp$call) {
+        return func.tp$call(args, kws);
+    } else {
+        // Slow path handles things like calling native JS fns
+        // (perhaps we should stop supporting that), and weird
+        // detection of the __call__ method (everything should use tp$call)
+        return Sk.misceval.applyOrSuspend(func, undefined, undefined, kws, args);
+    }
 };
 Sk.exportSymbol("Sk.misceval.callsimOrSuspendArray", Sk.misceval.callsimOrSuspendArray);
 

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -257,8 +257,8 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     Sk.asserts.assert((v !== null) && (v !== undefined), "passed null or undefined parameter to Sk.misceval.richCompareBool");
     Sk.asserts.assert((w !== null) && (w !== undefined), "passed null or undefined parameter to Sk.misceval.richCompareBool");
 
-    v_type = new Sk.builtin.type(v);
-    w_type = new Sk.builtin.type(w);
+    v_type = v.ob$type;
+    w_type = w.ob$type;
 
     // Python 2 has specific rules when comparing two different builtin types
     // currently, this code will execute even if the objects are not builtin types
@@ -423,13 +423,13 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
 
     // use comparison methods if they are given for either object
     if (v.tp$richcompare && (ret = v.tp$richcompare(w, op)) !== undefined) {
-        if (ret != Sk.builtin.NotImplemented.NotImplemented$) {
+        if (ret !== Sk.builtin.NotImplemented.NotImplemented$) {
             return Sk.misceval.isTrue(ret);
         }
     }
 
     if (w.tp$richcompare && (ret = w.tp$richcompare(v, Sk.misceval.swappedOp_[op])) !== undefined) {
-        if (ret != Sk.builtin.NotImplemented.NotImplemented$) {
+        if (ret !== Sk.builtin.NotImplemented.NotImplemented$) {
             return Sk.misceval.isTrue(ret);
         }
     }

--- a/src/type.js
+++ b/src/type.js
@@ -288,31 +288,13 @@ Sk.builtin.type = function (name, bases, dict) {
             return Sk.builtin.object.prototype.GenericSetAttr.call(this, pyName, data, canSuspend);
         };
 
-        klass.prototype.tp$getattr = function(pyName, canSuspend) {
-            // Find __getattribute__ on this type if we can
-            // TODO tp$getattr should be overriden up-front alongside the
-            // other dunder-funcs, to avoid running this typeLookup() every
-            // time
-            let descr = Sk.builtin.type.typeLookup(klass, Sk.builtin.str.$getattribute);
-
-            if (descr !== undefined && descr !== null && descr.tp$descr_get !== undefined) {
-                let getf = descr.tp$descr_get.call(descr, this, klass);
-                // Convert AttributeErrors back into 'undefined' returns to match the tp$getattr
-                // convention
-                let r = Sk.misceval.tryCatch(function() {
-                    return Sk.misceval.callsimOrSuspendArray(/** @type {Object} */ (getf), [pyName]);
-                }, function (e) {
-                    if (e instanceof Sk.builtin.AttributeError) {
-                        return undefined;
-                    } else {
-                        throw e;
-                    }
-                });
-                return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
-            } else {
-                return Sk.builtin.object.prototype.GenericGetAttr.call(this, pyName, canSuspend);
-            }
-        };
+        // We do not define tp$getattr here. We usually inherit it from object,
+        // unless we (or one of our parents) overrode it by defining
+        // __getattribute__. It's handled down with the other dunder-funcs.
+        // We could migrate other tp$/dunder-functions that way, but
+        // tp$getattr() is the performance hot-spot, and doing it this way
+        // allows us to work out *once* whether this class has a
+        // __getattribute__, rather than checking on every tp$getattr() call
 
         klass.prototype.tp$str = function () {
             var strf = this.tp$getattr(Sk.builtin.str.$str);
@@ -439,7 +421,7 @@ Sk.builtin.type = function (name, bases, dict) {
         };
 
         // Register skulpt shortcuts to magic methods defined by this class.
-        // Dynamically deflined methods (eg those returned by __getattr__())
+        // Dynamically defined methods (eg those returned by __getattr__())
         // cannot be used by these magic functions; this is consistent with
         // how CPython handles "new-style" classes:
         // https://docs.python.org/2/reference/datamodel.html#special-method-lookup-for-old-style-classes
@@ -457,6 +439,30 @@ Sk.builtin.type = function (name, bases, dict) {
                 // scope workaround
                 shortcutDunder(skulpt_name, dunder, klass[dunder], canSuspendIdx);
             }
+        }
+
+        // tp$getattr is a special case; we need to catch AttributeErrors and
+        // return undefined instead.
+        let getattributeFn = Sk.builtin.type.typeLookup(klass, Sk.builtin.str.$getattribute);
+        if (getattributeFn !== undefined && getattributeFn !== Sk.builtin.object.prototype.__getattribute__) {
+            klass.prototype.tp$getattr = function (pyName, canSuspend) {
+                let r = Sk.misceval.tryCatch(
+                    () => Sk.misceval.callsimOrSuspendArray(getattributeFn, [this, pyName]),
+                    function (e) {
+                        if (e instanceof Sk.builtin.AttributeError) {
+                            return undefined;
+                        } else {
+                            throw e;
+                        }
+                    }
+                );
+                return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
+            };
+        } else if (!klass.prototype.tp$getattr) {
+            // This is only relevant in Python 2, where
+            // it's possible not to inherit from object
+            // (or perhaps when inheriting from builtins? Unclear)
+            klass.prototype.tp$getattr = Sk.builtin.object.prototype.GenericGetAttr;
         }
 
         return klass;


### PR DESCRIPTION
This PR combines a series of performance improvements, totalling a ~45%~ **85%** speedup (aka a ~31%~ 46% reduction in runtime) on @rixner's student project ([`field.py`](https://gist.githubusercontent.com/rixner/f79dfa52a0385e5c82d147ae3d06c50c/raw/971a46b80c9ff79734e80f7bab49f66ecdc3ae11/field.py)).

Tagging @rixner because this is relevant to your interests, @albertjan because @rixner is busy, and @LeszekSwirski for arcane mysteries of V8 performance.

I'd suggest reviewing each commit individually: Each improvement is a single commit, with a paragraph of notes in the commit message.

Performance numbers throughout use the median of 10ish measurements on my laptop, of 500 ticks of `field.py`. (I made a desultory effort to get the CPU throttling into a consistent state, but it's pretty rough; T tests averaged around p=0.10.)

----
**Notes and Highlights:**

The hottest code was in the attribute-getting infrastructure:

* We win 16% by reworking an inefficient fallback from `klass.prototype.tp$getattr()` to `object.GenericPythonGetAttr`, which is of course the common case.

* Removing `klass.prototype.tp$getattr()` entirely when unnecessary (ie when the class doesn't define a custom `__getattribute__`) got us another 10%

* `Sk.abstr.gattr()` is an anomalously hot spot. Even after streamlining, it's still nearly 4% of CPU (according to the Chrome profiler), despite doing very little!

  - I initially tried inlining the `tp$getattr()` call straight into generated code, which won us quite a lot (4.5% speedup). I'm guessing this is because V8 could now do call-site-specific optimisation (each line of user code pretty consistently calls one `tp$getattr` implementation).

  - However, the benefit from that inlining basically disappeared after I removed `tp$getattr()` from most classes. This is presumably because, now that most classes share a single `tp$getattr()` implementation (in fact, _all_ classes in this particular program do), V8 can do call-site-specific optimisation on the `tp$getattr()` call in `Sk.abstr.gattr()` itself.

    I am slightly concerned that more complex programs that manipulate other types -- modules, exceptions, classes that implement `__getattribute__`, etc -- might prevent V8 from optimising that site. So perhaps we should still be inlining those calls, but I spent 5 minutes messing around with microbenchmarks and couldn't find evidence to justify it, so I'm holding off for now. (It's in this PR, but reverted.)

* Most attrs are looked up in the object dictionary, so a fast path for string comparisons in `Sk.builtin.dict.prototype.key$lookup` proved well worth it, netting us another 21% (harvested in two parts: 8.8% from remarkably small tweaks to `richCompareBool`, and then 16.3% from bypassing it altogether when doing string lookups)

The function-call infrastructure is next on my hit list. I've grabbed a couple of pieces of low-hanging fruit, but there's plenty still to get:

* `Sk.misceval.callsimOrSuspendArray()` has an API almost identical to `tp$call()`, but is much slower (it calls `applyOrSuspend()`, which goes round the houses of all the things Skulpt knows how to invoke). So I've added a fast path that invokes `tp$call` directly from generated code when possible.

  - I'm not actually sure we _should_ support invoking anything that doesn't have a `tp$call` method. We shouldn't sacrifice common-case performance to make things marginally easier for JS devs (eg allowing you to invoke JS functions). Forcing _all_ calls to use `tp$call` would speed up everything and clear out a bunch of code, but it would break our external API so I've held off.

* I've cherry-picked #950 into this, and the fast path is indeed catching most executions, but `func.tp$call` (and `method.tp$call`) are still taking ~4% of runtime each. Plenty to be getting on with here!
