### PR TITLE
improve performance of interned

### DIFF
--- a/src/str.js
+++ b/src/str.js
@@ -1,4 +1,12 @@
-Sk.builtin.interned = {};
+Sk.builtin.interned = Object.create(null);
+
+function getInterned (x) {
+    return Sk.builtin.interned[x];
+}
+
+function setInterned (x, pyStr) {
+    Sk.builtin.interned[x] = pyStr;
+}
 
 /**
  * @constructor
@@ -54,14 +62,15 @@ Sk.builtin.str = function (x) {
     }
 
     // interning required for strings in py
-    if (Sk.builtin.interned["1" + ret]) {
-        return Sk.builtin.interned["1" + ret];
+    const interned = getInterned(ret);
+    if (interned !== undefined) {
+        return interned;
     }
 
     this.__class__ = Sk.builtin.str;
     this.v = ret;
     this["v"] = this.v;
-    Sk.builtin.interned["1" + ret] = this;
+    setInterned(ret, this);
     return this;
 
 };


### PR DESCRIPTION
This one improves performance for strings but only if doing a lot of str conversion like

```python
from time import time

for j in range(2):
    t = time()
    for i in range(3000000):
        str(i)
    print(time()-t)

# Master:     25.3270001411438,  12.41999983787537
# ThisBranch: 10.52700018882751, 10.72699999809265
```
the first loop sets strings into `interned` 
the second will get strings from `interned`

By using 
```javascript
Sk.builtin.interned = Object.create(null)
``` 
instead of 
```javascript
Sk.builtin.interned = {}
```
 there's no need for `"1"+ ret` since there won't be any name conflicts with `Object.prototype` since `Sk.builtin.interned` no longer inherits from `Object` and thus has no `__proto__` methods that would otherwise cause conflict. 


