### PR TITLE
assertRaises as a context manager and kwarg support

### DIFF
--- a/src/lib/unittest/__init__.py
+++ b/src/lib/unittest/__init__.py
@@ -5,6 +5,66 @@ the unittest module from cpython.
 
 '''
 
+
+class _AssertRaisesBaseContext:
+
+    def __init__(self, expected, test_case):
+        self.test_case = test_case
+        self.expected = expected
+
+    def handle(self, args, kwargs):
+        """
+        If args is empty, assertRaises is being used as a
+        context manager, so return self.
+        If args is not empty, call a callable passing positional and keyword
+        arguments.
+        """
+        try:
+            if not args:
+                return self
+
+            callable_obj = args[0]
+            args = args[1:]
+            with self:
+                callable_obj(*args, **kwargs) 
+
+        finally:
+            # bpo-23890: manually break a reference cycle
+            self = None
+
+
+class _AssertRaisesContext(_AssertRaisesBaseContext):
+    """A context manager used to implement TestCase.assertRaises* methods."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        res = True
+        feedback = ""
+
+        # this is a workaround since exceptions don't have a .__name__ attribute
+        try:
+            act_exc = exc_type.__name__
+            exp_exc = self.expected.__name__
+
+        except AttributeError:
+            act_exc = str(exc_type)
+            exp_exc = str(self.expected)
+            act_exc = act_exc.split("'")[1] if 'class' in act_exc else act_exc
+            exp_exc = exp_exc.split("'")[1] if 'class' in exp_exc else exp_exc     
+
+        if exc_type is None:
+            res = False
+            feedback = "{} not raised".format(exp_exc)
+        if not issubclass(exc_type, self.expected):
+            res = False
+            feedback = "Expected {} but got {}".format(exp_exc, act_exc)
+
+        self.test_case.appendResult(res, act_exc, exp_exc, feedback)
+        return True
+
+
 class TestCase:
     def __init__(self):
         self.numPassed = 0
@@ -186,26 +246,14 @@ class TestCase:
             print(msg)
             self.assertFailed += 1
 
-    def assertRaises(self, exception, callable=None, *args, **kwds):
+    def assertRaises(self, expected_exception, *args, **kwargs):
         # with is currently not supported hence we just try and catch
-        if callable is None:
-            raise NotImplementedError("assertRaises does currently not support assert contexts")
-        if kwds:
-            raise NotImplementedError("assertRaises does currently not support **kwds")
-
-        res = False
-        actualerror = str(exception())
+        context = _AssertRaisesContext(expected_exception, self)
         try:
-            callable(*args)
-        except exception as ex:
-            res = True
-        except Exception as inst:
-            actualerror = str(inst)
-            print("ACT = ", actualerror, str(exception()))
-        else:
-            actualerror = "No Error"
-
-        self.appendResult(res, str(exception()), actualerror, "")
+            return context.handle(args, kwargs)
+        finally:
+            # bpo-23890: manually break a reference cycle
+            context = None
 
     def fail(self, msg=None):
         if msg is None:

--- a/test/unit3/test_math.py
+++ b/test/unit3/test_math.py
@@ -1329,18 +1329,14 @@ class MathTests(unittest.TestCase):
         # remainder(x, 0) and remainder(infinity, x) for non-NaN x are invalid
         # operations according to IEEE 754-2008 7.2(f), and should raise.
         for value in [NINF, -2.3, -0.0, 0.0, 2.3, INF]:
-            self.assertRaises(ValueError, math.remainder, INF, value)
-            self.assertRaises(ValueError, math.remainder, NINF, value)
-            self.assertRaises(ValueError, math.remainder, value,  0.0)
-            self.assertRaises(ValueError, math.remainder, value, -0.0)
-        #     with self.assertRaises(ValueError):
-        #         math.remainder(INF, value)
-        #     with self.assertRaises(ValueError):
-        #         math.remainder(NINF, value)
-        #     with self.assertRaises(ValueError):
-        #         math.remainder(value, 0.0)
-        #     with self.assertRaises(ValueError):
-        #         math.remainder(value, -0.0)
+            with self.assertRaises(ValueError):
+                math.remainder(INF, value)
+            with self.assertRaises(ValueError):
+                math.remainder(NINF, value)
+            with self.assertRaises(ValueError):
+                math.remainder(value, 0.0)
+            with self.assertRaises(ValueError):
+                math.remainder(value, -0.0)
 
 
     def testSin(self):


### PR DESCRIPTION
It is common to have to comment out `with self.assertRaises` or any `self.assertRaises` that has `kwargs` from Python unit tests 😢 . 

This pull request aims to close #1027, it:
- adds context manager support to `assertRaises`. 
- allows `kwargs` for `assertRaises`
- fixes the `repr` when an `assertRaises` test fails - currently you just get `Fail:` since `str(TypeError())` is empty
- uses code from cpython as a template and adapts to the Skulpt unittest module.


I uncommented a few of the `test_math.py` that included `with self.assertRaises` - I wasn't sure what other tests to add...?
