### PR TITLE
Implement Python3 range object

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -7,20 +7,20 @@
 
 Sk.builtin.range = function range (start, stop, step) {
     var ret = [];
+    var lst;
     var i;
 
     Sk.builtin.pyCheckArgsLen("range", arguments.length, 1, 3);
-    Sk.builtin.pyCheckType("start", "integer", Sk.builtin.checkInt(start));
+    Sk.builtin.pyCheckType("start", "integer", Sk.misceval.isIndex(start));
+    start = Sk.misceval.asIndex(start);
     if (stop !== undefined) {
-        Sk.builtin.pyCheckType("stop", "integer", Sk.builtin.checkInt(stop));
+        Sk.builtin.pyCheckType("stop", "integer", Sk.misceval.isIndex(stop));
+        stop = Sk.misceval.asIndex(stop);
     }
     if (step !== undefined) {
-        Sk.builtin.pyCheckType("step", "integer", Sk.builtin.checkInt(step));
+        Sk.builtin.pyCheckType("step", "integer", Sk.misceval.isIndex(step));
+        step = Sk.misceval.asIndex(step);
     }
-
-    start = Sk.builtin.asnum$(start);
-    stop = Sk.builtin.asnum$(stop);
-    step = Sk.builtin.asnum$(step);
 
     if ((stop === undefined) && (step === undefined)) {
         stop = start;
@@ -34,17 +34,46 @@ Sk.builtin.range = function range (start, stop, step) {
         throw new Sk.builtin.ValueError("range() step argument must not be zero");
     }
 
-    if (step > 0) {
-        for (i = start; i < stop; i += step) {
-            ret.push(new Sk.builtin.int_(i));
+    if ((typeof start === "number")
+	&& (typeof stop === "number")
+	&& (typeof step === "number")) {
+        if (step > 0) {
+            for (i = start; i < stop; i += step) {
+                ret.push(new Sk.builtin.int_(i));
+            }
+        } else {
+            for (i = start; i > stop; i += step) {
+                ret.push(new Sk.builtin.int_(i));
+            }
         }
     } else {
-        for (i = start; i > stop; i += step) {
-            ret.push(new Sk.builtin.int_(i));
+        // This is going to be slow, really needs to be a generator!
+        var startlng = new Sk.builtin.lng(start);
+        var stoplng = new Sk.builtin.lng(stop);
+        var steplng = new Sk.builtin.lng(step);
+
+        if (steplng.nb$ispositive()) {
+            i = startlng;
+            while (Sk.misceval.isTrue(i.ob$lt(stoplng))) {
+                ret.push(i);
+                i = i.nb$add(steplng);
+            }
+        } else {
+            i = startlng;
+            while (Sk.misceval.isTrue(i.ob$gt(stoplng))) {
+                ret.push(i);
+                i = i.nb$add(steplng);
+            }
         }
     }
 
-    return new Sk.builtin.list(ret);
+    lst = new Sk.builtin.list(ret);
+
+    if (Sk.__future__.python3) {
+        return new Sk.builtin.range_(start, stop, step, lst);
+    }
+
+    return lst;
 };
 
 Sk.builtin.asnum$ = function (a) {

--- a/src/list.js
+++ b/src/list.js
@@ -248,6 +248,9 @@ Sk.builtin.list.prototype.sq$repeat = function (n) {
     }
 
     n = Sk.misceval.asIndex(n);
+    if (typeof n !== "number") {
+        throw new Sk.builtin.OverflowError("cannot fit '" + Sk.abstr.typeName(n) + "' into an index-sized integer");
+    }
     ret = [];
     for (i = 0; i < n; ++i) {
         for (j = 0; j < this.v.length; ++j) {
@@ -267,6 +270,9 @@ Sk.builtin.list.prototype.nb$inplace_multiply = function(n) {
 
     // works on list itself --> inplace
     n = Sk.misceval.asIndex(n);
+    if (typeof n !== "number") {
+        throw new Sk.builtin.OverflowError("cannot fit '" + Sk.abstr.typeName(n) + "' into an index-sized integer");
+    }
     len = this.v.length;
     for (i = 1; i < n; ++i) {
         for (j = 0; j < len; ++j) {
@@ -312,6 +318,9 @@ Sk.builtin.list.prototype.list_subscript_ = function (index) {
     var i;
     if (Sk.misceval.isIndex(index)) {
         i = Sk.misceval.asIndex(index);
+        if (typeof i !== "number") {
+            throw new Sk.builtin.IndexError("cannot fit '" + Sk.abstr.typeName(index) + "' into an index-sized integer");
+        }
         if (i !== undefined) {
             if (i < 0) {
                 i = this.v.length + i;
@@ -339,6 +348,9 @@ Sk.builtin.list.prototype.list_ass_subscript_ = function (index, value) {
     var indices;
     if (Sk.misceval.isIndex(index)) {
         i = Sk.misceval.asIndex(index);
+        if (typeof i !== "number") {
+            throw new Sk.builtin.IndexError("cannot fit '" + Sk.abstr.typeName(index) + "' into an index-sized integer");
+        }
         if (i !== undefined) {
             if (i < 0) {
                 i = this.v.length + i;

--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,7 @@ require("./generator.js");
 require("./file.js");
 require("./ffi.js");
 require("./iterator.js");
+require("./range.js");
 require("./enumerate.js");
 require("./filter.js");
 require("./zip.js");

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -93,7 +93,10 @@ Sk.misceval.asIndex = function (o) {
         return o.v;
     }
     if (o.constructor === Sk.builtin.lng) {
-        return o.tp$index();
+        if (o.cantBeInt()) {
+            return o.str$(10, true);
+        }
+        return o.toInt$();
     }
     if (o.constructor === Sk.builtin.bool) {
         return Sk.builtin.asnum$(o);

--- a/src/range.js
+++ b/src/range.js
@@ -1,0 +1,116 @@
+/**
+ * @constructor
+ * @param {number} start
+ * @param {number} stop
+ * @param {number} step
+ * @param {Object} lst
+ */
+Sk.builtin.range_ = function (start, stop, step, lst) {
+    if (!(this instanceof Sk.builtin.range_)) {
+        return new Sk.builtin.range_(start, stop, step, lst);
+    }
+
+    this.v = lst;
+    this.$start = start;
+    this.$stop = stop;
+    this.$step = step;
+
+    this.$r = function () {
+        var name = "range(" + this.$start + ", " + this.$stop;
+        if (this.$step != 1) {
+            name += ", " + this.$step;
+        }
+        name += ")";
+        return new Sk.builtin.str(name);
+    };
+
+    return this;
+};
+
+Sk.abstr.setUpInheritance("range", Sk.builtin.range_, Sk.builtin.object);
+
+Sk.builtin.range_.prototype.__class__ = Sk.builtin.range_;
+
+Sk.builtin.range_.prototype.mp$subscript = function (index) {
+    var sub, start, stop, step;
+    sub = this.v.mp$subscript(index);
+    if (sub instanceof Sk.builtin.list) {
+        if (Sk.builtin.checkNone(index.start)) {
+            start = this.v.mp$subscript(0).v;
+        } else {
+            try {
+                start = this.v.mp$subscript(index.start).v;
+            } catch (exc) {
+                // start is before beginning of current range
+                start = this.$start;
+            }
+        }
+
+        try {
+            stop = this.v.mp$subscript(index.stop).v;
+        } catch (exc) {
+            // stop is past end of current range
+            stop = this.$stop;
+        }
+
+        if (Sk.builtin.checkNone(index.step)) {
+            // Implied 1
+            step = 1;
+        } else {
+            step = Sk.misceval.asIndex(index.step);
+        }
+        // Scale by range's current step
+        step = step * this.$step;
+
+        return new Sk.builtin.range_(start, stop, step, sub);
+    }
+    return sub;
+};
+
+Sk.builtin.range_.prototype.__getitem__ = new Sk.builtin.func(function (self, index) {
+    return Sk.builtin.range_.prototype.mp$subscript.call(self, index);
+});
+
+Sk.builtin.range_.prototype.sq$contains = function (item) {
+    return this.v.sq$contains(item);
+};
+
+Sk.builtin.range_.prototype.sq$length = function () {
+    return this.v.sq$length();
+};
+
+Sk.builtin.range_.prototype.tp$richcompare = function (w, op) {
+    if (w.__class__ == Sk.builtin.range_) {
+        w = w.v;
+    }
+    return this.v.tp$richcompare(w, op);
+};
+
+Sk.builtin.range_.prototype.tp$iter = function () {
+    // Hijack the list iterator
+    var iter = this.v.tp$iter();
+    iter.$r = function () {
+        return new Sk.builtin.str("<rangeiterator>");
+    };
+    return iter;
+};
+
+Sk.builtin.range_.prototype.__iter__ = new Sk.builtin.func(function (self) {
+    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 1, 1);
+    return self.tp$iter();
+});
+
+Sk.builtin.range_.prototype.__contains__ = new Sk.builtin.func(function (self, item) {
+    Sk.builtin.pyCheckArgsLen("__contains__", arguments.length, 2, 2);
+    return new Sk.builtin.bool(self.sq$contains(item));
+});
+
+Sk.builtin.range_.prototype["index"] = new Sk.builtin.func(function (self, item, start, stop) {
+    Sk.builtin.pyCheckArgsLen("index", arguments.length, 2, 4);
+    return Sk.misceval.callsimArray(self.v.index, [self.v, item, start, stop]);
+});
+
+Sk.builtin.range_.prototype["count"] = new Sk.builtin.func(function (self, item) {
+    Sk.builtin.pyCheckArgsLen("count", arguments.length, 2, 2);
+    return Sk.misceval.callsimArray(self.v.count, [self.v, item]);
+});

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -58,6 +58,9 @@ Sk.builtin.tuple.prototype.mp$subscript = function (index) {
     var i;
     if (Sk.misceval.isIndex(index)) {
         i = Sk.misceval.asIndex(index);
+        if (typeof i !== "number") {
+            throw new Sk.builtin.IndexError("cannot fit '" + Sk.abstr.typeName(index) + "' into an index-sized integer");
+        }
         if (i !== undefined) {
             if (i < 0) {
                 i = this.v.length + i;
@@ -109,6 +112,9 @@ Sk.builtin.tuple.prototype.sq$repeat = function (n) {
     var ret;
 
     n = Sk.misceval.asIndex(n);
+    if (typeof n !== "number") {
+        throw new Sk.builtin.OverflowError("cannot fit '" + Sk.abstr.typeName(n) + "' into an index-sized integer");
+    }
     ret = [];
     for (i = 0; i < n; ++i) {
         for (j = 0; j < this.v.length; ++j) {

--- a/test/unit3/test_range.py
+++ b/test/unit3/test_range.py
@@ -88,9 +88,9 @@ class RangeTest(unittest.TestCase):
         self.assertEqual(len(range(0, sys.maxsize, sys.maxsize-1)), 2)
 
     def test_large_operands(self):
-        # x = range(10**20, 10**20+10, 3)
-        # self.assertEqual(len(x), 4)
-        # self.assertEqual(len(list(x)), 4)
+        x = range(10**20, 10**20+10, 3)
+        self.assertEqual(len(x), 4)
+        self.assertEqual(len(list(x)), 4)
 
         x = range(10**20+10, 10**20, 3)
         self.assertEqual(len(x), 0)
@@ -100,9 +100,9 @@ class RangeTest(unittest.TestCase):
         self.assertEqual(len(x), 0)
         self.assertEqual(len(list(x)), 0)
 
-        # x = range(10**20+10, 10**20, -3)
-        # self.assertEqual(len(x), 4)
-        # self.assertEqual(len(list(x)), 4)
+        x = range(10**20+10, 10**20, -3)
+        self.assertEqual(len(x), 4)
+        self.assertEqual(len(list(x)), 4)
 
         # Now test range() with longs
         self.assertEqual(list(range(-2**100)), [])
@@ -114,30 +114,30 @@ class RangeTest(unittest.TestCase):
         b = int(100 * sys.maxsize)
         c = int(50 * sys.maxsize)
 
-        # self.assertEqual(list(range(a, a+2)), [a, a+1])
-        # self.assertEqual(list(range(a+2, a, -1)), [a+2, a+1])
-        # self.assertEqual(list(range(a+4, a, -2)), [a+4, a+2])
+        self.assertEqual(list(range(a, a+2)), [a, a+1])
+        self.assertEqual(list(range(a+2, a, -1)), [a+2, a+1])
+        self.assertEqual(list(range(a+4, a, -2)), [a+4, a+2])
 
-        # seq = list(range(a, b, c))
-        # self.assertIn(a, seq)
-        # self.assertNotIn(b, seq)
-        # self.assertEqual(len(seq), 2)
-        # self.assertEqual(seq[0], a)
-        # self.assertEqual(seq[-1], a+c)
+        seq = list(range(a, b, c))
+        self.assertIn(a, seq)
+        self.assertNotIn(b, seq)
+        self.assertEqual(len(seq), 2)
+        self.assertEqual(seq[0], a)
+        self.assertEqual(seq[-1], a+c)
 
-        # seq = list(range(b, a, -c))
-        # self.assertIn(b, seq)
-        # self.assertNotIn(a, seq)
-        # self.assertEqual(len(seq), 2)
-        # self.assertEqual(seq[0], b)
-        # self.assertEqual(seq[-1], b-c)
+        seq = list(range(b, a, -c))
+        self.assertIn(b, seq)
+        self.assertNotIn(a, seq)
+        self.assertEqual(len(seq), 2)
+        self.assertEqual(seq[0], b)
+        self.assertEqual(seq[-1], b-c)
 
         seq = list(range(-a, -b, -c))
-        # self.assertIn(-a, seq)
+        self.assertIn(-a, seq)
         self.assertNotIn(-b, seq)
-        # self.assertEqual(len(seq), 2)
-        # self.assertEqual(seq[0], -a)
-        # self.assertEqual(seq[-1], -a-c)
+        self.assertEqual(len(seq), 2)
+        self.assertEqual(seq[0], -a)
+        self.assertEqual(seq[-1], -a-c)
 
     def test_large_range(self):
         # Check long ranges (len > sys.maxsize)
@@ -220,14 +220,14 @@ class RangeTest(unittest.TestCase):
         class BadExc(Exception):
             pass
 
-        # class BadCmp:
-        #     def __eq__(self, other):
-        #         if other == 2:
-        #             raise BadExc()
-        #         return False
+        class BadCmp:
+            def __eq__(self, other):
+                if other == 2:
+                    raise BadExc()
+                return False
 
-        # a = range(4)
-        # self.assertRaises(BadExc, a.index, BadCmp())
+        a = range(4)
+        self.assertRaises(BadExc, a.index, BadCmp())
 
         a = range(-2, 3)
         self.assertEqual(a.index(0), 2)
@@ -256,14 +256,14 @@ class RangeTest(unittest.TestCase):
                 self.n = int(n)
             def __index__(self):
                 return self.n
-        # self.assertEqual(list(range(I(bignum), I(bignum + 1))), [bignum])
-        # self.assertEqual(list(range(I(smallnum), I(smallnum + 1))), [smallnum])
+        self.assertEqual(list(range(I(bignum), I(bignum + 1))), [bignum])
+        self.assertEqual(list(range(I(smallnum), I(smallnum + 1))), [smallnum])
 
         # User-defined class with a failing __index__ method
         class IX:
             def __index__(self):
                 raise RuntimeError
-        # self.assertRaises(RuntimeError, range, IX())
+        self.assertRaises(RuntimeError, range, IX())
 
         # User-defined class with an invalid __index__ method
         class IN:
@@ -286,10 +286,10 @@ class RangeTest(unittest.TestCase):
 
         # self.assertEqual(len(range(sys.maxsize, sys.maxsize+10)), 10)
 
-    # def test_repr(self):
-    #     self.assertEqual(repr(range(1)), 'range(0, 1)')
-    #     self.assertEqual(repr(range(1, 2)), 'range(1, 2)')
-    #     self.assertEqual(repr(range(1, 2, 3)), 'range(1, 2, 3)')
+    def test_repr(self):
+        self.assertEqual(repr(range(1)), 'range(0, 1)')
+        self.assertEqual(repr(range(1, 2)), 'range(1, 2)')
+        self.assertEqual(repr(range(1, 2, 3)), 'range(1, 2, 3)')
 
     def test_odd_bug(self):
         # This used to raise a "SystemError: NULL result without error"
@@ -377,27 +377,27 @@ class RangeTest(unittest.TestCase):
     #         test_id = "reversed(range({}, {}, {}))".format(start, end, step)
     #         self.assert_iterators_equal(iter1, iter2, test_id, limit=100)
 
-    # def test_slice(self):
-    #     def check(start, stop, step=None):
-    #         i = slice(start, stop, step)
-    #         self.assertEqual(list(r[i]), list(r)[i])
-    #         self.assertEqual(len(r[i]), len(list(r)[i]))
-    #     for r in [range(10),
-    #               range(0),
-    #               range(1, 9, 3),
-    #               range(8, 0, -3),
-    #               range(sys.maxsize+1, sys.maxsize+10),
-    #               ]:
-    #         check(0, 2)
-    #         check(0, 20)
-    #         check(1, 2)
-    #         check(20, 30)
-    #         check(-30, -20)
-    #         check(-1, 100, 2)
-    #         check(0, -1)
-    #         check(-1, -3, -1)
+    def test_slice1(self):
+        def check(start, stop, step=None):
+            i = slice(start, stop, step)
+            self.assertEqual(list(r[i]), list(r)[i])
+            self.assertEqual(len(r[i]), len(list(r)[i]))
+        for r in [range(10),
+                  range(0),
+                  range(1, 9, 3),
+                  range(8, 0, -3),
+                  range(sys.maxsize+1, sys.maxsize+10),
+                  ]:
+            check(0, 2)
+            check(0, 20)
+            check(1, 2)
+            check(20, 30)
+            check(-30, -20)
+            check(-1, 100, 2)
+            check(0, -1)
+            check(-1, -3, -1)
 
-    def test_slice(self):
+    def test_slice2(self):
         self.assertEqual(slice(1), slice(None, 1, None))
         a = range(10)[slice(0, 5, 2)]
         self.assertEqual(a, range(0,5,2))
@@ -435,9 +435,7 @@ class RangeTest(unittest.TestCase):
         self.assertEqual(l[8:-10:-1], range(8, -1, -1))
         def foo(x):
             x[4] = 4
-        #Skulpt fails the test below but it shouldn't
-        #this is because range should return a range object not a list
-        #self.assertRaises(TypeError, foo, l)
+        self.assertRaises(TypeError, foo, l)
 
     def test_contains(self):
         r = range(10)
@@ -473,23 +471,23 @@ class RangeTest(unittest.TestCase):
         self.assertNotIn(10, r)
         self.assertNotIn("", r)
 
-    # def test_reverse_iteration(self):
-    #     for r in [range(10),
-    #               range(0),
-    #               range(1, 9, 3),
-    #               range(8, 0, -3),
-    #               range(sys.maxsize+1, sys.maxsize+10),
-    #               ]:
-    #         self.assertEqual(list(reversed(r)), list(r)[::-1])
+    def test_reverse_iteration(self):
+        for r in [range(10),
+                  range(0),
+                  range(1, 9, 3),
+                  range(8, 0, -3),
+                  range(sys.maxsize+1, sys.maxsize+10),
+                  ]:
+            self.assertEqual(list(reversed(r)), list(r)[::-1])
 
-    # def test_issue11845(self):
-    #     r = range(*slice(1, 18, 2).indices(20))
-    #     values = {None, 0, 1, -1, 2, -2, 5, -5, 19, -19,
-    #               20, -20, 21, -21, 30, -30, 99, -99}
-    #     for i in values:
-    #         for j in values:
-    #             for k in values - {0}:
-    #                 r[i:j:k]
+    def test_issue11845(self):
+        r = range(*slice(1, 18, 2).indices(20))
+        values = {None, 0, 1, -1, 2, -2, 5, -5, 19, -19,
+                  20, -20, 21, -21, 30, -30, 99, -99}
+        for i in values:
+            for j in values:
+                for k in values - {0}:
+                    r[i:j:k]
 
     def test_comparison(self):
         test_ranges = [range(0), range(0, -1), range(1, 1, 3),
@@ -553,14 +551,14 @@ class RangeTest(unittest.TestCase):
     #     self.assertRaises(AttributeError, rangeobj, stop, 10)
     #     self.assertRaises(AttributeError, rangeobj, step, 1)
 
-##    def test_str(self):
-##        self.assertEqual(str(range(4))[:5], "range")
-##        self.assertEqual(str(range(-44))[:5], "range")
-##        self.assertEqual(str(range(0,5,3))[:5], "range")
-##        self.assertEqual(str(range(-8,-4))[:5], "range")
-##        self.assertEqual(str(range(-4,-8))[:5], "range")
-##        self.assertEqual(str(range(-4,-8,-1))[:5], "range")
-##        self.assertEqual(str(range(-8,-4,-1))[:5], "range")
+    def test_str(self):
+        self.assertEqual(str(range(4))[:5], "range")
+        self.assertEqual(str(range(-44))[:5], "range")
+        self.assertEqual(str(range(0,5,3))[:5], "range")
+        self.assertEqual(str(range(-8,-4))[:5], "range")
+        self.assertEqual(str(range(-4,-8))[:5], "range")
+        self.assertEqual(str(range(-4,-8,-1))[:5], "range")
+        self.assertEqual(str(range(-8,-4,-1))[:5], "range")
 
 
     def test_len(self):


### PR DESCRIPTION
This is an implementation of Python3's range object.  It allowed me to uncomment many of the commented out tests in test_range.py.

It computes the entire range ahead of time instead of being a generator object, which is no worse than what we do now.  But, that means it is inefficient for large ranges.  But, a lot of other capabilities are improved.