### PR TITLE
fix small bug for print

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -254,6 +254,7 @@ Sk.builtin.file.prototype["write"] = new Sk.builtin.func(function write(self, st
     } else {
         throw new Sk.builtin.IOError("File not open for writing");
     }
+    return Sk.builtin.none.none$;
 });
 
 


### PR DESCRIPTION
A one line change to `file.write` which should return `None`. 

This is problematic if the user ever does
```
print(print('foo'))
# or
x = print('foo')
type(x) # x is not defined
```