### PR TITLE
add py3/py2 switch to commandline repl

### DIFF
--- a/repl/repl.js
+++ b/repl/repl.js
@@ -41,17 +41,13 @@ Sk.configure({
     __future__: py3 ? Sk.python3 : Sk.python2,
 });
 
-var compilableLines = [],
-    //finds lines starting with "print"
+var //finds lines starting with "print"
     re = new RegExp("\\s*print"),
     //finds import statements
     importre = new RegExp("\\s*import"),
-    //finds multuline string constants
-    mls = new RegExp("'''"),
     //finds defining statements
     defre = new RegExp("def.*|class.*"),
     //test for empty line.
-    emptyline = new RegExp("^\\s*$"),
     comment = new RegExp("^#.*"),
     //a regex to check if a line is an assignment
     //this regex checks whether or not a line starts with
@@ -80,7 +76,7 @@ function isBalanced(lines) {
 
     for (l = 0; l < lines.length; l = l + 1) {
         if (lines[l] !== undefined) {
-            if (lines[l].match(/'''/) !== null && lines[l].match(/'''/).length === 1) {
+            if (lines[l].match(/'''|"""/) !== null && lines[l].match(/'''|"""/).length === 1) {
                 mlsopened = !mlsopened;
             }
             if (!mlsopened && lines[l].substr(lines[l].length - 1) === ":") {

--- a/repl/repl.js
+++ b/repl/repl.js
@@ -1,4 +1,6 @@
-const reqskulpt = require('../support/run/require-skulpt').requireSkulpt;
+const reqskulpt = require("../support/run/require-skulpt").requireSkulpt;
+const program = require("commander");
+const chalk = require("chalk");
 
 // Import Skulpt
 var skulpt = reqskulpt(false);
@@ -6,19 +8,37 @@ if (skulpt === null) {
     process.exit(1);
 }
 
-var readlineSync = require('readline-sync');
-var fs = require('fs');
+var readlineSync = require("readline-sync");
+var fs = require("fs");
 
 var readline = function () {
     return readlineSync.question("", { keepWhitespace: true });
 };
 
+program.parse(process.argv);
+
+if (program.args.length != 1) {
+    console.log(chalk.red("error: must specify python version (py2/py3) and python program to run"));
+    process.exit(1);
+}
+
+var py3;
+if (program.args[0] == "py2") {
+    py3 = false;
+} else if (program.args[0] == "py3") {
+    py3 = true;
+} else {
+    console.log(chalk.red("error: must specify python version ('py2' or 'py3'), not '" + program.args[0] + "'"));
+    process.exit(1);
+}
+
 Sk.configure({
-        output: (args) => { process.stdout.write(args); },
-        read: (fname) => { return fs.readFileSync(fname, "utf8"); },
-        systemexit: true,
-        retainglobals: true,
-        inputfun: readline
+    output: (args) => { process.stdout.write(args); },
+    read: (fname) => { return fs.readFileSync(fname, "utf8"); },
+    systemexit: true,
+    retainglobals: true,
+    inputfun: readline,
+    __future__: py3 ? Sk.python3 : Sk.python2,
 });
 
 var compilableLines = [],
@@ -50,30 +70,30 @@ console.log("[node: " + process.version + "] on a system");
 console.log('Don\'t type "help", "copyright", "credits" or "license" unless you\'ve assigned something to them');
 
 function isBalanced(lines) {
-    'use strict';
-        var depth = 0,
+    "use strict";
+    var depth = 0,
         mlsopened = false,
-                l;
+        l;
 
     for (l = 0; l < lines.length; l = l + 1) {
-                if (lines[l] !== undefined) {
-                        if (lines[l].match(/'''/) !== null && lines[l].match(/'''/).length === 1) {
-                                mlsopened = !mlsopened;
-                        }
-                        if (!mlsopened && lines[l].substr(lines[l].length - 1) === ":") {
-                                depth = depth + 1;
-                        }
-                        if (!mlsopened && lines[l] === "" && depth > 0) {
-                                depth = 0;
-                        }
-                }
+        if (lines[l] !== undefined) {
+            if (lines[l].match(/'''/) !== null && lines[l].match(/'''/).length === 1) {
+                mlsopened = !mlsopened;
+            }
+            if (!mlsopened && lines[l].substr(lines[l].length - 1) === ":") {
+                depth = depth + 1;
+            }
+            if (!mlsopened && lines[l] === "" && depth > 0) {
+                depth = 0;
+            }
+        }
     }
     return depth === 0 && !mlsopened;
 }
 
 //Loop
 while (true) {
-    process.stdout.write(isBalanced(lines) ? '>>> ' : '... ');
+    process.stdout.write(isBalanced(lines) ? ">>> " : "... ");
 
     //Read
     var l = readline();
@@ -93,7 +113,7 @@ while (true) {
         if (!assignment.test(lines[0]) && !defre.test(lines[0]) && !importre.test(lines[0]) && !comment.test(lines[0]) && lines[0].length > 0) {
             //if it doesn't contain print make sure it doesn't print None
             if (!re.test(lines[0])) {
-                                //remove the statement
+                //remove the statement
                 //evaluate it if nessecary
                 lines.push("evaluationresult = " + lines.pop());
                 //print the result if not None
@@ -105,10 +125,9 @@ while (true) {
     try {
         //Evaluate
         if (!lines || /^\s*$/.test(lines)) {
-            continue
-        }
-        else {
-            Sk.importMainWithBody("repl", false, lines.join('\n'));
+            continue;
+        } else {
+            Sk.importMainWithBody("repl", false, lines.join("\n"));
         }
     } catch (err) {
         if (err instanceof Sk.builtin.SystemExit) {
@@ -127,8 +146,8 @@ while (true) {
         //Don't add the last statement to the accumulated code
         console.log(origLines.map(function (str) {
             return ++line + (index === line ? ">" : " ") + ": " + str;
-        }).join('\n'));
+        }).join("\n"));
     } finally {
-                lines = [];
-        }
+        lines = [];
+    }
 }

--- a/repl/repl.js
+++ b/repl/repl.js
@@ -18,7 +18,7 @@ var readline = function () {
 program.parse(process.argv);
 
 if (program.args.length != 1) {
-    console.log(chalk.red("error: must specify python version (py2/py3) and python program to run"));
+    console.log(chalk.red("error: must specify python version (py2/py3)"));
     process.exit(1);
 }
 
@@ -59,12 +59,15 @@ var compilableLines = [],
     //it also checks if the identifier is a tuple.
     assignment = /^((\s*\(\s*(\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*,)*\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*\)\s*)|(\s*\s*(\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*,)*\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*\s*))([+-/*%&\^\|]?|[/<>*]{2})=/,
     lines = [],
-    origLines;
+    origLines,
+    printevaluationresult;
 
 if (Sk.__future__.python3) {
     console.log("Python 3.7(ish) (skulpt, " + new Date() + ")");
+    printevaluationresult = "if not evaluationresult == None: print(repr(evaluationresult))"
 } else {
     console.log("Python 2.7(ish) (skulpt, " + new Date() + ")");
+    printevaluationresult = "if not evaluationresult == None: print repr(evaluationresult)"
 }
 console.log("[node: " + process.version + "] on a system");
 console.log('Don\'t type "help", "copyright", "credits" or "license" unless you\'ve assigned something to them');
@@ -117,7 +120,7 @@ while (true) {
                 //evaluate it if nessecary
                 lines.push("evaluationresult = " + lines.pop());
                 //print the result if not None
-                lines.push("if not evaluationresult == None: print repr(evaluationresult)");
+                lines.push(printevaluationresult);
             }
         }
     }

--- a/support/build/help.js
+++ b/support/build/help.js
@@ -11,7 +11,7 @@ var commands = {
     "run dist": "Prepare the distribution: build the optimized Skulpt, run all tests, build docs.",
     "run brun <pyfile>": "Run Python <pyfile> in the browser.  This will automatically rebuild the unoptimized Skulpt first.",
     "run btest": "Run all unit tests in the browser.",
-    "run repl": "Open the REPL. You need to build Skulpt (either " + chalk.green("npm run build") + " or " + chalk.green("npm run devbuild") + ") first.",
+    "run repl <py2|py3>": "Open the REPL. You need to build Skulpt (either " + chalk.green("npm run build") + " or " + chalk.green("npm run devbuild") + ") first.",
     "test": "Run all tests. You need to build Skulpt (either " + chalk.green("npm run build") + " or " + chalk.green("npm run devbuild") + ") first.",
     "start <py2|py3> <pyfile>": "Run pyfile using either Python 2 (py2) or Python 3 (py3). You need to build Skulpt (either " + chalk.green("npm run build") + " or " + chalk.green("npm run devbuild") + ") first.",
     "run profile <py2|py3> <pyfile>": "Run pyfile using either Python 2 (py2) or Python 3 (py3) with the profiler on.  Will report the profiling results to the console. You need to build the optimized Skulpt (" + chalk.green("npm run build") + ") first."


### PR DESCRIPTION
Adds `py2` or `py3` as required parameter to `npm run repl`

```
➜  skulpt git:(master) ✗ npm run repl    

> skulpt@1.0.0 repl /Users/albertjan/skulpt
> node repl/repl.js

Using skulpt.min.js
error: must specify python version (py2/py3) and python program to run
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! skulpt@1.0.0 repl: `node repl/repl.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the skulpt@1.0.0 repl script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/albertjan/.npm/_logs/2020-05-25T12_45_56_434Z-debug.log
➜  skulpt git:(master) ✗ npm run repl py2

> skulpt@1.0.0 repl /Users/albertjan/skulpt
> node repl/repl.js "py2"

Using skulpt.min.js
Python 2.7(ish) (skulpt, Mon May 25 2020 13:45:59 GMT+0100 (British Summer Time))
[node: v10.16.0] on a system
Don't type "help", "copyright", "credits" or "license" unless you've assigned something to them
>>> print "hello" 
hello
>>> ^C
➜  skulpt git:(master) ✗ npm run repl py3

> skulpt@1.0.0 repl /Users/albertjan/skulpt
> node repl/repl.js "py3"

Using skulpt.min.js
Python 3.7(ish) (skulpt, Mon May 25 2020 13:46:09 GMT+0100 (British Summer Time))
[node: v10.16.0] on a system
Don't type "help", "copyright", "credits" or "license" unless you've assigned something to them
>>> print "hello"
SyntaxError: bad input on line 1
1>: print "hello"
>>> ^C
```

@s-cork please review 😄 

Fixes: #1031