### PR TITLE
improve __bulitins__.classmethod.classmethod

### DIFF
--- a/repl/repl.js
+++ b/repl/repl.js
@@ -41,6 +41,8 @@ Sk.configure({
     __future__: py3 ? Sk.python3 : Sk.python2,
 });
 
+Sk.globals = { __name__: new Sk.builtin.str("__main__")};
+
 var //finds lines starting with "print"
     re = new RegExp("\\s*print"),
     //finds import statements
@@ -60,10 +62,10 @@ var //finds lines starting with "print"
 
 if (Sk.__future__.python3) {
     console.log("Python 3.7(ish) (skulpt, " + new Date() + ")");
-    printevaluationresult = "if not evaluationresult == None: print(repr(evaluationresult))"
+    printevaluationresult = "if not evaluationresult == None: print(repr(evaluationresult))";
 } else {
     console.log("Python 2.7(ish) (skulpt, " + new Date() + ")");
-    printevaluationresult = "if not evaluationresult == None: print repr(evaluationresult)"
+    printevaluationresult = "if not evaluationresult == None: print repr(evaluationresult)";
 }
 console.log("[node: " + process.version + "] on a system");
 console.log('Don\'t type "help", "copyright", "credits" or "license" unless you\'ve assigned something to them');

--- a/src/import.js
+++ b/src/import.js
@@ -129,6 +129,8 @@ Sk.doOneTimeInitialization = function (canSuspend) {
         mod = Sk.misceval.retryOptionalSuspensionOrThrow(mod);
         Sk.asserts.assert(mod["$d"][fileWithoutExtension] !== undefined, "Should have imported name " + fileWithoutExtension);
         Sk.builtins[fileWithoutExtension] = mod["$d"][fileWithoutExtension];
+        delete Sk.builtins[fileWithoutExtension].__module__;
+        delete Sk.globals[fileWithoutExtension];
     }
 };
 


### PR DESCRIPTION
this pr aims to improve the hack with `classmethod` with an additional hack 🤷‍♂️ 

It essentially removes the `__module__` property from each of `property`, `classmethod` and `staticmethod`
It also removes these three objects from `Sk.globals` since they get added to `__builtins__` and shouldn't really be in `Sk.globals`

this way
```python
>>> classmethod
<class 'classmethod'>
# rather than <class '__builtins__.classmethod.classmethod'>
>>> globals()
{'__name__': '__main__', '__file__': 'repl.py', '__doc__': None, '__package__': None}
# rather than {..., 'classmethod': <class '__builtins__.classmethod.classmethod'>, ...}
```

a small change to `repl.js` which - since it retains globals carries over the `__name__` property `__builtins__.classmethod` 
By setting the `Sk.globals.__name__` property in advanced this remains the same after `classmethod` et al are injected

