### PR TITLE
fix __dict__ self-referencing __dict__ self-referencing __dict__ ...

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -63,7 +63,7 @@ Sk.builtin.object.prototype.GenericGetAttr = function (pyName, canSuspend) {
         }
         if (res !== undefined) {
             return res;
-        } else if (jsName == "__dict__") {
+        } else if (jsName == "__dict__" && dict instanceof Sk.builtin.dict) {
             return dict;
         }
     }

--- a/src/object.js
+++ b/src/object.js
@@ -63,6 +63,8 @@ Sk.builtin.object.prototype.GenericGetAttr = function (pyName, canSuspend) {
         }
         if (res !== undefined) {
             return res;
+        } else if (jsName == "__dict__") {
+            return dict;
         }
     }
 

--- a/src/type.js
+++ b/src/type.js
@@ -144,7 +144,7 @@ Sk.builtin.type = function (name, bases, dict) {
             }
 
             this["$d"] = new Sk.builtin.dict([]);
-            this["$d"].mp$ass_subscript(new Sk.builtin.str("__dict__"), this["$d"]);
+            this.__proto__.__dict__ = this.$d;
         };
 
         var _name = Sk.ffi.remapToJs(name); // unwrap name string to js for latter use

--- a/src/type.js
+++ b/src/type.js
@@ -144,7 +144,6 @@ Sk.builtin.type = function (name, bases, dict) {
             }
 
             this["$d"] = new Sk.builtin.dict([]);
-            this.__proto__.__dict__ = this.$d;
         };
 
         var _name = Sk.ffi.remapToJs(name); // unwrap name string to js for latter use

--- a/test/unit3/test_builtin.py
+++ b/test/unit3/test_builtin.py
@@ -1492,6 +1492,15 @@ class TestType(unittest.TestCase):
         class B:
             def ham(self):
                 return 'ham%d' % self
+
+        # test __dict__ is not self referencing
+        b = B()
+        self.assertEqual(b.__dict__, {})
+        b.x = 3
+        self.assertEqual(b.__dict__, {'x':3})
+        self.assertIn('x', b.__dict__)
+        self.assertNotIn('__dict__', b.__dict__)
+        
         # C = type('C', (B, int), {'spam': lambda self: 'spam%s' % self})
         # self.assertEqual(C.__name__, 'C')
         # self.assertEqual(C.__qualname__, 'C')


### PR DESCRIPTION
fixes this issue
```python
>>> class A:
...    pass
...
>>> a = A()
>>> a.x = 1
>>> a.__dict__
{'__dict__': {...}, 'x' : 1}
>>> a.__dict__["__dict__"]
{'__dict__': {...}, 'x' : 1}
>>> a.__dict__ is a.__dict__["__dict__"]
True
>>> d = a.__dict__
>>> for i in range(1000000): 
...     print(d["__dict__"])
...     d = d["__dict__"]
...
!@#
```

this pr aims to ensure that `a.__dict__` is not self-referencing.

---
It solves the issue in the following way.
removes the line that caused the self-referencing - effectively -  `this.$d["__dict__"] = this.$d`

adds a shortcut so that if `x.__dict__` is called then `x.$d` is returned

---

I know that this is a hot function so the solution might not be favourable. It simply aimed to ensure that `y.__dict__` always returns `this.$d` without `"__dict__"` needing to be a key inside `this$d`

---

My first solution (3e5d6f7) initially failed with objects that were copied because of how GenericGetattr prioritised its lookup... 