### PR TITLE
add co_name to wrappedFn

### DIFF
--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -2251,6 +2251,7 @@ function generateTurtleModule(_target) {
             }
         };
 
+        wrapperFn.co_name = new Sk.builtin.str(displayName); 
         wrapperFn.co_varnames = co_varnames.slice();
         wrapperFn.$defaults = [];
 


### PR DESCRIPTION
A one-line fix to close #1081 

Adding the `co_name` to the wrapped function provides correct error messages.