### PR TITLE
ipython example

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -667,12 +667,14 @@ and the non-module version. First off, the call to Sk.configure
 contains another key value pair which sets up a specialized read
 function. This is the function that is responsible for returning your
 module out of the large array of files that are contained in the
-skulpt-stdlib.js file. You will see that all of the modules are
+`skulpt-stdlib.js` file. You will see that all of the modules are
 contained in this one file, stored in a big JSON structure. The extra
-key value pair is: read: builtinRead
+key value pair is: `read: builtinRead`
 
 The read function is just for loading modules and is called when you do
-an import statement of some kind. In this case the function accesses the
+an import statement of some kind. This is an optional argument to `Sk.configure`, 
+the default implementation is as above. You can of course override this function 
+to implement bespoke module loading. In the default case the function accesses the
 variable builtinFiles which is created from the skulpt-stdlib.js file.
 The other difference, of course, is that you have to include
 skulpt-stdlib.js in your html file. Note that skulpt-stdlib.js must be

--- a/example/ipython.css
+++ b/example/ipython.css
@@ -1,0 +1,85 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    min-height: 400px;
+    max-height: 80vh;
+    margin: auto;
+    width: 80vw;
+}
+#clickGuard {
+    flex-grow: 1;
+}
+
+#editor {
+    /* height: 400px; */
+    min-height: 30px;
+    /* max-height: 90vh; */
+    padding: 7px;
+    overflow: scroll;
+    /* display: flex;
+    flex-direction: row;
+    flex-wrap: wrap; */
+}
+#editor > div {
+    min-height: 15px;
+    max-height: 200vh;
+    width: 100%;
+}
+#editor > div > .ace_gutter-cell:first-child {
+    margin-left: 0px;
+}
+#output {
+    min-height: 50px;
+    /* width: 40vw; */
+}
+
+.ace_gutter-cell {
+    visibility: hidden;
+    padding-left: 0;
+    padding-right: 13px;
+}
+
+.in-gutter::before {
+    content: "In [";
+}
+.out-gutter::after,
+.in-gutter::after {
+    content: "]:";
+    position: absolute;
+    right: 0;
+}
+.out-gutter::before {
+    content: "Out[";
+}
+.out-gutter::before,
+.in-gutter::before {
+    position: absolute;
+    left: 5px;
+    padding: 0;
+}
+
+.out-gutter,
+.in-gutter {
+    /* left: 0;
+    z-index: 3; */
+    padding-left: 30px;
+    visibility: visible;
+    display: block;
+}
+
+.in-gutter {
+    color: mediumseagreen;
+}
+.out-gutter {
+    color: crimson;
+}
+.ace_gutter {
+    font-size: 11px;
+}
+.ace_gutter-cell:not(:first-child):after {
+    content: "...:";
+    visibility: visible;
+    position: absolute;
+    right: 0;
+    color: mediumseagreen;
+}

--- a/example/ipython.css
+++ b/example/ipython.css
@@ -11,14 +11,9 @@
 }
 
 #editor {
-    /* height: 400px; */
     min-height: 30px;
-    /* max-height: 90vh; */
     padding: 7px;
     overflow: scroll;
-    /* display: flex;
-    flex-direction: row;
-    flex-wrap: wrap; */
 }
 #editor > div {
     min-height: 15px;
@@ -27,10 +22,6 @@
 }
 #editor > div > .ace_gutter-cell:first-child {
     margin-left: 0px;
