### PR TITLE
fix for long.toInt$

### DIFF
--- a/src/long.js
+++ b/src/long.js
@@ -156,7 +156,7 @@ Sk.longFromStr = function (s, base) {
 Sk.exportSymbol("Sk.longFromStr", Sk.longFromStr);
 
 Sk.builtin.lng.prototype.toInt$ = function () {
-    return this.biginteger.intValue();
+    return parseInt(this.biginteger.toString(), 10);
 };
 
 Sk.builtin.lng.prototype.clone = function () {

--- a/test/unit/test_int.py
+++ b/test/unit/test_int.py
@@ -77,6 +77,8 @@ class IntTestCases(unittest.TestCase):
         # Failed in all Linux builds.
         x = -1-sys.maxsize
         self.assertEqual(x >> 1, x//2)
+        self.assertEqual(int(x >> 1), x//2)
+
 
         x = int('1' * 600)
         """

--- a/test/unit3/test_math.py
+++ b/test/unit3/test_math.py
@@ -1650,6 +1650,10 @@ class IsCloseTests(unittest.TestCase):
     #     self.assertAllNotClose(fraction_examples, rel_tol=1e-9)
 
 
+    def test_skulptBugs(self):
+        # 1113
+        self.assertAlmostEqual(math.log(9007199254740992 // 2), 36.04365338911715, 15)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A fix to close #1113 

the issue seems to be in the `biginteger` library
https://github.com/skulpt/skulpt/blob/master/src/biginteger.js#L878
```javascript
 return ((this[1] & ((1 << (32 - this.DB)) - 1)) << this.DB) | this[0];
```
the bitwise operations can return unexpected results for largish integers (`>2**31`) and the threshold we use internally for this function is `Number.MAX_SAFE_INTEGER`... (`2**53 - 1`)

```javascript
a = new Sk.builtin.biginteger(2**31)
a.intValue() // -2147483648 
a.toString() // "2147483648"
b = new Sk.builtin.biginteger(2**32 + 1)
b.intValue() // 1
b.toString() // "4294967297"
```

`biginteger.toString()` seems safer for this use case then... 

I replace `this.biginteger.intValue()` with `parseInt(this.biginteger.toString(), 10)` 
We know this is safe internally since the operation is only called in the following way 
```javascript
this.cantBeInt() ? this.str$(10, true) : this.toInt$();
```


test added in `test_math.py` which replicates the behaviour in #1113 
and another test in `test_int.py`
```python
        x = -1-sys.maxsize
        self.assertEqual(x >> 1, x//2)
        self.assertEqual(int(x >> 1), x//2) # new test which previously failed
```
