### PR TITLE
setting attributes of builtin types should fail

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -870,20 +870,16 @@ Sk.builtin.setattr = function setattr (obj, pyName, value) {
     var jsName;
     Sk.builtin.pyCheckArgsLen("setattr", arguments.length, 3, 3);
     // cannot set or del attr from builtin type
-    if (obj === undefined || obj["$r"] === undefined || obj["$r"]().v.slice(1,5) !== "type") {
-        if (!Sk.builtin.checkString(pyName)) {
-            throw new Sk.builtin.TypeError("attribute name must be string");
-        }
-        jsName = pyName.$jsstr();
-        if (obj.tp$setattr) {
-            obj.tp$setattr(new Sk.builtin.str(Sk.fixReservedWords(jsName)), value);
-        } else {
-            throw new Sk.builtin.AttributeError("object has no attribute " + jsName);
-        }
-        return Sk.builtin.none.none$;
+    if (!Sk.builtin.checkString(pyName)) {
+        throw new Sk.builtin.TypeError("attribute name must be string");
     }
-
-    throw new Sk.builtin.TypeError("can't set attributes of built-in/extension type '" + obj.tp$name + "'");
+    jsName = pyName.$jsstr();
+    if (obj.tp$setattr) {
+        obj.tp$setattr(new Sk.builtin.str(Sk.fixReservedWords(jsName)), value);
+    } else {
+        throw new Sk.builtin.AttributeError("object has no attribute " + jsName);
+    }
+    return Sk.builtin.none.none$;
 };
 
 Sk.builtin.raw_input = function (prompt) {

--- a/src/import.js
+++ b/src/import.js
@@ -89,6 +89,9 @@ Sk.doOneTimeInitialization = function (canSuspend) {
         child["$d"].mp$ass_subscript(Sk.builtin.type.basesStr_, new Sk.builtin.tuple(bases));
         child["$d"].mp$ass_subscript(Sk.builtin.type.mroStr_, new Sk.builtin.tuple([child].concat(bases)));
         child["$d"].mp$ass_subscript(new Sk.builtin.str("__name__"), new Sk.builtin.str(child.prototype.tp$name));
+        child.tp$setattr = function(pyName, value, canSuspend) {
+            throw new Sk.builtin.TypeError("can't set attributes of built-in/extension type '" + this.tp$name + "'");
+        };
     };
 
     for (x in Sk.builtin) {

--- a/src/type.js
+++ b/src/type.js
@@ -517,6 +517,9 @@ Sk.builtin.type["$r"] = function () {
         return new Sk.builtin.str("<type 'type'>");
     }
 };
+Sk.builtin.type.tp$setattr = function(pyName, value, canSuspend) {
+    throw new Sk.builtin.TypeError("can't set attributes of built-in/extension type '" + this.tp$name + "'");
+};
 
 //Sk.builtin.type.prototype.tp$descr_get = function() { print("in type descr_get"); };
 

--- a/test/unit/test_builtin.py
+++ b/test/unit/test_builtin.py
@@ -77,6 +77,11 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, setattr, sys, 1, 'spam')
         self.assertRaises(AttributeError, setattr, 1, 'spam', 9)
         self.assertRaises(TypeError, setattr)
+        for builtin_type in (int, float, Exception, object, type, super):
+            self.assertRaises(TypeError, setattr, builtin_type, 'foo', 'bar')
+            with self.assertRaises(TypeError):
+                builtin_type.foo = 'bar'
+        
 
     def test_delattr(self):
         class NoName:

--- a/test/unit3/test_builtin.py
+++ b/test/unit3/test_builtin.py
@@ -1185,6 +1185,10 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(sys.spam, 1)
         self.assertRaises(TypeError, setattr, sys, 1, 'spam')
         self.assertRaises(TypeError, setattr)
+        for builtin_type in (int, float, Exception, object, type, super):
+            self.assertRaises(TypeError, setattr, builtin_type, 'foo', 'bar')
+            with self.assertRaises(TypeError):
+                builtin_type.foo = 'bar'
 
     # test_str(): see test_unicode.py and test_bytes.py for str() tests.
 


### PR DESCRIPTION
This pr aims to fix #1078 

The approach I took was to add the appropriate `tp$setattr` function to builtin type and type objects 

This negates the need to check whether an object is a builtin in the `builtin.setattr` function 
