### PR TITLE
fix formatting with negative percentages

### DIFF
--- a/src/formatting.js
+++ b/src/formatting.js
@@ -215,9 +215,14 @@ let formatNumber = function(num, formatSpec, isFractional) {
             if (isNaN(convValue)) {
                 return handleWidth(m, "nan%", "", true);
             }
+            let neg = false;
+            if (convValue < 0) {
+                convValue = -convValue;
+                neg = true;
+            }
             let precision = m[FMT.PRECISION] ? parseInt(m[FMT.PRECISION], 10) : 6;
             let result = (convValue*100.0).toFixed(precision) + "%";
-            return handleWidth(m, result, signForNeg(m, convValue < 0), true);
+            return handleWidth(m, result, signForNeg(m, neg), true);
         };
 
         default:

--- a/test/unit3/test_strformat.py
+++ b/test/unit3/test_strformat.py
@@ -82,6 +82,8 @@ class string_format(unittest.TestCase):
         points = 19.5
         total = 22
         self.assertEqual('Correct answers: 88.64%', 'Correct answers: {:.2%}'.format(points/total))
+        self.assertEqual("-5.00%", "{:.2%}".format(-.05))
+
 
     def test_datetime(self):
        import datetime


### PR DESCRIPTION
Small change to the `formatting.js`

Currently
```
>>>"{:.2%}".format(-0.05)
--0.05%
```

This pull request fixes this bug.