### PR TITLE
Upgrade this.py to Python 3

### DIFF
--- a/src/builtin/this.py
+++ b/src/builtin/this.py
@@ -25,4 +25,4 @@ for c in (65, 97):
     for i in range(26):
         d[chr(i+c)] = chr((i+13) % 26 + c)
 
-print "".join([d.get(c, c) for c in s])
+print("".join([d.get(c, c) for c in s]))


### PR DESCRIPTION
Fixes `SyntaxError: bad input on line 28` when running with `__future__: Sk.python3` and still works for Python 2.