### PR TITLE
Pr/math `new`, <native JS>, some formatting

### DIFF
--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -239,7 +239,7 @@ var $builtinmodule = function (name) {
         }
     });
 
-    _isclose = function isclose(a, b, rel_tol, abs_tol) {
+    function isclose(a, b, rel_tol, abs_tol) {
         Sk.builtin.pyCheckArgsLen("isclose", arguments.length, 2, 4, true);
         Sk.builtin.pyCheckType("a", "number", Sk.builtin.checkNumber(a));
         Sk.builtin.pyCheckType("b", "number", Sk.builtin.checkNumber(b));
@@ -267,12 +267,12 @@ var $builtinmodule = function (name) {
         return new Sk.builtin.bool(res);
     };
 
-    _isclose.co_varnames = ["a", "b", "rel_tol", "abs_tol"];
-    _isclose.co_argcount = 2;
-    _isclose.co_kwonlyargcount = 2;
-    _isclose.$kwdefs = [1e-9, 0.0];
+    isclose.co_varnames = ["a", "b", "rel_tol", "abs_tol"];
+    isclose.co_argcount = 2;
+    isclose.co_kwonlyargcount = 2;
+    isclose.$kwdefs = [1e-9, 0.0];
 
-    mod.isclose = new Sk.builtin.func(_isclose);
+    mod.isclose = new Sk.builtin.func(isclose);
 
     mod.isfinite = new Sk.builtin.func(function isfinite(x) {
         Sk.builtin.pyCheckArgsLen("isfinite", arguments.length, 1, 1);
@@ -683,7 +683,7 @@ var $builtinmodule = function (name) {
         return new Sk.builtin.float_(Math.log(L));
     });
 
-    mod.atanh = new Sk.builtin.func(function (x) {
+    mod.atanh = new Sk.builtin.func(function atanh(x) {
         Sk.builtin.pyCheckArgsLen("atanh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
@@ -708,7 +708,7 @@ var $builtinmodule = function (name) {
         return new Sk.builtin.float_(result);
     });
 
-    mod.cosh = new Sk.builtin.func(function (x) {
+    mod.cosh = new Sk.builtin.func(function cosh(x) {
         Sk.builtin.pyCheckArgsLen("cosh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
@@ -762,15 +762,15 @@ var $builtinmodule = function (name) {
         throw new Sk.builtin.NotImplementedError("math.erf() is not yet implemented in Skulpt");
     });
 
-    mod.erfc = new Sk.builtin.func(function (x) {
+    mod.erfc = new Sk.builtin.func(function erfc(x) {
         throw new Sk.builtin.NotImplementedError("math.erfc() is not yet implemented in Skulpt");
     });
 
-    mod.gamma = new Sk.builtin.func(function (x) {
+    mod.gamma = new Sk.builtin.func(function gamma(x) {
         throw new Sk.builtin.NotImplementedError("math.gamma() is not yet implemented in Skulpt");
     });
 
-    mod.lgamma = new Sk.builtin.func(function (x) {
+    mod.lgamma = new Sk.builtin.func(function lgamma(x) {
         throw new Sk.builtin.NotImplementedError("math.lgamma() is not yet implemented in Skulpt");
     });
 

--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -23,7 +23,7 @@ var $builtinmodule = function (name) {
         throw new Sk.builtin.NotImplementedError("math.comb() is not yet implemented in Skulpt");
     });
 
-    function get_sign (n) {
+    function get_sign(n) {
         //deals with signed zeros
         // returns -1 or +1 for the sign
         if (n) {
@@ -47,7 +47,7 @@ var $builtinmodule = function (name) {
         const sign_y = get_sign(_y);
         const sign = sign_x * sign_y;
 
-        return new Sk.builtin.float_(_x*sign);
+        return new Sk.builtin.float_(_x * sign);
     });
 
     mod.fabs = new Sk.builtin.func(function fabs(x) {
@@ -93,7 +93,7 @@ var $builtinmodule = function (name) {
             }
 
             r = bigup(r);
-            for (var i = MAX_SAFE_INTEGER_FACTORIAL+1; i <= x; i++) {
+            for (var i = MAX_SAFE_INTEGER_FACTORIAL + 1; i <= x; i++) {
                 var i_bigup = bigup(i);
                 r = r.multiply(i_bigup);
             }
@@ -223,7 +223,7 @@ var $builtinmodule = function (name) {
             return _biggcd(b, a.remainder(b));
         }
 
-        if ((a instanceof Sk.builtin.lng) || (b instanceof Sk.builtin.lng)) {
+        if (a instanceof Sk.builtin.lng || b instanceof Sk.builtin.lng) {
             let _a = Sk.builtin.lng(a).biginteger;
             let _b = Sk.builtin.lng(b).biginteger;
             let res = _biggcd(_a, _b);
@@ -238,7 +238,6 @@ var $builtinmodule = function (name) {
             return new Sk.builtin.int_(res);
         }
     });
-
 
     _isclose = function isclose(a, b, rel_tol, abs_tol) {
         Sk.builtin.pyCheckArgsLen("isclose", arguments.length, 2, 4, true);
@@ -271,7 +270,7 @@ var $builtinmodule = function (name) {
     _isclose.co_varnames = ["a", "b", "rel_tol", "abs_tol"];
     _isclose.co_argcount = 2;
     _isclose.co_kwonlyargcount = 2;
-    _isclose.$kwdefs = [1e-09, 0.0];
+    _isclose.$kwdefs = [1e-9, 0.0];
 
     mod.isclose = new Sk.builtin.func(_isclose);
 
@@ -443,7 +442,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.expm1 = new Sk.builtin.func(function expm1(x) {
-        // as per python docs this implements an algorithm for evaluating exp(x) - 1 
+        // as per python docs this implements an algorithm for evaluating exp(x) - 1
         // for smaller values of x
         Sk.builtin.pyCheckArgsLen("expm1", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
@@ -764,16 +763,16 @@ var $builtinmodule = function (name) {
     });
 
     mod.erfc = new Sk.builtin.func(function (x) {
-        throw new Sk.builtin.NotImplementedError("math.erfc() is not yet implemented in Skulpt")
+        throw new Sk.builtin.NotImplementedError("math.erfc() is not yet implemented in Skulpt");
     });
 
     mod.gamma = new Sk.builtin.func(function (x) {
-        throw new Sk.builtin.NotImplementedError("math.gamma() is not yet implemented in Skulpt")
+        throw new Sk.builtin.NotImplementedError("math.gamma() is not yet implemented in Skulpt");
     });
 
     mod.lgamma = new Sk.builtin.func(function (x) {
-        throw new Sk.builtin.NotImplementedError("math.lgamma() is not yet implemented in Skulpt")
+        throw new Sk.builtin.NotImplementedError("math.lgamma() is not yet implemented in Skulpt");
     });
 
     return mod;
-}
+};

--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -9,33 +9,32 @@ var $builtinmodule = function (name) {
     mod.inf = new Sk.builtin.float_(Infinity);
 
     // Number-theoretic and representation functions
-    mod.ceil = new Sk.builtin.func(function (x) {
+    mod.ceil = new Sk.builtin.func(function ceil(x) {
         Sk.builtin.pyCheckArgsLen("ceil", arguments.length, 1, 1);
-        Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
-
+        Sk.builtin.pyCheckType("", "real number", Sk.builtin.checkNumber(x));
+        const _x = Sk.builtin.asnum$(x);
         if (Sk.__future__.ceil_floor_int) {
-            return new Sk.builtin.int_(Math.ceil(Sk.builtin.asnum$(x)));
-        };
-
-        return new Sk.builtin.float_(Math.ceil(Sk.builtin.asnum$(x)));
+            return new Sk.builtin.int_(Math.ceil(_x));
+        }
+        return new Sk.builtin.float_(Math.ceil(_x));
     });
 
     mod.comb = new Sk.builtin.func(function (x, y) {
-        throw new Sk.builtin.NotImplementedError("math.comb() is not yet implemented in Skulpt")
+        throw new Sk.builtin.NotImplementedError("math.comb() is not yet implemented in Skulpt");
     });
 
-    var get_sign = function (n) {
+    function get_sign (n) {
         //deals with signed zeros
         // returns -1 or +1 for the sign
         if (n) {
             n = n < 0 ? -1 : 1;
         } else {
             n = 1 / n < 0 ? -1 : 1;
-        };
-        return n
-    };
+        }
+        return n;
+    }
 
-    mod.copysign = new Sk.builtin.func(function (x, y) {
+    mod.copysign = new Sk.builtin.func(function copysign(x, y) {
         // returns abs of x with sign y
         // does sign x * sign y * x which is equivalent
         Sk.builtin.pyCheckArgsLen("copysign", arguments.length, 2, 2);
@@ -46,24 +45,22 @@ var $builtinmodule = function (name) {
         const _x = Sk.builtin.asnum$(x);
         const sign_x = get_sign(_x);
         const sign_y = get_sign(_y);
-        const sign = Sk.builtin.int_(sign_x * sign_y);
+        const sign = sign_x * sign_y;
 
-        return new Sk.builtin.float_(Sk.abstr.numberBinOp(x, sign, "Mult"));
-
+        return new Sk.builtin.float_(_x*sign);
     });
 
-    mod.fabs = new Sk.builtin.func(function (x) {
+    mod.fabs = new Sk.builtin.func(function fabs(x) {
         Sk.builtin.pyCheckArgsLen("fabs", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
-
-        let _x = Sk.builtin.asnum$(Sk.builtin.float_(x)); //should raise OverflowError for large ints to floats
-        _x = Math.abs(_x)
+        let _x = Sk.builtin.asnum$(new Sk.builtin.float_(x)); //should raise OverflowError for large ints to floats
+        _x = Math.abs(_x);
 
         return new Sk.builtin.float_(_x);
     });
 
-    var MAX_SAFE_INTEGER_FACTORIAL = 18; // 19! > Number.MAX_SAFE_INTEGER
-    mod.factorial = new Sk.builtin.func(function (x) {
+    const MAX_SAFE_INTEGER_FACTORIAL = 18; // 19! > Number.MAX_SAFE_INTEGER
+    mod.factorial = new Sk.builtin.func(function factorial(x) {
         Sk.builtin.pyCheckArgsLen("factorial", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
@@ -77,22 +74,22 @@ var $builtinmodule = function (name) {
             throw new Sk.builtin.ValueError("factorial() not defined for negative numbers");
         }
 
-        var r = 1;
-        for (var i = 2; i <= x && i <= MAX_SAFE_INTEGER_FACTORIAL; i++) {
+        let r = 1;
+        for (let i = 2; i <= x && i <= MAX_SAFE_INTEGER_FACTORIAL; i++) {
             r *= i;
         }
-        if(x<=MAX_SAFE_INTEGER_FACTORIAL){
+        if (x <= MAX_SAFE_INTEGER_FACTORIAL) {
             return new Sk.builtin.int_(r);
-        }else{
+        } else {
             // for big numbers (19 and larger) we first calculate 18! above
             // and then use bigintegers to continue the process.
 
             // This is inefficient as hell, but it produces correct answers.
 
             // promotes an integer to a biginteger
-            function bigup(number){
-              var n = Sk.builtin.asnum$nofloat(number);
-              return new Sk.builtin.biginteger(number);
+            function bigup(number) {
+                var n = Sk.builtin.asnum$nofloat(number);
+                return new Sk.builtin.biginteger(number);
             }
 
             r = bigup(r);
@@ -104,7 +101,7 @@ var $builtinmodule = function (name) {
         }
     });
 
-    mod.floor = new Sk.builtin.func(function (x) {
+    mod.floor = new Sk.builtin.func(function floor(x) {
         Sk.builtin.pyCheckArgsLen("floor", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
@@ -115,27 +112,27 @@ var $builtinmodule = function (name) {
         return new Sk.builtin.float_(Math.floor(Sk.builtin.asnum$(x)));
     });
 
-    mod.fmod = new Sk.builtin.func(function (x, y) {
+    mod.fmod = new Sk.builtin.func(function fmod(x, y) {
         Sk.builtin.pyCheckArgsLen("fmod", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         Sk.builtin.pyCheckType("y", "number", Sk.builtin.checkNumber(y));
 
-        const _x = Sk.builtin.asnum$(Sk.builtin.float_(x));
-        const _y = Sk.builtin.asnum$(Sk.builtin.float_(y)); //should raise OverFlow for large ints to floats
+        const _x = Sk.builtin.asnum$(new Sk.builtin.float_(x));
+        const _y = Sk.builtin.asnum$(new Sk.builtin.float_(y)); //should raise OverFlow for large ints to floats
 
         if ((_y == Infinity || _y == -Infinity) && isFinite(_x)) {
-            return new Sk.builtin.float_(_x)
-        };
-        const r = _x % _y
+            return new Sk.builtin.float_(_x);
+        }
+        const r = _x % _y;
         if (isNaN(r)) {
             if (!isNaN(_x) && !isNaN(_y)) {
                 throw new Sk.builtin.ValueError("math domain error");
-            };
-        };
-        return Sk.builtin.float_(r);
+            }
+        }
+        return new Sk.builtin.float_(r);
     });
 
-    mod.frexp = new Sk.builtin.func(function (x) {
+    mod.frexp = new Sk.builtin.func(function frexp(x) {
         //  algorithm taken from https://locutus.io/c/math/frexp/
         Sk.builtin.pyCheckArgsLen("frexp", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
@@ -149,25 +146,25 @@ var $builtinmodule = function (name) {
             // These while loops compensate for rounding errors that sometimes occur because of ECMAScript's Math.log2's undefined precision
             // and also works around the issue of Math.pow(2, -exp) === Infinity when exp <= -1024
             while (m < 0.5) {
-                m *= 2
-                exp--
-            };
+                m *= 2;
+                exp--;
+            }
             while (m >= 1) {
-                m *= 0.5
-                exp++
-            };
+                m *= 0.5;
+                exp++;
+            }
             if (arg < 0) {
-                m = -m
-            };
+                m = -m;
+            }
             res[0] = m;
             res[1] = exp;
-        };
+        }
         res[0] = new Sk.builtin.float_(res[0]);
         res[1] = new Sk.builtin.int_(res[1]);
-        return new Sk.builtin.tuple(res)
+        return new Sk.builtin.tuple(res);
     });
 
-    mod.fsum = new Sk.builtin.func(function (iter) {
+    mod.fsum = new Sk.builtin.func(function fsum(iter) {
         // algorithm from https://code.activestate.com/recipes/393090/
         // as well as https://github.com/brython-dev/brython/blob/master/www/src/libs/math.js
         Sk.builtin.pyCheckArgsLen("fsum", arguments.length, 1, 1);
@@ -181,9 +178,9 @@ var $builtinmodule = function (name) {
         for (let x = iter.tp$iternext(); x !== undefined; x = iter.tp$iternext()) {
             Sk.builtin.pyCheckType("", "real number", Sk.builtin.checkNumber(x));
             i = 0;
-            x = Sk.builtin.asnum$(Sk.builtin.float_(x));
+            x = Sk.builtin.asnum$(new Sk.builtin.float_(x));
             for (let j = 0, len = partials.length; j < len; j++) {
-                let y = partials[j]
+                let y = partials[j];
                 if (Math.abs(x) < Math.abs(y)) {
                     let temp = x;
                     x = y;
@@ -197,16 +194,16 @@ var $builtinmodule = function (name) {
                 }
                 x = hi;
             }
-            partials = partials.slice(0, i).concat([x])
+            partials = partials.slice(0, i).concat([x]);
         }
         const sum = partials.reduce(function (a, b) {
             return a + b;
         }, 0);
 
-        return new Sk.builtin.float_(sum)
+        return new Sk.builtin.float_(sum);
     });
 
-    mod.gcd = new Sk.builtin.func(function (a, b) {
+    mod.gcd = new Sk.builtin.func(function gcd(a, b) {
         Sk.builtin.pyCheckArgsLen("gcd", arguments.length, 2, 2);
         // non ints not allowed in python 3.7.x
         Sk.builtin.pyCheckType("a", "integer", Sk.builtin.checkInt(a));
@@ -215,7 +212,7 @@ var $builtinmodule = function (name) {
         function _gcd(a, b) {
             if (b == 0) {
                 return a;
-            };
+            }
             return _gcd(b, a % b);
         }
 
@@ -238,13 +235,12 @@ var $builtinmodule = function (name) {
             let _b = Math.abs(Sk.builtin.asnum$(b));
             let res = _gcd(_a, _b);
             res = res < 0 ? -res : res; // python only returns positive gcds
-
             return new Sk.builtin.int_(res);
         }
     });
 
 
-    _isclose = function (a, b, rel_tol, abs_tol) {
+    _isclose = function isclose(a, b, rel_tol, abs_tol) {
         Sk.builtin.pyCheckArgsLen("isclose", arguments.length, 2, 4, true);
         Sk.builtin.pyCheckType("a", "number", Sk.builtin.checkNumber(a));
         Sk.builtin.pyCheckType("b", "number", Sk.builtin.checkNumber(b));
@@ -258,23 +254,20 @@ var $builtinmodule = function (name) {
 
         if (_rel_tol < 0.0 || _abs_tol < 0.0) {
             throw new Sk.builtin.ValueError("tolerances must be non-negative");
-        };
+        }
         if (_a == _b) {
             return Sk.builtin.bool.true$;
-        };
+        }
 
         if (_a == Infinity || _a == -Infinity || _b == Infinity || _b == -Infinity) {
             // same sign infinities were caught in previous test
             return Sk.builtin.bool.false$;
-        };
+        }
         const diff = Math.abs(_b - _a);
-        const res = (((diff <= Math.abs(_rel_tol * _b)) ||
-                (diff <= Math.abs(_rel_tol * _a))) ||
-            (diff <= _abs_tol));
-        return new Sk.builtin.bool(res)
+        const res = diff <= Math.abs(_rel_tol * _b) || diff <= Math.abs(_rel_tol * _a) || diff <= _abs_tol;
+        return new Sk.builtin.bool(res);
     };
 
-    _isclose.co_name = new Sk.builtins.str("isclose");
     _isclose.co_varnames = ["a", "b", "rel_tol", "abs_tol"];
     _isclose.co_argcount = 2;
     _isclose.co_kwonlyargcount = 2;
@@ -282,36 +275,36 @@ var $builtinmodule = function (name) {
 
     mod.isclose = new Sk.builtin.func(_isclose);
 
-    mod.isfinite = new Sk.builtin.func(function (x) {
+    mod.isfinite = new Sk.builtin.func(function isfinite(x) {
         Sk.builtin.pyCheckArgsLen("isfinite", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
-        let _x = Sk.builtin.asnum$(x);
+        const _x = Sk.builtin.asnum$(x);
         if (Sk.builtin.checkInt(x)) {
             return Sk.builtin.bool.true$; //deals with big integers returning False
         } else if (isFinite(_x)) {
             return Sk.builtin.bool.true$;
         } else {
-            return Sk.builtin.bool.false$
-        };
+            return Sk.builtin.bool.false$;
+        }
     });
 
-    mod.isinf = new Sk.builtin.func(function (x) {
+    mod.isinf = new Sk.builtin.func(function isinf(x) {
         /* Return True if x is infinite or nan, and False otherwise. */
         Sk.builtin.pyCheckArgsLen("isinf", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
-        let _x = Sk.builtin.asnum$(x);
+        const _x = Sk.builtin.asnum$(x);
         if (Sk.builtin.checkInt(x)) {
             return Sk.builtin.bool.false$; //deals with big integers returning True
         } else if (isFinite(_x) || isNaN(_x)) {
             return Sk.builtin.bool.false$;
         } else {
             return Sk.builtin.bool.true$;
-        };
+        }
     });
 
-    mod.isnan = new Sk.builtin.func(function (x) {
+    mod.isnan = new Sk.builtin.func(function isnan(x) {
         // Return True if x is a NaN (not a number), and False otherwise.
         Sk.builtin.pyCheckArgsLen("isnan", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "float", Sk.builtin.checkFloat(x));
@@ -324,66 +317,67 @@ var $builtinmodule = function (name) {
         }
     });
 
-    mod.isqrt = new Sk.builtin.func(function (x) {
-        throw new Sk.builtin.NotImplementedError("math.isqrt() is not yet implemented in Skulpt")
+    mod.isqrt = new Sk.builtin.func(function issqrt(x) {
+        throw new Sk.builtin.NotImplementedError("math.isqrt() is not yet implemented in Skulpt");
     });
 
-    mod.ldexp = new Sk.builtin.func(function (x, i) {
+    mod.ldexp = new Sk.builtin.func(function ldexp(x, i) {
         // return x * (2**i)
         Sk.builtin.pyCheckArgsLen("ldexp", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         Sk.builtin.pyCheckType("i", "integer", Sk.builtin.checkInt(i));
 
-        const _x = Sk.builtin.asnum$(Sk.builtin.float_(x));
+        const _x = Sk.builtin.asnum$(new Sk.builtin.float_(x));
         const _i = Sk.builtin.asnum$(i);
 
         if (_x == Infinity || _x == -Infinity || _x == 0 || isNaN(_x)) {
             return x;
-        };
+        }
         const res = _x * Math.pow(2, _i);
         if (!isFinite(res)) {
-            throw new Sk.builtin.OverflowError("math range error")
-        };
+            throw new Sk.builtin.OverflowError("math range error");
+        }
         return new Sk.builtin.float_(res);
     });
 
-    mod.modf = new Sk.builtin.func(function (x) {
+    mod.modf = new Sk.builtin.func(function modf(x) {
         Sk.builtin.pyCheckArgsLen("modf", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
-        let _x = Sk.builtin.asnum$(x)
-        if (!isFinite(_x)) { //special cases
+        let _x = Sk.builtin.asnum$(x);
+        if (!isFinite(_x)) {
+            //special cases
             if (_x == Infinity) {
-                return new Sk.builtin.tuple([Sk.builtin.float_(0.0), Sk.builtin.float_(_x)]);
+                return new Sk.builtin.tuple([new Sk.builtin.float_(0.0), new Sk.builtin.float_(_x)]);
             } else if (_x == -Infinity) {
-                return new Sk.builtin.tuple([Sk.builtin.float_(-0.0), Sk.builtin.float_(_x)]);
+                return new Sk.builtin.tuple([new Sk.builtin.float_(-0.0), new Sk.builtin.float_(_x)]);
             } else if (isNaN(_x)) {
-                return new Sk.builtin.tuple([Sk.builtin.float_(_x), Sk.builtin.float_(_x)]);
-            };
-        };
+                return new Sk.builtin.tuple([new Sk.builtin.float_(_x), new Sk.builtin.float_(_x)]);
+            }
+        }
         const sign = get_sign(_x);
         _x = Math.abs(_x);
         const i = sign * Math.floor(_x); //integer part
         const d = sign * (_x - Math.floor(_x)); //decimal part
 
-        return new Sk.builtin.tuple([Sk.builtin.float_(d), Sk.builtin.float_(i)]);
+        return new Sk.builtin.tuple([new Sk.builtin.float_(d), new Sk.builtin.float_(i)]);
     });
 
-    mod.perm = new Sk.builtin.func(function (x) {
-        throw new Sk.builtin.NotImplementedError("math.perm() is not yet implemented in Skulpt")
+    mod.perm = new Sk.builtin.func(function perm(x) {
+        throw new Sk.builtin.NotImplementedError("math.perm() is not yet implemented in Skulpt");
     });
 
-    mod.prod = new Sk.builtin.func(function (x) {
-        throw new Sk.builtin.NotImplementedError("math.prod() is not yet implemented in Skulpt")
+    mod.prod = new Sk.builtin.func(function prod(x) {
+        throw new Sk.builtin.NotImplementedError("math.prod() is not yet implemented in Skulpt");
     });
 
-    mod.remainder = new Sk.builtin.func(function (x, y) {
+    mod.remainder = new Sk.builtin.func(function remainder(x, y) {
         // as per cpython algorithm see cpython for details
         Sk.builtin.pyCheckArgsLen("reamainder", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         Sk.builtin.pyCheckType("y", "number", Sk.builtin.checkNumber(y));
-        _x = Sk.builtin.asnum$(Sk.builtin.float_(x));
-        _y = Sk.builtin.asnum$(Sk.builtin.float_(y));
+        _x = Sk.builtin.asnum$(new Sk.builtin.float_(x));
+        _y = Sk.builtin.asnum$(new Sk.builtin.float_(y));
 
         // deal with most common cases first
         if (isFinite(_x) && isFinite(_y)) {
@@ -405,7 +399,7 @@ var $builtinmodule = function (name) {
                 }
                 r = m - 2.0 * ((0.5 * (absx - m)) % absy);
             }
-            return Sk.builtin.float_(get_sign(_x) * r);
+            return new Sk.builtin.float_(get_sign(_x) * r);
         }
         /* Special values. */
         if (isNaN(_x)) {
@@ -420,24 +414,23 @@ var $builtinmodule = function (name) {
         if (!(_y == Infinity || _y == -Infinity)) {
             throw new Sk.builtin.AssertionError();
         }
-        return Sk.builtin.float_(x);
+        return new Sk.builtin.float_(_x);
     });
 
-    mod.trunc = new Sk.builtin.func(function (x) {
+    mod.trunc = new Sk.builtin.func(function trunc(x) {
         Sk.builtin.pyCheckArgsLen("trunc", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         if (Sk.builtin.checkInt(x)) {
-            return x //deals with large ints being passed 
-        };
+            return x; //deals with large ints being passed
+        }
         return new Sk.builtin.int_(Sk.builtin.asnum$(x) | 0);
     });
 
-
     // Power and logarithmic functions
-    mod.exp = new Sk.builtin.func(function (x) {
+    mod.exp = new Sk.builtin.func(function exp(x) {
         Sk.builtin.pyCheckArgsLen("exp", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
-        const _x = Sk.builtin.asnum$(Sk.builtin.float_(x));
+        const _x = Sk.builtin.asnum$(new Sk.builtin.float_(x));
         if (_x == Infinity || _x == -Infinity || isNaN(_x)) {
             return new Sk.builtin.float_(Math.exp(_x));
         }
@@ -449,52 +442,52 @@ var $builtinmodule = function (name) {
         return new Sk.builtin.float_(res);
     });
 
-    mod.expm1 = new Sk.builtin.func(function (x) {
+    mod.expm1 = new Sk.builtin.func(function expm1(x) {
         // as per python docs this implements an algorithm for evaluating exp(x) - 1 
         // for smaller values of x
         Sk.builtin.pyCheckArgsLen("expm1", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         const _x = Sk.builtin.asnum$(x);
 
-        if (Math.abs(_x) < .7) {
-            const _u = Math.exp(_x)
+        if (Math.abs(_x) < 0.7) {
+            const _u = Math.exp(_x);
             if (_u == 1.0) {
-                return Sk.builtin.float_(_x)
+                return new Sk.builtin.float_(_x);
             } else {
-                const res = (_u - 1.0) * _x / Math.log(_u);
-                return new Sk.builtin.float_(res)
-            };
+                const res = ((_u - 1.0) * _x) / Math.log(_u);
+                return new Sk.builtin.float_(res);
+            }
         } else {
             const res = Math.exp(_x) - 1.0;
-            return new Sk.builtin.float_(res)
-        };
+            return new Sk.builtin.float_(res);
+        }
     });
 
-    mod.log = new Sk.builtin.func(function (x, base) {
+    mod.log = new Sk.builtin.func(function log(x, base) {
         Sk.builtin.pyCheckArgsLen("log", arguments.length, 1, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
-
-        let _x = Sk.builtin.asnum$(x)
+        let _x = Sk.builtin.asnum$(x);
         let _base, res;
         if (_x <= 0) {
-            throw new Sk.builtin.ValueError("math domain error")
-        };
+            throw new Sk.builtin.ValueError("math domain error");
+        }
         if (base === undefined) {
             _base = Math.E;
         } else {
             Sk.builtin.pyCheckType("base", "number", Sk.builtin.checkNumber(base));
             _base = Sk.builtin.asnum$(base);
-        };
+        }
 
         if (_base <= 0) {
-            throw new Sk.builtin.ValueError("math domain error")
+            throw new Sk.builtin.ValueError("math domain error");
         } else if (Sk.builtin.checkFloat(x) || _x < Number.MAX_SAFE_INTEGER) {
             res = Math.log(_x) / Math.log(_base);
-        } else { //int that is larger than max safe integer
+        } else {
+            //int that is larger than max safe integer
             // use idea x = 123456789 = .123456789 * 10**9
             // log(x)  = 9 * log(10) + log(.123456789)
-            _x = Sk.builtin.str(x).$jsstr();
+            _x = new Sk.builtin.str(x).$jsstr();
             const digits = _x.length;
             const decimal = parseFloat("0." + _x);
             res = (digits * Math.log(10) + Math.log(decimal)) / Math.log(_base);
@@ -502,7 +495,7 @@ var $builtinmodule = function (name) {
         return new Sk.builtin.float_(res);
     });
 
-    mod.log1p = new Sk.builtin.func(function (x) {
+    mod.log1p = new Sk.builtin.func(function log1p(x) {
         // as per python docs this is an algorithm for evaluating log 1+x (base e)
         // designed to be more accurate close to 0
         Sk.builtin.pyCheckArgsLen("log1p", arguments.length, 1, 1);
@@ -511,35 +504,36 @@ var $builtinmodule = function (name) {
         const _x = Sk.builtin.asnum$(new Sk.builtin.float_(x));
 
         if (_x <= -1.0) {
-            throw new Sk.builtin.ValueError("math domain error")
-        } else if (_x == 0.) {
+            throw new Sk.builtin.ValueError("math domain error");
+        } else if (_x == 0) {
             return new Sk.builtin.float_(_x); // respects log1p(-0.0) return -0.0
-        } else if (Math.abs(_x) < Number.EPSILON / 2.) {
+        } else if (Math.abs(_x) < Number.EPSILON / 2) {
             return new Sk.builtin.float_(_x);
-        } else if (-0.5 <= _x && _x <= 1.) {
-            const _y = 1. + _x;
-            const res = Math.log(_y) - ((_y - 1.) - _x) / _y;
+        } else if (-0.5 <= _x && _x <= 1) {
+            const _y = 1 + _x;
+            const res = Math.log(_y) - (_y - 1 - _x) / _y;
             return new Sk.builtin.float_(res);
         } else {
             const res = Math.log(1 + _x);
             return new Sk.builtin.float_(res);
-        };
+        }
     });
 
-    mod.log2 = new Sk.builtin.func(function (x) {
+    mod.log2 = new Sk.builtin.func(function log2(x) {
         Sk.builtin.pyCheckArgsLen("log2", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
-        let _x = Sk.builtin.asnum$(x)
+        let _x = Sk.builtin.asnum$(x);
         let res;
         if (_x < 0) {
-            throw new Sk.builtin.ValueError("math domain error")
+            throw new Sk.builtin.ValueError("math domain error");
         } else if (Sk.builtin.checkFloat(x) || _x < Number.MAX_SAFE_INTEGER) {
             res = Math.log2(_x);
-        } else { //int that is larger than max safe integer
+        } else {
+            //int that is larger than max safe integer
             // use idea x = 123456789 = .123456789 * 10**9
             // log2(x)  = 9 * log2(10) + log2(.123456789)
-            _x = Sk.builtin.str(x).$jsstr();
+            _x = new Sk.builtin.str(x).$jsstr();
             const digits = _x.length;
             const decimal = parseFloat("0." + _x);
             res = digits * Math.log2(10) + Math.log2(decimal);
@@ -547,19 +541,20 @@ var $builtinmodule = function (name) {
         return new Sk.builtin.float_(res);
     });
 
-    mod.log10 = new Sk.builtin.func(function (x) {
+    mod.log10 = new Sk.builtin.func(function log10(x) {
         Sk.builtin.pyCheckArgsLen("log10", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         let _x = Sk.builtin.asnum$(x);
         let res;
         if (_x < 0) {
-            throw new Sk.builtin.ValueError("math domain error")
+            throw new Sk.builtin.ValueError("math domain error");
         } else if (Sk.builtin.checkFloat(x) || _x < Number.MAX_SAFE_INTEGER) {
             res = Math.log10(_x);
-        } else { //int that is larger than max safe integer
+        } else {
+            //int that is larger than max safe integer
             // use idea x = 123456789 = .123456789 * 10**9
             // log10(x)  = 9 + log10(.123456789)
-            _x = Sk.builtin.str(x).$jsstr();
+            _x = new Sk.builtin.str(x).$jsstr();
             const digits = _x.length;
             const decimal = parseFloat("0." + _x);
             res = digits + Math.log10(decimal);
@@ -567,34 +562,34 @@ var $builtinmodule = function (name) {
         return new Sk.builtin.float_(res);
     });
 
-    mod.pow = new Sk.builtin.func(function (x, y) {
+    mod.pow = new Sk.builtin.func(function pow(x, y) {
         Sk.builtin.pyCheckArgsLen("pow", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         Sk.builtin.pyCheckType("y", "number", Sk.builtin.checkNumber(y));
 
-        const _x = Sk.builtin.asnum$(Sk.builtin.float_(x));
-        const _y = Sk.builtin.asnum$(Sk.builtin.float_(y));
+        const _x = Sk.builtin.asnum$(new Sk.builtin.float_(x));
+        const _y = Sk.builtin.asnum$(new Sk.builtin.float_(y));
 
         if (_x == 0 && _y < 0) {
             throw new Sk.builtin.ValueError("math domain error");
         } else if (_x == 1) {
-            return new Sk.builtin.float_(1.0)
+            return new Sk.builtin.float_(1.0);
         } else if (Number.isFinite(_x) && Number.isFinite(_y) && _x < 0 && !Number.isInteger(_y)) {
             throw new Sk.builtin.ValueError("math domain error");
         } else if (_x == -1 && (_y == -Infinity || _y == Infinity)) {
             return new Sk.builtin.float_(1.0);
-        };
+        }
 
         const res = Math.pow(_x, _y);
         if (!Number.isFinite(_x) || !Number.isFinite(_y)) {
             return new Sk.builtin.float_(res);
         } else if (res == Infinity || res == -Infinity) {
-            throw new Sk.builtin.OverflowError("math range error")
+            throw new Sk.builtin.OverflowError("math range error");
         }
         return new Sk.builtin.float_(res);
     });
 
-    mod.sqrt = new Sk.builtin.func(function (x) {
+    mod.sqrt = new Sk.builtin.func(function sqrt(x) {
         Sk.builtin.pyCheckArgsLen("sqrt", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
@@ -603,28 +598,28 @@ var $builtinmodule = function (name) {
 
     // Trigonometric functions and Hyperbolic
 
-    mod.asin = new Sk.builtin.func(function (rad) {
+    mod.asin = new Sk.builtin.func(function asin(rad) {
         Sk.builtin.pyCheckArgsLen("asin", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.asin(Sk.builtin.asnum$(rad)));
     });
 
-    mod.acos = new Sk.builtin.func(function (rad) {
+    mod.acos = new Sk.builtin.func(function acos(rad) {
         Sk.builtin.pyCheckArgsLen("acos", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.acos(Sk.builtin.asnum$(rad)));
     });
 
-    mod.atan = new Sk.builtin.func(function (rad) {
+    mod.atan = new Sk.builtin.func(function atan(rad) {
         Sk.builtin.pyCheckArgsLen("atan", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.atan(Sk.builtin.asnum$(rad)));
     });
 
-    mod.atan2 = new Sk.builtin.func(function (y, x) {
+    mod.atan2 = new Sk.builtin.func(function atan2(y, x) {
         Sk.builtin.pyCheckArgsLen("atan2", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("y", "number", Sk.builtin.checkNumber(y));
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
@@ -639,52 +634,52 @@ var $builtinmodule = function (name) {
         return new Sk.builtin.float_(Math.sin(Sk.builtin.asnum$(rad)));
     });
 
-    mod.cos = new Sk.builtin.func(function (rad) {
+    mod.cos = new Sk.builtin.func(function cos(rad) {
         Sk.builtin.pyCheckArgsLen("cos", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.cos(Sk.builtin.asnum$(rad)));
     });
 
-    mod.tan = new Sk.builtin.func(function (rad) {
+    mod.tan = new Sk.builtin.func(function tan(rad) {
         Sk.builtin.pyCheckArgsLen("tan", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
         return new Sk.builtin.float_(Math.tan(Sk.builtin.asnum$(rad)));
     });
 
-    mod.dist = new Sk.builtin.func(function (x) {
-        throw new Sk.builtin.NotImplementedError("math.dist() is not yet implemented in Skulpt")
+    mod.dist = new Sk.builtin.func(function dist(x) {
+        throw new Sk.builtin.NotImplementedError("math.dist() is not yet implemented in Skulpt");
     });
 
-    mod.hypot = new Sk.builtin.func(function (x, y) {
+    mod.hypot = new Sk.builtin.func(function hypot(x, y) {
         Sk.builtin.pyCheckArgsLen("hypot", arguments.length, 2, 2);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
         Sk.builtin.pyCheckType("y", "number", Sk.builtin.checkNumber(y));
 
         x = Sk.builtin.asnum$(x);
         y = Sk.builtin.asnum$(y);
-        return new Sk.builtin.float_(Math.sqrt((x * x) + (y * y)));
+        return new Sk.builtin.float_(Math.sqrt(x * x + y * y));
     });
 
-    mod.asinh = new Sk.builtin.func(function (x) {
+    mod.asinh = new Sk.builtin.func(function asinh(x) {
         Sk.builtin.pyCheckArgsLen("asinh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Sk.builtin.asnum$(x);
 
-        var L = x + Math.sqrt(x * x + 1);
+        const L = x + Math.sqrt(x * x + 1);
 
         return new Sk.builtin.float_(Math.log(L));
     });
 
-    mod.acosh = new Sk.builtin.func(function (x) {
+    mod.acosh = new Sk.builtin.func(function acosh(x) {
         Sk.builtin.pyCheckArgsLen("acosh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Sk.builtin.asnum$(x);
 
-        var L = x + Math.sqrt(x * x - 1);
+        const L = x + Math.sqrt(x * x - 1);
 
         return new Sk.builtin.float_(Math.log(L));
     });
@@ -695,21 +690,21 @@ var $builtinmodule = function (name) {
 
         x = Sk.builtin.asnum$(x);
 
-        var L = (1 + x) / (1 - x);
+        const L = (1 + x) / (1 - x);
 
         return new Sk.builtin.float_(Math.log(L) / 2);
     });
 
-    mod.sinh = new Sk.builtin.func(function (x) {
+    mod.sinh = new Sk.builtin.func(function sinh(x) {
         Sk.builtin.pyCheckArgsLen("sinh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         x = Sk.builtin.asnum$(x);
 
-        var e = Math.E;
-        var p = Math.pow(e, x);
-        var n = 1 / p;
-        var result = (p - n) / 2;
+        const e = Math.E;
+        const p = Math.pow(e, x);
+        const n = 1 / p;
+        const result = (p - n) / 2;
 
         return new Sk.builtin.float_(result);
     });
@@ -720,52 +715,52 @@ var $builtinmodule = function (name) {
 
         x = Sk.builtin.asnum$(x);
 
-        var e = Math.E;
-        var p = Math.pow(e, x);
-        var n = 1 / p;
-        var result = (p + n) / 2;
+        const e = Math.E;
+        const p = Math.pow(e, x);
+        const n = 1 / p;
+        const result = (p + n) / 2;
 
         return new Sk.builtin.float_(result);
     });
 
-    mod.tanh = new Sk.builtin.func(function (x) {
+    mod.tanh = new Sk.builtin.func(function tanh(x) {
         Sk.builtin.pyCheckArgsLen("tanh", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
 
         const _x = Sk.builtin.asnum$(x);
 
         if (_x === 0) {
-            return Sk.builtin.float_(x);
-        };
+            return new Sk.builtin.float_(_x);
+        }
 
-        var e = Math.E;
-        var p = Math.pow(e, _x);
-        var n = 1 / p;
-        var result = ((p - n) / 2) / ((p + n) / 2);
+        const e = Math.E;
+        const p = Math.pow(e, _x);
+        const n = 1 / p;
+        const result = (p - n) / 2 / ((p + n) / 2);
 
         return new Sk.builtin.float_(result);
     });
 
     // Angular Conversion
-    mod.radians = new Sk.builtin.func(function (deg) {
+    mod.radians = new Sk.builtin.func(function radians(deg) {
         Sk.builtin.pyCheckArgsLen("radians", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("deg", "number", Sk.builtin.checkNumber(deg));
 
-        var ret = Math.PI / 180.0 * Sk.builtin.asnum$(deg);
+        const ret = (Math.PI / 180.0) * Sk.builtin.asnum$(deg);
         return new Sk.builtin.float_(ret);
     });
 
-    mod.degrees = new Sk.builtin.func(function (rad) {
+    mod.degrees = new Sk.builtin.func(function degrees(rad) {
         Sk.builtin.pyCheckArgsLen("degrees", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("rad", "number", Sk.builtin.checkNumber(rad));
 
-        var ret = 180.0 / Math.PI * Sk.builtin.asnum$(rad);
+        const ret = (180.0 / Math.PI) * Sk.builtin.asnum$(rad);
         return new Sk.builtin.float_(ret);
     });
 
     // Special Functions
-    mod.erf = new Sk.builtin.func(function (x) {
-        throw new Sk.builtin.NotImplementedError("math.erf() is not yet implemented in Skulpt")
+    mod.erf = new Sk.builtin.func(function erf(x) {
+        throw new Sk.builtin.NotImplementedError("math.erf() is not yet implemented in Skulpt");
     });
 
     mod.erfc = new Sk.builtin.func(function (x) {

--- a/support/build/wrapmodules.js
+++ b/support/build/wrapmodules.js
@@ -39,7 +39,14 @@ function processDirectories(dirs, recursive, exts, ret, minifyjs, excludes) {
                     if (exts.includes(ext)) {
                         let contents = fs.readFileSync(fullname, 'utf8');
                         if (minifyjs && (ext == ".js")) {
-                            let result = minify(contents);
+                            let result = minify(contents, {
+                                mangle: {
+                                    keepFnName: true,
+                                },
+                                deadcode: {
+                                    keepFnName: true,
+                                },
+                            });
                             contents = result.code;
                         }
                         ret.files[fullname] = contents;

--- a/test/unit3/test_math.py
+++ b/test/unit3/test_math.py
@@ -1653,6 +1653,10 @@ class IsCloseTests(unittest.TestCase):
     def test_skulptBugs(self):
         # 1113
         self.assertAlmostEqual(math.log(9007199254740992 // 2), 36.04365338911715, 15)
+        # check func names
+        self.assertIn("ceil", repr(math.ceil))
+        self.assertIn("isclose", repr(math.isclose))
+        self.assertIn("fabs", repr(math.fabs))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
4 types of changes to math.js
use of `new` keyword
make sure all js funcs have names to avoid the dreaded `<native JS>`
put it through prettier
a couple of var/cons/let adjustments

No change to logic in this pr. 

_edit: 
I've added a change to Babel minifier for stdlib to preserve func names so that things like `print(math.ceil)` work as expected for the user._ 