### PR TITLE
Pr/name mangling plus

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -634,7 +634,7 @@ Sk.abstr.gattr = function (obj, pyName, canSuspend) {
     // Should this be an assert?
     if (obj === null || !obj.tp$getattr) {
         let objname = Sk.abstr.typeName(obj);
-        let jsName = Sk.unfixReserved(pyName.$jsstr());
+        let jsName = pyName.$jsstr();
         throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
     }
 
@@ -643,12 +643,12 @@ Sk.abstr.gattr = function (obj, pyName, canSuspend) {
     let ret = obj.tp$getattr(pyName, canSuspend);
 
     if (ret === undefined) {
-        let jsName = Sk.unfixReserved(pyName.$jsstr());
+        let jsName = pyName.$jsstr();
         throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + jsName + "'");
     } else if (ret.$isSuspension) {
         return Sk.misceval.chain(ret, function(r) {
             if (r === undefined) {
-                let jsName = Sk.unfixReserved(pyName.$jsstr());
+                let jsName = pyName.$jsstr();
                 throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + jsName + "'");
             }
             return r;
@@ -664,14 +664,14 @@ Sk.abstr.sattr = function (obj, pyName, data, canSuspend) {
     var objname = Sk.abstr.typeName(obj), r, setf;
 
     if (obj === null) {
-        let jsName = Sk.unfixReserved(pyName.$jsstr());
+        let jsName = pyName.$jsstr();
         throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
     }
 
     if (obj.tp$setattr !== undefined) {
         return obj.tp$setattr(pyName, data, canSuspend);
     } else {
-        let jsName = Sk.unfixReserved(pyName.$jsstr());
+        let jsName = pyName.$jsstr();
         throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
     }
 };

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -634,8 +634,7 @@ Sk.abstr.gattr = function (obj, pyName, canSuspend) {
     // Should this be an assert?
     if (obj === null || !obj.tp$getattr) {
         let objname = Sk.abstr.typeName(obj);
-        let jsName = pyName.$jsstr();
-        throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
+        throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + pyName.$jsstr() + "'");
     }
 
     // This function is so hot that we do our own inline suspension checks
@@ -643,13 +642,11 @@ Sk.abstr.gattr = function (obj, pyName, canSuspend) {
     let ret = obj.tp$getattr(pyName, canSuspend);
 
     if (ret === undefined) {
-        let jsName = pyName.$jsstr();
-        throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + jsName + "'");
+        throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + pyName.$jsstr() + "'");
     } else if (ret.$isSuspension) {
         return Sk.misceval.chain(ret, function(r) {
             if (r === undefined) {
-                let jsName = pyName.$jsstr();
-                throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + jsName + "'");
+                throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + pyName.$jsstr() + "'");
             }
             return r;
         });
@@ -664,15 +661,13 @@ Sk.abstr.sattr = function (obj, pyName, data, canSuspend) {
     var objname = Sk.abstr.typeName(obj), r, setf;
 
     if (obj === null) {
-        let jsName = pyName.$jsstr();
-        throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
+        throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + pyName.$jsstr() + "'");
     }
 
     if (obj.tp$setattr !== undefined) {
         return obj.tp$setattr(pyName, data, canSuspend);
     } else {
-        let jsName = pyName.$jsstr();
-        throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + jsName + "'");
+        throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + pyName.$jsstr() + "'");
     }
 };
 Sk.exportSymbol("Sk.abstr.sattr", Sk.abstr.sattr);

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -933,19 +933,18 @@ Sk.builtin.hash = function hash (value) {
 };
 
 Sk.builtin.getattr = function getattr (obj, pyName, default_) {
-    var ret, mangledName, jsName;
+    var ret, jsName;
     Sk.builtin.pyCheckArgsLen("getattr", arguments.length, 2, 3);
     if (!Sk.builtin.checkString(pyName)) {
         throw new Sk.builtin.TypeError("attribute name must be string");
     }
 
-    jsName = pyName.$jsstr();
-    mangledName = new Sk.builtin.str(Sk.fixReserved(jsName));
-    ret = obj.tp$getattr(mangledName);
+    ret = obj.tp$getattr(pyName);
     if (ret === undefined) {
         if (default_ !== undefined) {
             return default_;
         } else {
+            jsName = pyName.$jsstr();
             throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + jsName + "'");
         }
     }
