### PR TITLE
fix inheritance for py3 StandardError

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -75,7 +75,8 @@ Sk.doOneTimeInitialization = function (canSuspend) {
         var base;
 
         for (base = parent; base !== undefined; base = base.prototype.tp$base) {
-            if (!base.sk$abstract) {
+            if (!base.sk$abstract && Sk.builtins[base.tp$name]) {
+                // check the base is not an abstract class and that it is in the builtins dict
                 bases.push(base);
             }
         }

--- a/test/unit3/test_inheritance.py
+++ b/test/unit3/test_inheritance.py
@@ -102,6 +102,7 @@ class InheritanceTesting(unittest.TestCase):
 
         self.assertEqual(int.__mro__, (int, object))
         self.assertEqual(Exception.__mro__, (Exception, BaseException, object))
+        self.assertEqual(TypeError.__bases__, (Exception, BaseException, object))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A small amendment to fix #1051 

A base must be in the `Sk.builtins` dict in order to be a parent class... 