### PR TITLE
handling of bool in abstr.objectPositive/Negative

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -737,35 +737,18 @@ Sk.abstr.objectAdd = function (a, b) {
 
 // in Python 2.6, this behaviour seems to be defined for numbers and bools (converts bool to int)
 Sk.abstr.objectNegative = function (obj) {
-    var objtypename;
-    var obj_asnum = Sk.builtin.asnum$(obj); // this will also convert bool type to int
-
-    if (obj instanceof Sk.builtin.bool) {
-        obj = new Sk.builtin.int_(obj_asnum);
-    }
-
     if (obj.nb$negative) {
         return obj.nb$negative();
     }
-
-    objtypename = Sk.abstr.typeName(obj);
-    throw new Sk.builtin.TypeError("bad operand type for unary -: '" + objtypename + "'");
+    throw new Sk.builtin.TypeError("bad operand type for unary -: '" + Sk.abstr.typeName(obj) + "'");
 };
 
 // in Python 2.6, this behaviour seems to be defined for numbers and bools (converts bool to int)
 Sk.abstr.objectPositive = function (obj) {
-    var objtypename = Sk.abstr.typeName(obj);
-    var obj_asnum = Sk.builtin.asnum$(obj); // this will also convert bool type to int
-
-    if (obj instanceof Sk.builtin.bool) {
-        obj = new Sk.builtin.int_(obj_asnum);
-    }
-
-    if (obj.nb$negative) {
+    if (obj.nb$positive) {
         return obj.nb$positive();
     }
-
-    throw new Sk.builtin.TypeError("bad operand type for unary +: '" + objtypename + "'");
+    throw new Sk.builtin.TypeError("bad operand type for unary +: '" + Sk.abstr.typeName(obj) + "'");
 };
 
 Sk.abstr.objectDelItem = function (o, key) {

--- a/src/bool.js
+++ b/src/bool.js
@@ -8,8 +8,8 @@
  * Where possible, do not create a new instance but use the constants 
  * Sk.builtin.bool.true$ or Sk.builtin.bool.false$. These are defined in src/constant.js
  *
- * @extends {Sk.builtin.object}
- * 
+ * @extends {Sk.builtin.int_}
+ *
  * @param  {(Object|number|boolean)} x Value to evaluate as true or false
  * @return {Sk.builtin.bool} Sk.builtin.bool.true$ if x is true, Sk.builtin.bool.false$ otherwise
  */


### PR DESCRIPTION
in `objectPositive/Negative` we handle `bools` as if they are a special case but since they are instances of `int` they are not special and so can be treated as per all other number types with an `nb$positive/negative` slot. 