@@ -959,10 +958,10 @@ Sk.builtin.setattr = function setattr (obj, pyName, value) {
     if (!Sk.builtin.checkString(pyName)) {
         throw new Sk.builtin.TypeError("attribute name must be string");
     }
-    jsName = pyName.$jsstr();
     if (obj.tp$setattr) {
-        obj.tp$setattr(new Sk.builtin.str(Sk.fixReserved(jsName)), value);
+        obj.tp$setattr(pyName, value);
     } else {
+        jsName = pyName.$jsstr();
         throw new Sk.builtin.AttributeError("object has no attribute " + jsName);
     }
     return Sk.builtin.none.none$;

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -933,7 +933,7 @@ Sk.builtin.hash = function hash (value) {
 };
 
 Sk.builtin.getattr = function getattr (obj, pyName, default_) {
-    var ret, jsName;
+    var ret;
     Sk.builtin.pyCheckArgsLen("getattr", arguments.length, 2, 3);
     if (!Sk.builtin.checkString(pyName)) {
         throw new Sk.builtin.TypeError("attribute name must be string");
@@ -944,15 +944,13 @@ Sk.builtin.getattr = function getattr (obj, pyName, default_) {
         if (default_ !== undefined) {
             return default_;
         } else {
-            jsName = pyName.$jsstr();
-            throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + jsName + "'");
+            throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(obj) + "' object has no attribute '" + pyName.$jsstr() + "'");
         }
     }
     return ret;
 };
 
 Sk.builtin.setattr = function setattr (obj, pyName, value) {
-    var jsName;
     Sk.builtin.pyCheckArgsLen("setattr", arguments.length, 3, 3);
     // cannot set or del attr from builtin type
     if (!Sk.builtin.checkString(pyName)) {
@@ -961,8 +959,7 @@ Sk.builtin.setattr = function setattr (obj, pyName, value) {
     if (obj.tp$setattr) {
         obj.tp$setattr(pyName, value);
     } else {
-        jsName = pyName.$jsstr();
-        throw new Sk.builtin.AttributeError("object has no attribute " + jsName);
+        throw new Sk.builtin.AttributeError("object has no attribute " + pyName.$jsstr());
     }
     return Sk.builtin.none.none$;
 };
@@ -1159,7 +1156,6 @@ Sk.builtin.filter = function filter (fun, iterable) {
 
 Sk.builtin.hasattr = function hasattr (obj, attr) {
     Sk.builtin.pyCheckArgsLen("hasattr", arguments.length, 2, 2);
-    var special, ret;
     if (!Sk.builtin.checkString(attr)) {
         throw new Sk.builtin.TypeError("hasattr(): attribute name must be string");
     }

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -1315,10 +1315,11 @@ Sk.builtin.issubclass = function issubclass (c1, c2) {
 };
 
 Sk.builtin.globals = function globals () {
-    var i;
+    var i, unmangled;
     var ret = new Sk.builtin.dict([]);
     for (i in Sk["globals"]) {
-        ret.mp$ass_subscript(new Sk.builtin.str(i), Sk["globals"][i]);
+        unmangled = Sk.unfixReserved(i);
+        ret.mp$ass_subscript(new Sk.builtin.str(unmangled), Sk["globals"][i]);
     }
 
     return ret;

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -90,7 +90,7 @@ Sk.builtins = {
     "bytearray" : Sk.builtin.bytearray,
     "callable"  : Sk.builtin.callable,
     "delattr"   : Sk.builtin.delattr,
-    "eval_$rn$" : Sk.builtin.eval_,
+    "eval_$rw$" : Sk.builtin.eval_,
     "execfile"  : Sk.builtin.execfile,
     "frozenset" : Sk.builtin.frozenset,
     "help"      : Sk.builtin.help,
@@ -104,7 +104,7 @@ Sk.builtins = {
     "unichr"    : Sk.builtin.unichr,
     "vars"      : Sk.builtin.vars,
     "xrange"    : Sk.builtin.xrange,
-    "apply_$rn$": Sk.builtin.apply_,
+    "apply_$rw$": Sk.builtin.apply_,
     "buffer"    : Sk.builtin.buffer,
     "coerce"    : Sk.builtin.coerce,
     "intern"    : Sk.builtin.intern

--- a/src/compile.js
+++ b/src/compile.js
@@ -2613,7 +2613,6 @@ Compiler.prototype.exitScope = function () {
     if (prev.name.v !== "<module>") {// todo; hacky
         mangled = prev.name["$r"]().v;
         mangled = mangled.substring(1, mangled.length - 1);
-        // mangled = fixReserved(mangled);
         out(prev.scopename, ".co_name=new Sk.builtins['str']('", mangled, "');");
     }
     for (var constant in prev.consts) {

--- a/src/compile.js
+++ b/src/compile.js
@@ -126,123 +126,18 @@ Compiler.prototype.niceName = function (roughName) {
     return this.gensym(roughName.replace("<", "").replace(">", "").replace(" ", "_"));
 };
 
-var reservedWords_ = {
-    "abstract": true,
-    "as": true,
-    "boolean": true,
-    "break": true,
-    "byte": true,
-    "case": true,
-    "catch": true,
-    "char": true,
-    "class": true,
-    "continue": true,
-    "const": true,
-    "debugger": true,
-    "default": true,
-    "delete": true,
-    "do": true,
-    "double": true,
-    "else": true,
-    "enum": true,
-    "export": true,
-    "extends": true,
-    "false": true,
-    "final": true,
-    "finally": true,
-    "float": true,
-    "for": true,
-    "function": true,
-    "goto": true,
-    "if": true,
-    "implements": true,
-    "import": true,
-    "in": true,
-    "instanceof": true,
-    "int": true,
-    "interface": true,
-    "is": true,
-    "long": true,
-    "namespace": true,
-    "native": true,
-    "new": true,
-    "null": true,
-    "package": true,
-    "private": true,
-    "protected": true,
-    "public": true,
-    "return": true,
-    "short": true,
-    "static": true,
-    "super": false,
-    "switch": true,
-    "synchronized": true,
-    "this": true,
-    "throw": true,
-    "throws": true,
-    "transient": true,
-    "true": true,
-    "try": true,
-    "typeof": true,
-    "use": true,
-    "var": true,
-    "void": true,
-    "volatile": true,
-    "while": true,
-    "with": true
-};
+var reservedWords_ = Sk.builtin.str.reservedWords_; // defined in str.js
 
-/**
- * Fix reserved words
- *
- * @param {string} name
- */
-function fixReservedWords(name) {
-    if (reservedWords_[name] !== true) {
+
+function fixReserved(name) {
+    if (reservedWords_[name] === undefined) {
         return name;
     }
     return name + "_$rw$";
 }
 
-var reservedNames_ = {
-    "__defineGetter__": true,
-    "__defineSetter__": true,
-    "apply": true,
-    "arguments": true,
-    "call": true,
-    "caller": true, 
-    "eval": true,
-    "hasOwnProperty": true,
-    "isPrototypeOf": true,
-    "__lookupGetter__": true,
-    "__lookupSetter__": true,
-    "__noSuchMethod__": true,
-    "propertyIsEnumerable": true,
-    "prototype": true,
-    "toSource": true,
-    "toLocaleString": true,
-    "toString": true,
-    "unwatch": true,
-    "valueOf": true,
-    "watch": true,
-    "length": true,
-    "name": true,
-};
-
-function fixReservedNames (name) {
-    if (reservedNames_[name]) {
-        return name + "_$rn$";
-    }
-    return name;
-}
-
-function fixReserved (name) {
-    name = fixReservedNames(fixReservedWords(name));
-    return name;
-}
-
 function unfixReserved(name) {
-    return name.replace(/_\$r[wn]\$$/, "");
+    return name.replace(/_\$rw\$$/, "");
 }
 
 function mangleName (priv, ident) {
@@ -299,7 +194,7 @@ Compiler.prototype.makeConstant = function (rest) {
     v = this.u.scopename + "." + this.gensym("const");
     this.u.consts[v] = val;
     return v;
-}
+};
 
 /**
  * @param {string} hint basename for gensym
@@ -324,7 +219,7 @@ Compiler.prototype._gr = function (hint, rest) {
 Compiler.prototype.outputInterruptTest = function () { // Added by RNL
     var output = "";
     if (Sk.execLimit !== null || Sk.yieldLimit !== null && this.u.canSuspend) {
-            output += "var $dateNow = Date.now();";
+        output += "var $dateNow = Date.now();";
         if (Sk.execLimit !== null) {
             output += "if ($dateNow - Sk.execStart > Sk.execLimit) {throw new Sk.builtin.TimeLimitError(Sk.timeoutMsg())}";
         }
@@ -420,7 +315,7 @@ Compiler.prototype.cunpackstarstoarray = function(elts, permitEndOnly) {
         // Fast path
         return "[" + elts.map((expr) => this.vexpr(expr)).join(",") + "]";
     }
-}
+};
 
 Compiler.prototype.ctuplelistorset = function(e, data, tuporlist) {
     var i;
@@ -910,7 +805,6 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
             mangled = e.attr["$r"]().v;
             mangled = mangled.substring(1, mangled.length - 1);
             mangled = mangleName(this.u.private_, new Sk.builtin.str(mangled)).v;
-            mangled = fixReserved(mangled);
             mname = this.makeConstant("new Sk.builtin.str('" + mangled + "')");
             switch (e.ctx) {
                 case Sk.astnodes.AugLoad:
@@ -1776,7 +1670,7 @@ Compiler.prototype.cfromimport = function (s) {
         level = -1;
     }
     for (i = 0; i < n; ++i) {
-        names[i] = "'" + fixReservedWords(s.names[i].name.v) + "'";
+        names[i] = "'" + fixReserved(s.names[i].name.v) + "'";
     }
     out("$ret = Sk.builtin.__import__(", s.module["$r"]().v, ",$gbl,$loc,[", names, "],",level,");");
 
@@ -1787,7 +1681,7 @@ Compiler.prototype.cfromimport = function (s) {
     mod = this._gr("module", "$ret");
     for (i = 0; i < n; ++i) {
         alias = s.names[i];
-        aliasOut = "'" + fixReservedWords(alias.name.v) + "'";
+        aliasOut = "'" + alias.name.v + "'";
         if (i === 0 && alias.name.v === "*") {
             Sk.asserts.assert(n === 1);
             out("Sk.importStar(", mod, ",$loc, $gbl);");
@@ -2028,17 +1922,20 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     for (i = 0; args && i < args.args.length; ++i) {
         id = args.args[i].arg;
         if (this.isCell(id)) {
-            this.u.varDeclsCode += "$cell." + id.v + "=" + id.v + ";";
+            let mangled = fixReserved(mangleName(this.u.private_, id).v);
+            this.u.varDeclsCode += "$cell." + mangled + "=" + mangled + ";";
         }
     }
     for (i = 0; args && args.kwonlyargs && i < args.kwonlyargs.length; ++i) {
         id = args.kwonlyargs[i].arg;
         if (this.isCell(id)) {
-            this.u.varDeclsCode += "$cell." + id.v + "=" + id.v + ";";
+            let mangled = fixReserved(mangleName(this.u.private_, id).v);
+            this.u.varDeclsCode += "$cell." + mangled + "=" + mangled + ";";
         }
     }
     if (vararg && this.isCell(vararg.arg)) {
-        this.u.varDeclsCode += "$cell." + vararg.arg.v + "=" + vararg.arg.v + ";";
+        let mangled = fixReserved(mangleName(this.u.private_, vararg.arg).v);
+        this.u.varDeclsCode += "$cell." + mangled + "=" + mangled + ";";
     }
 
     //
@@ -2048,7 +1945,8 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         this.u.localnames.push(kwarg.arg.v);
         this.u.varDeclsCode += kwarg.arg.v + "=new Sk.builtins['dict']($kwa);";
         if (this.isCell(kwarg.arg)) {
-            this.u.varDeclsCode += "$cell." + kwarg.arg.v + "=" + kwarg.arg.v + ";";
+            let mangled = fixReserved(mangleName(this.u.private_, kwarg.arg).v);
+            this.u.varDeclsCode += "$cell." + mangled + "=" + mangled + ";";
         }
     }
 
@@ -2524,7 +2422,7 @@ var D_FREEVARS = 1;
 var D_CELLVARS = 2;
 
 Compiler.prototype.isCell = function (name) {
-    var mangled = mangleName(this.u.private_, name).v;
+    var mangled = fixReserved(mangleName(this.u.private_, name).v);
     var scope = this.u.ste.getScope(mangled);
     var dict = null;
     return scope === Sk.SYMTAB_CONSTS.CELL;
@@ -2555,7 +2453,7 @@ Compiler.prototype.nameop = function (name, ctx, dataToStore) {
 
     mangled = mangleName(this.u.private_, name).v;
     // Have to do this before looking it up in the scope
-    mangled = fixReservedNames(mangled);
+    mangled = fixReserved(mangled);
     op = 0;
     optype = OP_NAME;
     scope = this.u.ste.getScope(mangled);
@@ -2586,8 +2484,6 @@ Compiler.prototype.nameop = function (name, ctx, dataToStore) {
             break;
     }
 
-    // have to do this after looking it up in the scope
-    mangled = fixReservedWords(mangled);
 
     //print("mangled", mangled);
     // TODO TODO TODO todo; import * at global scope failing here
@@ -2707,8 +2603,7 @@ Compiler.prototype.exitScope = function () {
     this.nestlevel--;
     if (this.stack.length - 1 >= 0) {
         this.u = this.stack.pop();
-    }
-    else {
+    } else {
         this.u = null;
     }
     if (this.u) {
@@ -2718,7 +2613,7 @@ Compiler.prototype.exitScope = function () {
     if (prev.name.v !== "<module>") {// todo; hacky
         mangled = prev.name["$r"]().v;
         mangled = mangled.substring(1, mangled.length - 1);
-        mangled = fixReserved(mangled);
+        // mangled = fixReserved(mangled);
         out(prev.scopename, ".co_name=new Sk.builtins['str']('", mangled, "');");
     }
     for (var constant in prev.consts) {
@@ -2875,12 +2770,6 @@ Sk.resetCompiler = function () {
 };
 
 Sk.exportSymbol("Sk.resetCompiler", Sk.resetCompiler);
-
-Sk.fixReservedWords = fixReservedWords;
-Sk.exportSymbol("Sk.fixReservedWords", Sk.fixReservedWords);
-
-Sk.fixReservedNames = fixReservedNames;
-Sk.exportSymbol("Sk.fixReservedNames", Sk.fixReservedNames);
 
 Sk.fixReserved = fixReserved;
 Sk.exportSymbol("Sk.fixReserved", Sk.fixReserved);

--- a/src/lib/collections.js
+++ b/src/lib/collections.js
@@ -1269,7 +1269,7 @@ var $builtinmodule = function (name) {
 
             // create the field properties
             for (let i = 0; i < flds.length; i++) {
-                fld = Sk.fixReservedNames(flds[i]);
+                fld = Sk.fixReserved(flds[i]);
                 cons[fld] = {};
                 cons[fld].tp$descr_set = function () {
                     throw new Sk.builtin.AttributeError("can't set attribute");

--- a/src/object.js
+++ b/src/object.js
@@ -44,7 +44,6 @@ Sk.builtin.object.prototype.GenericGetAttr = function (pyName, canSuspend) {
     var tp;
     var dict;
     var getf;
-    var jsName = pyName.$jsstr();
 
     tp = this.ob$type;
     Sk.asserts.assert(tp !== undefined, "object has no ob$type!");
@@ -59,11 +58,12 @@ Sk.builtin.object.prototype.GenericGetAttr = function (pyName, canSuspend) {
         } else if (dict.mp$subscript) {
             res = Sk.builtin._tryGetSubscript(dict, pyName);
         } else if (typeof dict === "object") {
-            res = dict[jsName];
+            const mangled = pyName.$mangled;
+            res = dict[mangled];
         }
         if (res !== undefined) {
             return res;
-        } else if (jsName == "__dict__" && dict instanceof Sk.builtin.dict) {
+        } else if (pyName.v == "__dict__" && dict instanceof Sk.builtin.dict) {
             return dict;
         }
     }
@@ -165,11 +165,12 @@ Sk.builtin.object.prototype.GenericSetAttr = function (pyName, value, canSuspend
         if (this instanceof Sk.builtin.object && !(this.ob$type.sk$klass) &&
             dict.mp$lookup(pyName) === undefined) {
             // Cannot add new attributes to a builtin object
-            throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + Sk.unfixReserved(jsName) + "'");
+            throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + pyName.$jsstr() + "'");
         }
         dict.mp$ass_subscript(pyName, value);
     } else if (typeof dict === "object") {
-        dict[jsName] = value;
+        const mangled = pyName.$mangled;
+        dict[mangled] = value;
     }
 };
 Sk.exportSymbol("Sk.builtin.object.prototype.GenericSetAttr", Sk.builtin.object.prototype.GenericSetAttr);

--- a/src/object.js
+++ b/src/object.js
@@ -63,7 +63,7 @@ Sk.builtin.object.prototype.GenericGetAttr = function (pyName, canSuspend) {
         }
         if (res !== undefined) {
             return res;
-        } else if (pyName.v == "__dict__" && dict instanceof Sk.builtin.dict) {
+        } else if (pyName.$jsstr() == "__dict__" && dict instanceof Sk.builtin.dict) {
             return dict;
         }
     }

--- a/src/str.js
+++ b/src/str.js
@@ -71,6 +71,7 @@ Sk.builtin.str = function (x) {
     this.v = ret;
     this["v"] = this.v;
     setInterned(ret, this);
+    this.$mangled = fixReserved(ret);
     return this;
 
 };
@@ -1327,3 +1328,104 @@ Sk.builtin.str_iter_.prototype.next$ = function (self) {
     }
     return ret;
 };
+
+
+var reservedWords_ = {
+    "abstract": true,
+    "as": true,
+    "boolean": true,
+    "break": true,
+    "byte": true,
+    "case": true,
+    "catch": true,
+    "char": true,
+    "class": true,
+    "continue": true,
+    "const": true,
+    "debugger": true,
+    "default": true,
+    "delete": true,
+    "do": true,
+    "double": true,
+    "else": true,
+    "enum": true,
+    "export": true,
+    "extends": true,
+    "false": true,
+    "final": true,
+    "finally": true,
+    "float": true,
+    "for": true,
+    "function": true,
+    "goto": true,
+    "if": true,
+    "implements": true,
+    "import": true,
+    "in": true,
+    "instanceof": true,
+    "int": true,
+    "interface": true,
+    "is": true,
+    "long": true,
+    "namespace": true,
+    "native": true,
+    "new": true,
+    "null": true,
+    "package": true,
+    "private": true,
+    "protected": true,
+    "public": true,
+    "return": true,
+    "short": true,
+    "static": true,
+    // "super": false,
+    "switch": true,
+    "synchronized": true,
+    "this": true,
+    "throw": true,
+    "throws": true,
+    "transient": true,
+    "true": true,
+    "try": true,
+    "typeof": true,
+    "use": true,
+    "var": true,
+    "void": true,
+    "volatile": true,
+    "while": true,
+    "with": true,
+    // reserved Names
+    "__defineGetter__": true,
+    "__defineSetter__": true,
+    "apply": true,
+    "arguments": true,
+    "call": true,
+    "caller": true, 
+    "eval": true,
+    "hasOwnProperty": true,
+    "isPrototypeOf": true,
+    "__lookupGetter__": true,
+    "__lookupSetter__": true,
+    "__noSuchMethod__": true,
+    "propertyIsEnumerable": true,
+    "prototype": true,
+    "toSource": true,
+    "toLocaleString": true,
+    "toString": true,
+    "unwatch": true,
+    "valueOf": true,
+    "watch": true,
+    "length": true,
+    "name": true,
+};
+
+Sk.builtin.str.reservedWords_ = reservedWords_;
+
+function fixReserved(name) {
+    if (reservedWords_[name] === undefined) {
+        return name;
+    }
+    return name + "_$rw$";
+}
+
+

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -357,7 +357,7 @@ SymbolTable.prototype.SEQExpr = function (nodes) {
 
 SymbolTable.prototype.enterBlock = function (name, blockType, ast, lineno) {
     var prev;
-    name = Sk.fixReservedNames(name);
+    name = Sk.fixReserved(name);
     //print("enterBlock:", name);
     prev = null;
     if (this.cur) {
@@ -422,8 +422,8 @@ SymbolTable.prototype.newTmpname = function (lineno) {
 SymbolTable.prototype.addDef = function (name, flag, lineno) {
     var fromGlobal;
     var val;
-    var mangled = Sk.mangleName(this.curClass, new Sk.builtin.str(name)).v;
-    mangled = Sk.fixReservedNames(mangled);
+    var mangled = Sk.mangleName(this.curClass, name).v;
+    mangled = Sk.fixReserved(mangled);
     val = this.cur.symFlags[mangled];
     if (val !== undefined) {
         if ((flag & DEF_PARAM) && (val & DEF_PARAM)) {
@@ -529,7 +529,7 @@ SymbolTable.prototype.visitStmt = function (s) {
             if (s.target.constructor == Sk.astnodes.Name) {
                 e_name = s.target;
                 name = Sk.mangleName(this.curClass, e_name.id).v;
-                name = Sk.fixReservedNames(name);
+                name = Sk.fixReserved(name);
                 cur = this.cur.symFlags[name];
                 if ((cur & (DEF_GLOBAL | DEF_NONLOCAL) )
                     && (this.global != this.cur.symFlags) // TODO
@@ -611,7 +611,7 @@ SymbolTable.prototype.visitStmt = function (s) {
             nameslen = s.names.length;
             for (i = 0; i < nameslen; ++i) {
                 name = Sk.mangleName(this.curClass, s.names[i]).v;
-                name = Sk.fixReservedNames(name);
+                name = Sk.fixReserved(name);
                 cur = this.cur.symFlags[name];
                 if (cur & (DEF_LOCAL | USE)) {
                     if (cur & DEF_LOCAL) {

--- a/src/type.js
+++ b/src/type.js
@@ -524,7 +524,7 @@ Sk.builtin.type.typeLookup = function (type, pyName) {
     var base;
     var res;
     var i;
-    var jsName = pyName.$jsstr();
+    var jsName = pyName.$mangled;
 
     // todo; probably should fix this, used for builtin types to get stuff
     // from prototype

--- a/test/unit/test_reserved_words.py
+++ b/test/unit/test_reserved_words.py
@@ -12,6 +12,7 @@ class A:
 a = A()
 a.name = 'foo'
 a.length = 'bar'
+default = "foo"
 
 class Test_ReservedWords(unittest.TestCase):
     def test_getattr(self):
@@ -65,6 +66,8 @@ class Test_ReservedWords(unittest.TestCase):
                 return name
             return inner
         self.assertEqual(wrapper("foo")(), "foo")
+    def test_global(self):
+        self.assertTrue("default" in globals())
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_reserved_words.py
+++ b/test/unit/test_reserved_words.py
@@ -22,6 +22,9 @@ class Test_ReservedWords(unittest.TestCase):
         func_delete = getattr(f, "delete")
         self.assertTrue(func_delete())
 
+        self.assertNotIn("$", repr(func_default))
+        self.assertNotIn("$", repr(func_delete))
+
     def test_getattr_with_name(self):
         self.assertEqual(getattr(a, 'name'), 'foo')
         self.assertEqual(getattr(a, 'length'), 'bar')

--- a/test/unit/test_reserved_words.py
+++ b/test/unit/test_reserved_words.py
@@ -59,5 +59,12 @@ class Test_ReservedWords(unittest.TestCase):
         with self.assertRaises(AttributeError):
             A.arguments 
 
+    def test_bug_949(self):
+        def wrapper(name):
+            def inner():
+                return name
+            return inner
+        self.assertEqual(wrapper("foo")(), "foo")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
this is building on top of #1070 and #1116 
close #949

I unify the handling of `reservedWords` and `reservedNames` so instead we have a single object and a single function `Sk.fixReserved`
- I remove passing of `_$rw$` to the client in `compile.js` - specifically for `functions` 
- I remove passing of `_$rw$` to the client in globals
- I implement @acbart fix outlined in issue #949 which is a related bug and seems sensible to include here

relevant tests added for each of the above that previously failed

---

The approach is to add `$mangled` onto each `str` instance. 
```javascript
Sk.builting.str = function str(x) {
...
    this.v = ret;
    this.$mangled = fixReserved(ret);
...
}
```

You'd think this might be slow but the same benchmark in #1116 shows identical speed
(below is a one time test)

```python
from time import time

for j in range(2):
    t = time()
    for i in range(3000000):
        str(i)
    print(time()-t)

# Master:      25.3270001411438,  12.41999983787537
# branch 1116: 10.52700018882751, 10.72699999809265
# this_branch: 10.25099992752075, 9.874000072479248
```

I think this is a strict improvement of the current approach. It simplifies the code in object lookups since we only deal with mangled names in one place - `typeLookup` (and the the odd internal cases when `$d` is an object)

