### PR TITLE
use of callsimArray

### DIFF
--- a/src/lib/operator.js
+++ b/src/lib/operator.js
@@ -54,7 +54,7 @@ var $builtinmodule = function (name) {
     });
 
     mod.abs = new Sk.builtin.func(function (obj) {
-        return Sk.misceval.callsimArray(Sk.builtin.abs, [obj]);
+        return Sk.builtin.abs(obj);
     });
     mod.__abs__ = mod.abs;
 

--- a/src/lib/tokenize.js
+++ b/src/lib/tokenize.js
@@ -24,7 +24,7 @@ var $builtinmodule = function(name) {
         }
 
         function jsReadline() {
-            const line = Sk.misceval.callsim(readline);
+            const line = Sk.misceval.callsimArray(readline);
             return Sk.ffi.remapToJs(line);
         }
 

--- a/src/print.js
+++ b/src/print.js
@@ -68,12 +68,12 @@ var print_f = function function_print(kwa) {
 
     s += kw_list.end;
 
-    if(kw_list.file !== null) {
+    if (kw_list.file !== null) {
         // currently not tested, though it seems that we need to see how we should access the write function in a correct manner
         Sk.misceval.callsimArray(kw_list.file.write, [kw_list.file, new Sk.builtin.str(s)]); // callsim to write function
     } else {
-        return Sk.misceval.chain(Sk.importModule("sys", false, true), function(sys) {
-            return Sk.misceval.apply(sys["$d"]["stdout"]["write"], undefined, undefined, undefined, [sys["$d"]["stdout"], new Sk.builtin.str(s)]);
+        return Sk.misceval.chain(Sk.importModule("sys", false, true), function (sys) {
+            return Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdout"]["write"], [sys["$d"]["stdout"], new Sk.builtin.str(s)]);
         });
     }
     // ToDo:


### PR DESCRIPTION
3 changes in places using `callsim(OrSuspend)Array` where this is our internally preferred callsignature
I also remove this in one place where it makes more sense to directly call the JS function. 