### PR TITLE
Builtin Inheritance

### DIFF
--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -29,6 +29,7 @@ Sk.builtins = {
     "any"       : new Sk.builtin.func(Sk.builtin.any),
     "all"       : new Sk.builtin.func(Sk.builtin.all),
 
+    "BaseException"      : Sk.builtin.BaseException, 
     "AttributeError"     : Sk.builtin.AttributeError,
     "ValueError"         : Sk.builtin.ValueError,
     "Exception"          : Sk.builtin.Exception,

--- a/src/import.js
+++ b/src/import.js
@@ -70,12 +70,14 @@ Sk.doOneTimeInitialization = function (canSuspend) {
     // Register a Python class with an internal dictionary, which allows it to
     // be subclassed
     var setUpClass = function (child) {
-        var parent = child.tp$base || child.prototype.tp$base;
+        var parent = child.prototype.tp$base;
         var bases = [];
         var base;
 
-        for (base = parent; base !== undefined; base = base.tp$base || base.prototype.tp$base) {
-            bases.push(base);
+        for (base = parent; base !== undefined; base = base.prototype.tp$base) {
+            if (!base.sk$abstract) {
+                bases.push(base);
+            }
         }
 
         child.tp$mro = new Sk.builtin.tuple([child]);

--- a/src/import.js
+++ b/src/import.js
@@ -86,7 +86,7 @@ Sk.doOneTimeInitialization = function (canSuspend) {
         }
         child["$d"] = new Sk.builtin.dict([]);
         child["$d"].mp$ass_subscript(Sk.builtin.type.basesStr_, new Sk.builtin.tuple(bases));
-        child["$d"].mp$ass_subscript(Sk.builtin.type.mroStr_, child.tp$mro);
+        child["$d"].mp$ass_subscript(Sk.builtin.type.mroStr_, new Sk.builtin.tuple([child].concat(bases)));
         child["$d"].mp$ass_subscript(new Sk.builtin.str("__name__"), new Sk.builtin.str(child.prototype.tp$name));
     };
 

--- a/src/import.js
+++ b/src/import.js
@@ -87,6 +87,7 @@ Sk.doOneTimeInitialization = function (canSuspend) {
         child["$d"] = new Sk.builtin.dict([]);
         child["$d"].mp$ass_subscript(Sk.builtin.type.basesStr_, new Sk.builtin.tuple(bases));
         child["$d"].mp$ass_subscript(Sk.builtin.type.mroStr_, child.tp$mro);
+        child["$d"].mp$ass_subscript(new Sk.builtin.str("__name__"), new Sk.builtin.str(child.prototype.tp$name));
     };
 
     for (x in Sk.builtin) {

--- a/src/import.js
+++ b/src/import.js
@@ -70,11 +70,11 @@ Sk.doOneTimeInitialization = function (canSuspend) {
     // Register a Python class with an internal dictionary, which allows it to
     // be subclassed
     var setUpClass = function (child) {
-        var parent = child.tp$base;
+        var parent = child.tp$base || child.prototype.tp$base;
         var bases = [];
         var base;
 
-        for (base = parent; base !== undefined; base = base.tp$base) {
+        for (base = parent; base !== undefined; base = base.tp$base || base.prototype.tp$base) {
             bases.push(base);
         }
 

--- a/test/unit3/test_inheritance.py
+++ b/test/unit3/test_inheritance.py
@@ -93,6 +93,13 @@ class InheritanceTesting(unittest.TestCase):
         self.assertTrue(issubclass(Foo,object))
         self.assertTrue(issubclass(Frob,XXX))
 
+    def test_builtins(self):
+        for _cls in (int, dict, set, list, object, tuple):
+            self.assertTrue(issubclass(_cls, object))
+        
+        for error in (Exception, TypeError, ValueError, AttributeError):
+            self.assertTrue(issubclass(error, Exception))
+
 if __name__ == '__main__':
     unittest.main()
             

--- a/test/unit3/test_inheritance.py
+++ b/test/unit3/test_inheritance.py
@@ -100,6 +100,9 @@ class InheritanceTesting(unittest.TestCase):
         for error in (Exception, TypeError, ValueError, AttributeError):
             self.assertTrue(issubclass(error, Exception))
 
+        self.assertEqual(int.__mro__, (int, object))
+        self.assertEqual(Exception.__mro__, (Exception, BaseException, object))
+
 if __name__ == '__main__':
     unittest.main()
             


### PR DESCRIPTION
This fixes #1046. 

I believe the algorithm for `setUpClass` was not quite right for builtins as it checked `child.tp$base` but the actual base class is located at `child.prototype.tp$base`

This effectively meant that all builtins had an attribute `__bases__ = ()` 

I added some failing tests. 

My first attempt failed because I unknowingly included `sk$abstract` classes in `bases`. The final commit corrected this, adding a check to ensure that a potential parent did not have `sk$abstract = true` before pushing it to bases. 

___
While I'm here I add a `.__name__` atribute to all builtins. 
And fix the `.__mro__` property
___
**Example fixes:**

```python
>>> issubclass(int, object)
True  # previously False
>>> int.__bases__
(<class 'object'>, ) # previously empty tuple
>>> int.__mro__
(<class 'int'>, <class 'object'>) #previously <class 'int'>
>>> int.__name__
'int' # previously AttributeError
>>> class F(int):
...  pass
...
>>> F.__bases__
(int,)
>>> issubclass(F, int)
True
>>> issubclass(F, object)
True # previously False

```