### PR TITLE
compile pyBody if supplied string even if empty

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -240,7 +240,7 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, rela
             // - run module and set the module locals returned to the module __dict__
             module = new Sk.builtin.module();
 
-            if (suppliedPyBody) {
+            if (typeof suppliedPyBody === "string") {
                 filename = name + ".py";
                 co = Sk.compile(suppliedPyBody, filename, "exec", canSuspend);
             } else {

--- a/support/run/run_template.ejs
+++ b/support/run/run_template.ejs
@@ -110,9 +110,7 @@ function runit(myDiv, pyver) {
 <h3>Test Code</h3>
 <div id="runbrowser">
 <form>
-<textarea edit_id="eta_5" id="runbrowser_code" cols="72" rows="20" style="font-family: 'Lucida Console', Monaco, monospace;">
-<%- code %>
-</textarea>
+<textarea edit_id="eta_5" id="runbrowser_code" cols="72" rows="20" style="font-family: 'Lucida Console', Monaco, monospace;"><%- code %></textarea>
 <br>
 <input type="checkbox" id="debug">Debug</input>
 <br>


### PR DESCRIPTION
A minor bug that I found when working on #1110 
If the supplied body is a string it should still be compiled - even if that string is empty. 
Otherwise the compile logic tries to find `.py` in `builtinFiles`

I didn't add tests but I did make the default code in `npm run brun` an empty string rather than a new line. 
A quick check of this branch vs master `npm run brun tok_test.py` will compile an empty line whereas before it would raise the error
```
ImportError: No module named <stdin>
```