-}
-#output {
-    min-height: 50px;
-    /* width: 40vw; */
 }
 
 .ace_gutter-cell {
@@ -60,8 +51,6 @@
 
 .out-gutter,
 .in-gutter {
-    /* left: 0;
-    z-index: 3; */
     padding-left: 30px;
     visibility: visible;
     display: block;

--- a/example/ipython.html
+++ b/example/ipython.html
@@ -1,0 +1,21 @@
+<script src="../dist/skulpt.min.js" type="text/javascript"></script>
+<script src="../dist/skulpt-stdlib.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.11/ace.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.11/mode-python.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.11/theme-gruvbox.min.js"></script>
+<script src="ipython.js"></script>
+<link rel="stylesheet" type="text/css" href="ipython.css"/>
+
+<script>
+    var ide;
+    window.addEventListener("load", function (event) {
+        var editor = document.getElementById("editor");
+        ide = new Sk.ipython(editor);
+    })
+</script>
+
+<div class="container ace-gruvbox ace_editor">
+    <div id="editor" class="ace-gruvbox ace_editor" style="font-size: 10px;"> </div>
+    <div id="clickGuard"></div>
+</div>
+

--- a/example/ipython.js
+++ b/example/ipython.js
@@ -95,7 +95,7 @@
         Sk.misceval.callsimArray(Sk.globals.In.append, [Sk.globals.In, codeAsPyStr]);
         this.inputs[this.inputs.length - 1] = code;
 
-        let compile_code = code.trimEnd();
+        let compile_code = code.trimEnd() || "None";
 
         const lines = compile_code.split("\n");
         let last_line = lines[lines.length - 1];

--- a/example/ipython.js
+++ b/example/ipython.js
@@ -1,0 +1,331 @@
+(function () {
+    var //finds import statements
+        importre = new RegExp("\\s*import"),
+        //finds defining statements
+        defre = new RegExp("def.*|class.*"),
+        //test for empty line.
+        comment = new RegExp("^#.*"),
+        //a regex to check if a line is an assignment
+        //this regex checks whether or not a line starts with
+        //an identifier followed with some whitspace and then an = and then some more white space.
+        //it also checks if the identifier is a tuple.
+        assignment = /^((\s*\(\s*(\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*,)*\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*\)\s*)|(\s*\s*(\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*,)*\s*((\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*)|(\s*\(\s*(\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*,)*\s*((\s*[_a-zA-Z]\w*\s*)|(\s*\(\s*(\s*[_a-zA-Z]\w*\s*,)*\s*[_a-zA-Z]\w*\s*\)\s*))\s*\)\s*))\s*\s*))([+-/*%&\^\|]?|[/<>*]{2})=/;
+
+    Sk.globals = {
+        _ih: new Sk.builtin.list(),
+        _oh: new Sk.builtin.dict(),
+        _: Sk.builtin.str.$empty,
+        __: Sk.builtin.str.$empty,
+        ___: Sk.builtin.str.$empty,
+        _i: Sk.builtin.str.$empty,
+        _ii: Sk.builtin.str.$empty,
+        _iii: Sk.builtin.str.$empty,
+    };
+    Sk.globals.In = Sk.globals._ih;
+    Sk.globals.Out = Sk.globals._oh;
+
+    Sk.stopExecution = false;
+
+    const info = "# Python 3.7(ish) (Skulpt ipython, " + new Date() + ") \n" + "# [" + navigator.userAgent + "] on " + navigator.platform;
+
+    Sk.ipython = function (dom) {
+        if (ace === undefined) {
+            Sk.asserts.fail("No ace");
+        }
+        this.editor = dom;
+        this.clickGuard = document.getElementById("clickGuard");
+        this.clickGuard.addEventListener("click", () => {
+            this.inCell.focus();
+        });
+        const keyboardInterrupt = (e) => {
+            if (e.ctrlKey && e.key === "c") {
+                // faile safe for keyboard interrupt
+                Sk.stopExecution = true;
+            }
+        };
+        this.editor.addEventListener("keydown", keyboardInterrupt);
+        this.clickGuard.addEventListener("keydown", keyboardInterrupt);
+
+        const infoElement = document.createElement("DIV");
+        infoElement.innerText = info;
+        infoElement.style.padding = "5px";
+        this.editor.appendChild(infoElement);
+
+        this.inputs = [];
+        this.idx = 0;
+        this.inCell;
+        this.outCell;
+        this.printCell;
+        this.newCells();
+        this.outf = this.outf.bind(this);
+        this.lineHeight = this.inCell.renderer.lineHeight || 16;
+        this.pad = 15;
+
+        Sk.configure({
+            output: this.outf,
+            __future__: Sk.python3,
+            yieldLimit: 1000,
+            execLimit: 30000,
+            retainGlobals: true,
+            inputfunTakesPrompt: true,
+            inputfun: (args) => {
+                let res;
+                this.outf(args + " ");
+                this.outf((res = prompt(args)));
+                return res;
+            },
+        });
+    };
+
+    Sk.ipython.prototype.newCells = function () {
+        this.idx = this.inputs.length;
+        this.inCell = this.newIn();
+        this.printCell = this.newPrint();
+        this.outCell = this.newOut();
+        this.inCell.focus();
+        this.inCell.container.scrollIntoView();
+    };
+
+    Sk.ipython.prototype.execute = function () {
+        Sk.stopExecution = false;
+        const code = this.inCell.getValue();
+        const codeAsPyStr = new Sk.builtin.str(code);
+        Sk.globals["_i" + this.inputs.length] = codeAsPyStr;
+        Sk.misceval.callsimArray(Sk.globals.In.append, [Sk.globals.In, codeAsPyStr]);
+        this.inputs[this.inputs.length - 1] = code;
+
+        let compile_code = code.trimEnd();
+
+        const lines = compile_code.split("\n");
+        let last_line = lines[lines.length - 1];
+        if (
+            !assignment.test(last_line) &&
+            !defre.test(last_line) &&
+            !importre.test(last_line) &&
+            !comment.test(last_line) &&
+            last_line.length > 0 &&
+            last_line[0] !== " "
+        ) {
+            lines[lines.length - 1] = "_" + this.inputs.length + " = " + last_line;
+        }
+        compile_code = lines.join("\n");
+        this.inCell.setReadOnly(true);
+        this.inCell.renderer.$cursorLayer.element.style.opacity = 0;
+        const executionPromise = Sk.misceval.asyncToPromise(() => Sk.importMainWithBody("<stdin>", false, compile_code, true), {
+            "*": () => {
+                if (Sk.stopExecution) {
+                    throw "\nKeyboard interrupt";
+                }
+            },
+        });
+        executionPromise
+            .then((res) => {
+                const printContent = this.printCell.getValue();
+                if (printContent.substring(printContent.length - 1) === "\n") {
+                    this.printCell.setValue(printContent.substring(0, printContent.length - 1), -1);
+                }
+                this.printCell.container.style.height = this.printCell.session.getLength() * this.lineHeight + this.pad;
+                this.printCell.resize();
+
+                const last_input = Sk.globals["_" + this.inputs.length];
+                if (Sk.builtin.checkNone(last_input) || last_input === undefined) {
+                    delete Sk.globals["_" + this.inputs.length];
+                } else {
+                    this.outCell.setValue(Sk.misceval.objectRepr(last_input), -1);
+                    if (last_input !== Sk.globals.Out) {
+                        Sk.abstr.objectSetItem(Sk.globals._oh, Sk.ffi.remapToPy(this.inputs.length), last_input);
+                        Sk.globals["___"] = Sk.globals["__"];
+                        Sk.globals["__"] = Sk.globals["_"];
+                        Sk.globals["_"] = last_input;
+                    }
+                }
+            })
+            .catch((e) => {
+                this.outf(e.toString());
+            })
+            .finally(() => {
+                Sk.globals["_iii"] = Sk.globals["_ii"];
+                Sk.globals["_ii"] = Sk.globals["_i"];
+                Sk.globals["_i"] = Sk.globals["_i" + this.inputs.length];
+                if (this.printCell.isVisible || this.outCell.isVisible) {
+                    this.inCell.container.style.height = this.inCell.session.getLength() * 16;
+                    this.inCell.resize();
+                }
+                this.newCells();
+            });
+    };
+
+    Sk.ipython.prototype.outf = function (text) {
+        const curr_val = this.printCell.getValue();
+        this.printCell.setValue(curr_val + text, 1);
+    };
+
+    Sk.ipython.prototype.newIn = function () {
+        let cell = document.createElement("DIV");
+        this.editor.appendChild(cell);
+        cell = ace.edit(cell);
+        this.inputs.push("");
+        cell.setOptions({
+            showLineNumbers: true,
+            firstLineNumber: this.inputs.length,
+            printMargin: false,
+            highlightGutterLine: false,
+            highlightActiveLine: false,
+            showFoldWidgets: false,
+            theme: "ace/theme/gruvbox",
+            mode: "ace/mode/python",
+        });
+        cell.session.addGutterDecoration(0, "in-gutter");
+        cell.container.style.height = 30;
+        cell.resize();
+        cell.on("blur", () => {
+            cell.selection.setSelectionRange(new ace.Range(0, 0, 0, 0), false);
+        });
+        cell.on("change", () => {
+            cell.container.style.height = cell.session.getLength() * this.lineHeight + this.pad;
+            cell.resize();
+            cell.container.scrollIntoView();
+        });
+        cell.renderer.onResize(() => {});
+
+        cell.commands.addCommands([
+            {
+                name: "upHistory",
+                bindKey: {
+                    mac: "Up",
+                    win: "Up",
+                },
+                exec: (e, t) => {
+                    if (cell.getCursorPosition().row === 0) {
+                        if (this.idx > 0) {
+                            cell.setValue(this.inputs[--this.idx], 1);
+                            cell.container.scrollIntoView();
+                        }
+                    } else {
+                        cell.commands.commands.golineup.exec(e, t);
+                    }
+                },
+            },
+            {
+                name: "downHistory",
+                bindKey: {
+                    mac: "Down",
+                    win: "Down",
+                },
+                exec: (e, t) => {
+                    if (cell.getCursorPosition().row === cell.session.getLength() - 1) {
+                        if (this.idx < this.inputs.length - 1) {
+                            cell.setValue(this.inputs[++this.idx], -1);
+                            cell.container.scrollIntoView();
+                        }
+                    } else {
+                        cell.commands.commands.golinedown.exec(e, t);
+                    }
+                },
+            },
+            {
+                name: "execute",
+                bindKey: {
+                    win: "ctrl-enter",
+                    mac: "command-enter",
+                },
+                exec: (e, t) => {
+                    this.execute();
+                },
+            },
+            {
+                name: "keyboardInterrupt",
+                bindKey: {
+                    mac: "ctrl-C",
+                    win: "ctrl-C",
+                },
+                exec: (e, t) => {
+                    Sk.stopExecution = true;
+                },
+                readOnly: true,
+            },
+        ]);
+        return cell;
+    };
+
+    Sk.ipython.prototype.newPrint = function () {
+        let cell = document.createElement("DIV");
+        this.editor.appendChild(cell);
+        cell = ace.edit(cell);
+        cell.setOptions({
+            readOnly: true,
+            printMargin: false,
+            showGutter: false,
+            showLineNumbers: false,
+            highlightActiveLine: false,
+            highlightGutterLine: false,
+            highlightSelectedWord: false,
+            theme: "ace/theme/gruvbox",
+        });
+        cell.renderer.$cursorLayer.element.style.opacity = 0;
+        cell.on("blur", () => {
+            cell.selection.setSelectionRange(new ace.Range(0, 0, 0, 0), false);
+            cell.renderer.$cursorLayer.element.style.opacity = 0;
+        });
+        cell.on("change", () => {
+            if (!cell.isVisible) {
+                cell.container.style.display = "block";
+                cell.isVisible = true;
+            }
+            cell.container.style.height = cell.session.getLength() * this.lineHeight + this.pad;
+            cell.resize();
+            cell.focus();
+            cell.renderer.$cursorLayer.element.style.opacity = "";
+            cell.container.scrollIntoView();
+        });
+        cell.container.style.display = "none";
+        cell.isVisible = false;
+        cell.commands.addCommand({
+            name: "keyboardInterrupt",
+            bindKey: {
+                mac: "ctrl-C",
+                win: "ctrl-C",
+            },
+            exec: (e, t) => {
+                Sk.stopExecution = true;
+            },
+            readOnly: true,
+        });
+        return cell;
+    };
+
+    Sk.ipython.prototype.newOut = function () {
+        let cell = document.createElement("DIV");
+        this.editor.appendChild(cell);
+        cell = ace.edit(cell);
+        cell.setOptions({
+            showLineNumbers: true,
+            firstLineNumber: this.inputs.length,
+            highlightActiveLine: false,
+            highlightGutterLine: false,
+            highlightSelectedWord: false,
+            readOnly: true,
+            printMargin: false,
+            theme: "ace/theme/gruvbox",
+        });
+        cell.session.addGutterDecoration(0, "out-gutter");
+        cell.renderer.$cursorLayer.element.style.opacity = 0;
+        cell.on("blur", () => {
+            cell.selection.setSelectionRange(new ace.Range(0, 0, 0, 0), false);
+        });
+        cell.on("change", () => {
+            if (!cell.isVisible) {
+                cell.container.style.display = "block";
+                this.printCell.container.style.height = this.printCell.session.getLength() * this.lineHeight;
+                this.printCell.resize();
+                cell.isVisible = true;
+            }
+            cell.container.style.height = cell.session.getLength() * this.lineHeight + this.pad;
+            cell.resize();
+            cell.container.scrollIntoView();
+        });
+        cell.container.style.display = "none";
+        cell.isVisible = false;
+        return cell;
+    };
+})();

--- a/example/ipython.js
+++ b/example/ipython.js
@@ -25,11 +25,11 @@
     Sk.globals.In = Sk.globals._ih;
     Sk.globals.Out = Sk.globals._oh;
 
-    Sk.stopExecution = false;
+    var stopExecution = false;
 
     const info = "# Python 3.7(ish) (Skulpt ipython, " + new Date() + ") \n" + "# [" + navigator.userAgent + "] on " + navigator.platform;
 
-    Sk.ipython = function (dom) {
+    ipythonExample = function (dom) {
         if (ace === undefined) {
             Sk.asserts.fail("No ace");
         }
@@ -41,7 +41,7 @@
         const keyboardInterrupt = (e) => {
             if (e.ctrlKey && e.key === "c") {
                 // faile safe for keyboard interrupt
-                Sk.stopExecution = true;
+                stopExecution = true;
             }
         };
         this.editor.addEventListener("keydown", keyboardInterrupt);
@@ -78,7 +78,7 @@
         });
     };
 
-    Sk.ipython.prototype.newCells = function () {
+    ipythonExample.prototype.newCells = function () {
         this.idx = this.inputs.length;
         this.inCell = this.newIn();
         this.printCell = this.newPrint();
@@ -87,8 +87,8 @@
         this.inCell.container.scrollIntoView();
     };
 
-    Sk.ipython.prototype.execute = function () {
-        Sk.stopExecution = false;
+    ipythonExample.prototype.execute = function () {
+        stopExecution = false;
         const code = this.inCell.getValue();
         const codeAsPyStr = new Sk.builtin.str(code);
         Sk.globals["_i" + this.inputs.length] = codeAsPyStr;
@@ -114,7 +114,7 @@
         this.inCell.renderer.$cursorLayer.element.style.opacity = 0;
         const executionPromise = Sk.misceval.asyncToPromise(() => Sk.importMainWithBody("ipython", false, compile_code, true), {
             "*": () => {
-                if (Sk.stopExecution) {
+                if (stopExecution) {
                     throw "\nKeyboard interrupt";
                 }
             },
@@ -156,12 +156,12 @@
             });
     };
 
-    Sk.ipython.prototype.outf = function (text) {
+    ipythonExample.prototype.outf = function (text) {
         const curr_val = this.printCell.getValue();
         this.printCell.setValue(curr_val + text, 1);
     };
 
-    Sk.ipython.prototype.newIn = function () {
+    ipythonExample.prototype.newIn = function () {
         let cell = document.createElement("DIV");
         this.editor.appendChild(cell);
         cell = ace.edit(cell);
@@ -241,7 +241,7 @@
                     win: "ctrl-C",
                 },
                 exec: (e, t) => {
-                    Sk.stopExecution = true;
+                    stopExecution = true;
                 },
                 readOnly: true,
             },
@@ -249,7 +249,7 @@
         return cell;
     };
 
-    Sk.ipython.prototype.newPrint = function () {
+    ipythonExample.prototype.newPrint = function () {
         let cell = document.createElement("DIV");
         this.editor.appendChild(cell);
         cell = ace.edit(cell);
@@ -288,14 +288,14 @@
                 win: "ctrl-C",
             },
             exec: (e, t) => {
-                Sk.stopExecution = true;
+                stopExecution = true;
             },
             readOnly: true,
         });
         return cell;
     };
 
-    Sk.ipython.prototype.newOut = function () {
+    ipythonExample.prototype.newOut = function () {
         let cell = document.createElement("DIV");
         this.editor.appendChild(cell);
         cell = ace.edit(cell);

--- a/example/ipython.js
+++ b/example/ipython.js
@@ -20,6 +20,7 @@
         _i: Sk.builtin.str.$empty,
         _ii: Sk.builtin.str.$empty,
         _iii: Sk.builtin.str.$empty,
+        __name__: new Sk.builtin.str("__main__"),
     };
     Sk.globals.In = Sk.globals._ih;
     Sk.globals.Out = Sk.globals._oh;
@@ -111,7 +112,7 @@
         compile_code = lines.join("\n");
         this.inCell.setReadOnly(true);
         this.inCell.renderer.$cursorLayer.element.style.opacity = 0;
-        const executionPromise = Sk.misceval.asyncToPromise(() => Sk.importMainWithBody("<stdin>", false, compile_code, true), {
+        const executionPromise = Sk.misceval.asyncToPromise(() => Sk.importMainWithBody("ipython", false, compile_code, true), {
             "*": () => {
                 if (Sk.stopExecution) {
                     throw "\nKeyboard interrupt";
@@ -131,7 +132,7 @@
                 if (Sk.builtin.checkNone(last_input) || last_input === undefined) {
                     delete Sk.globals["_" + this.inputs.length];
                 } else {
-                    this.outCell.setValue(Sk.misceval.objectRepr(last_input), -1);
+                    this.outCell.setValue(Sk.ffi.remapToJs(Sk.misceval.objectRepr(last_input)), -1);
                     if (last_input !== Sk.globals.Out) {
                         Sk.abstr.objectSetItem(Sk.globals._oh, Sk.ffi.remapToPy(this.inputs.length), last_input);
                         Sk.globals["___"] = Sk.globals["__"];
@@ -328,4 +329,5 @@
         cell.isVisible = false;
         return cell;
     };
+
 })();

--- a/example/turtle.html
+++ b/example/turtle.html
@@ -28,14 +28,9 @@ wn.exitonclick()
 </textarea>
     <script>
         var prog = document.getElementById("code").value;
-	function builtinRead(x) {
-	    if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined)
-		    throw "File not found: '" + x + "'";
-	    return Sk.builtinFiles["files"][x];
-	}
+
     (Sk.TurtleGraphics || (Sk.TurtleGraphics = {})).target = 'mycanvas';
 
-    Sk.configure({ read: builtinRead });
 
     Sk.misceval.asyncToPromise(function() {
       return Sk.importMainWithBody("<stdin>",false,prog,true);

--- a/example/webgl/webgl-0001-basic.html
+++ b/example/webgl/webgl-0001-basic.html
@@ -65,12 +65,6 @@ gl.drawArrays(gl.TRIANGLES, 0, 6)
         output.innerHTML = output.innerHTML + text.replace(/</g, '&lt;');
       }
 
-      function builtinRead(x) {
-        if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined) {
-          throw "File not found: '" + x + "'";
-        }
-        return Sk.builtinFiles["files"][x];
-      }
 
       function runit() {
         var prog = document.getElementById("code").value;
@@ -78,7 +72,7 @@ gl.drawArrays(gl.TRIANGLES, 0, 6)
         document.getElementById("my-output").innerHTML = '';
         Sk.canvas = "my-canvas";
         Sk.pre = "my-output";
-        Sk.configure({"output":outputHandler, "read":builtinRead});
+        Sk.configure({"output":outputHandler});
         try {
            eval(Sk.importMainWithBody("<stdin>", false, prog));
         }

--- a/example/webgl/webgl-0002-viewport.html
+++ b/example/webgl/webgl-0002-viewport.html
@@ -65,12 +65,6 @@ gl.drawArrays(gl.TRIANGLES, 0, 6)
         output.innerHTML = output.innerHTML + text.replace(/</g, '&lt;');
       }
 
-      function builtinRead(x) {
-        if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined) {
-          throw "File not found: '" + x + "'";
-        }
-        return Sk.builtinFiles["files"][x];
-      }
 
       function runit() {
         var prog = document.getElementById("code").value;
@@ -78,7 +72,7 @@ gl.drawArrays(gl.TRIANGLES, 0, 6)
         document.getElementById("my-output").innerHTML = '';
         Sk.canvas = "my-canvas";
         Sk.pre = "my-output";
-        Sk.configure({"output":outputHandler, "read":builtinRead});
+        Sk.configure({"output":outputHandler, });
         try {
            eval(Sk.importMainWithBody("<stdin>", false, prog));
         }

--- a/example/webgl/webgl-0003-color.html
+++ b/example/webgl/webgl-0003-color.html
@@ -82,20 +82,13 @@ gl.drawArrays(gl.TRIANGLES, 0, 6)
         output.innerHTML = output.innerHTML + text.replace(/</g, '&lt;');
       }
 
-      function builtinRead(x) {
-        if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined) {
-          throw "File not found: '" + x + "'";
-        }
-        return Sk.builtinFiles["files"][x];
-      }
-
       function runit() {
         var prog = document.getElementById("code").value;
         // Clear the output
         document.getElementById("my-output").innerHTML = '';
         Sk.canvas = "my-canvas";
         Sk.pre = "my-output";
-        Sk.configure({"output":outputHandler, "read":builtinRead});
+        Sk.configure({"output":outputHandler, });
         try {
            eval(Sk.importMainWithBody("<stdin>", false, prog));
         }

--- a/example/webgl/webgl-0004-movement.html
+++ b/example/webgl/webgl-0004-movement.html
@@ -89,12 +89,6 @@ gl.setDrawFunc(draw);
         output.innerHTML = output.innerHTML + text.replace(/</g, '&lt;');
       }
 
-      function builtinRead(x) {
-        if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined) {
-          throw "File not found: '" + x + "'";
-        }
-        return Sk.builtinFiles["files"][x];
-      }
 
       function runit() {
         var prog = document.getElementById("code").value;
@@ -102,7 +96,7 @@ gl.setDrawFunc(draw);
         document.getElementById("my-output").innerHTML = '';
         Sk.canvas = "my-canvas";
         Sk.pre = "my-output";
-        Sk.configure({"output":outputHandler, "read":builtinRead});
+        Sk.configure({"output":outputHandler, });
         try {
            eval(Sk.importMainWithBody("<stdin>", false, prog));
         }

--- a/example/webgl/webgl-0005-3d.html
+++ b/example/webgl/webgl-0005-3d.html
@@ -120,12 +120,7 @@ gl.setDrawFunc(draw);
         output.innerHTML = output.innerHTML + text.replace(/</g, '&lt;');
       }
 
-      function builtinRead(x) {
-        if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined) {
-          throw "File not found: '" + x + "'";
-        }
-        return Sk.builtinFiles["files"][x];
-      }
+
 
       function runit() {
         var prog = document.getElementById("code").value;
@@ -133,7 +128,7 @@ gl.setDrawFunc(draw);
         document.getElementById("my-output").innerHTML = '';
         Sk.canvas = "my-canvas";
         Sk.pre = "my-output";
-        Sk.configure({"output":outputHandler, "read":builtinRead});
+        Sk.configure({"output":outputHandler, });
         try {
            eval(Sk.importMainWithBody("<stdin>", false, prog));
         }

--- a/repl/repl.js
+++ b/repl/repl.js
@@ -36,7 +36,7 @@ Sk.configure({
     output: (args) => { process.stdout.write(args); },
     read: (fname) => { return fs.readFileSync(fname, "utf8"); },
     systemexit: true,
-    retainglobals: true,
+    retainGlobals: true,
     inputfun: readline,
     __future__: py3 ? Sk.python3 : Sk.python2,
 });

--- a/src/env.js
+++ b/src/env.js
@@ -257,12 +257,12 @@ Sk.output = function (x) {
 };
 
 /*
- * Replacable function to load modules with (called via import, etc.)
+ * Replaceable function to load modules with (called via import, etc.)
  * todo; this should be an async api
  */
 Sk.read = function (x) {
     if (Sk.builtinFiles === undefined) {
-        throw Sk.builtin.NotImplementedError("Sk.read has not been implemented");
+        throw "skulpt-stdlib.js has not been loaded";
     } else if (Sk.builtinFiles.files[x] === undefined) {
         throw "File not found: '" + x + "'";
     }

--- a/src/env.js
+++ b/src/env.js
@@ -130,7 +130,7 @@ Sk.configure = function (options) {
     Sk.inputfunTakesPrompt = options["inputfunTakesPrompt"] || false;
     Sk.asserts.assert(typeof Sk.inputfunTakesPrompt === "boolean");
 
-    Sk.retainGlobals = options["retainglobals"] || false;
+    Sk.retainGlobals = options["retainglobals"] || options["retainGlobals"] || false;
     Sk.asserts.assert(typeof Sk.retainGlobals === "boolean");
 
     Sk.debugging = options["debugging"] || false;
@@ -261,7 +261,12 @@ Sk.output = function (x) {
  * todo; this should be an async api
  */
 Sk.read = function (x) {
-    throw "Sk.read has not been implemented";
+    if (Sk.builtinFiles === undefined) {
+        throw Sk.builtin.NotImplementedError("Sk.read has not been implemented");
+    } else if (Sk.builtinFiles.files[x] === undefined) {
+        throw "File not found: '" + x + "'";
+    }
+    return Sk.builtinFiles.files[x];
 };
 
 /*

--- a/support/run/run_template.ejs
+++ b/support/run/run_template.ejs
@@ -29,16 +29,7 @@ function showjs(text) {
 }
 
 
-function builtinRead(x) {
-    console.log(x);
-    if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined) {
-        throw "File not found: '" + x + "'";
-    }
 
-    var file = Sk.builtinFiles["files"][x];
-
-    return file;
-}
 
 function runit(myDiv, pyver) {
     var prog = document.getElementById(myDiv+"_code").value;
@@ -74,7 +65,6 @@ function runit(myDiv, pyver) {
 
     Sk.configure({
         output:outf,
-        read: builtinRead,
         inputfunTakesPrompt: true,
         debugout: showjs,
         debugging: debug,

--- a/test/turtle/referenceImageCreator.html
+++ b/test/turtle/referenceImageCreator.html
@@ -124,12 +124,6 @@ t = turtle.Turtle()</textarea>
             outf('});');
         }
 
-        function builtinRead(x) {
-            if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined)
-                throw "File not found: '" + x + "'";
-            return Sk.builtinFiles["files"][x];
-        }
-
         function runit(myDiv) {
             //var prog = document.getElementById(myDiv + "_code").value;
             var mypre = document.getElementById(myDiv + "_pre");
@@ -160,7 +154,6 @@ t = turtle.Turtle()</textarea>
             Sk.pre = myDiv+"_pre";
             Sk.configure({
                 output: outf,
-                read: builtinRead
             });
 
             //try {

--- a/test/turtle/spec/TurtleSpec.js
+++ b/test/turtle/spec/TurtleSpec.js
@@ -1,12 +1,6 @@
 describe("Turtle", function () {
     'use strict';
-    var builtinRead = function (x) {
-            if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined) {
-                throw "File not found: '" + x + "'";
-            }
-            return Sk.builtinFiles["files"][x];
-        },
-        c,
+	var c,
         ref = document.createElement('canvas'),
         loadImage = function (file) {
             var a = new Image();
@@ -31,7 +25,6 @@ describe("Turtle", function () {
             output: function(s) {
                 console.log(s);
             },
-            read: builtinRead
         });
         c = document.createElement('canvas');
         c.id = "turtlecanvas";
@@ -184,13 +177,7 @@ describe("Turtle", function () {
 
 describe("Turtle (non-animated)", function () {
 	'use strict';
-	var builtinRead = function (x) {
-			if (Sk.builtinFiles === undefined || Sk.builtinFiles["files"][x] === undefined) {
-				throw "File not found: '" + x + "'";
-			}
-			return Sk.builtinFiles["files"][x];
-		},
-		c,
+	var c,
 		ref = document.createElement('canvas'),
 		loadImage = function (file, done) {
 			var a = new Image();
@@ -216,7 +203,6 @@ describe("Turtle (non-animated)", function () {
 			output: function(s) {
 				console.log(s);
 			},
-			read: builtinRead
 		});
 		c = document.createElement('canvas')
 		c.id = "turtlecanvas";


### PR DESCRIPTION
I wanted to create a new example - potentially could be added to the website instead - but I thought i'd showcase it as a PR. 

it uses `ace` code editor. I'm sure I could adapt it to `codemirror` if preferred. 

here's the gif:

![Bak9RsqQLN](https://user-images.githubusercontent.com/36813890/86760925-2eae3a00-c078-11ea-8287-e00e3e9be0c8.gif)

___

The ipyhton repl adds keyboard bindings to scroll through previous entries
as well as a keyboard interrupt feature `ctrl + c`
`ctrl/cmd - enter` runs the command
`_`, `__`, `_1` work as per ipython
as do `In`, `Out`, `_i1`, `_ii` 

___

A couple of suggested changes with this pr - 
`Sk.retainGlobals` should match camelCase for `options["retainGlobals"]` (with backward compatibility)

Every example has the same `builtinRead` function should this become the default option?
Since it's the default option I remove this function from all examples. 

Both the above changes can be overridden - just ideas. 





