### PR TITLE
Pr/float overflow

### DIFF
--- a/src/float.js
+++ b/src/float.js
@@ -54,7 +54,7 @@ Sk.builtin.float_ = function (x) {
     if (typeof x === "string") {
         this.v = parseFloat(x);
         if (this.v == Infinity || this.v == -Infinity){ //trying to convert a large js string to a float
-            throw new Sk.builtin.OverflowError("int too large to convert to float")
+            throw new Sk.builtin.OverflowError("int too large to convert to float");
         }
         return this;
     }
@@ -83,7 +83,7 @@ Sk.builtin._str_to_float = function (str) {
     } else if (!isNaN(str)) {
         tmp = parseFloat(str);
         if (tmp === Infinity || tmp === -Infinity) {
-            throw new Sk.builtin.OverflowError("int too large to convert to float")
+            throw new Sk.builtin.OverflowError("int too large to convert to float");
         }
     } else {
         throw new Sk.builtin.ValueError("float: Argument: " + str + " is not number");

--- a/src/float.js
+++ b/src/float.js
@@ -53,7 +53,7 @@ Sk.builtin.float_ = function (x) {
 
     if (typeof x === "string") {
         this.v = parseFloat(x);
-        if ((this.v === Infinity && !x.v.match(/^[+]?inf$/i)) || (this.v === -Infinity && !x.v.match(/^[+]?inf$/i))){
+        if (this.v == Infinity || this.v == -Infinity){ //trying to convert a large js string to a float
             throw new Sk.builtin.OverflowError("int too large to convert to float")
         }
         return this;

--- a/src/float.js
+++ b/src/float.js
@@ -53,6 +53,9 @@ Sk.builtin.float_ = function (x) {
 
     if (typeof x === "string") {
         this.v = parseFloat(x);
+        if ((this.v === Infinity && !x.v.match(/^[+]?inf$/i)) || (this.v === -Infinity && !x.v.match(/^[+]?inf$/i))){
+            throw new Sk.builtin.OverflowError("int too large to convert to float")
+        }
         return this;
     }
 
@@ -79,6 +82,9 @@ Sk.builtin._str_to_float = function (str) {
         tmp = NaN;
     } else if (!isNaN(str)) {
         tmp = parseFloat(str);
+        if (tmp === Infinity || tmp === -Infinity) {
+            throw new Sk.builtin.OverflowError("int too large to convert to float")
+        }
     } else {
         throw new Sk.builtin.ValueError("float: Argument: " + str + " is not number");
     }

--- a/test/unit3/test_float.py
+++ b/test/unit3/test_float.py
@@ -33,5 +33,9 @@ class FloatTestCases(unittest.TestCase):
     def test_repr(self):
         self.assertEqual(repr(1.5), '1.5')
 
+    def test_overflow(self):
+        self.assertRaises(OverflowError, float, 2**1024)
+        self.assertRaises(OverflowError, float, -2**1024)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_float.py
+++ b/test/unit3/test_float.py
@@ -36,6 +36,7 @@ class FloatTestCases(unittest.TestCase):
     def test_overflow(self):
         self.assertRaises(OverflowError, float, 2**1024)
         self.assertRaises(OverflowError, float, -2**1024)
+        self.assertRaises(OverflowError, float, str(2**1024))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
a small fix for `float(2**1024)` fixes #1003 

previously any conversion to float larger than `2**1024` or less than `-2**1024` would be converted to `inf`.

It also has the consequence that if you do (in js)
```javascript
a = Sk.abstr.numberBinOp(Sk.builtin.int_(2), Sk.builtin.int_(1024),"Pow")
a = Sk.builtin.asnum$(a)
a = Sk.builtin.float_(a)
```
there will also be an overflowerror

in addition
`math.fabs(2**1024)`
`math.fmod(2**1024, 2)` 
 now raise an overflow error (which they didn't before)

