### PR TITLE
Pr/js inheritance for py

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -205,6 +205,8 @@ Sk.configure = function (options) {
     Sk.switch_version("copy$", Sk.__future__.python3);
 
     Sk.builtin.lng.tp$name = Sk.__future__.no_long_type ? "int" : "long";
+    Sk.builtin.lng.prototype.tp$name = Sk.__future__.no_long_type ? "int" : "long";
+    Sk.builtin.lng.prototype.ob$type = Sk.__future__.no_long_type ? Sk.builtin.int_ : Sk.builtin.lng;
 
     Sk.builtin.str.$next = Sk.__future__.python3 ? new Sk.builtin.str("__next__") : new Sk.builtin.str("next");
 

--- a/src/import.js
+++ b/src/import.js
@@ -60,8 +60,6 @@ Sk.importSearchPathForName = function (name, ext, searchPath) {
  * @return {undefined}
  */
 Sk.doOneTimeInitialization = function (canSuspend) {
-    var proto, name, i, x, type, typesWithFunctionsToWrap, builtin_type, j;
-
     // can't fill these out when making the type because tuple/dict aren't
     // defined yet.
     Sk.builtin.type.basesStr_ = new Sk.builtin.str("__bases__");
@@ -70,11 +68,10 @@ Sk.doOneTimeInitialization = function (canSuspend) {
     // Register a Python class with an internal dictionary, which allows it to
     // be subclassed
     var setUpClass = function (child) {
-        var parent = child.prototype.tp$base;
-        var bases = [];
-        var base;
+        const parent = child.prototype.tp$base;
+        const bases = [];
 
-        for (base = parent; base !== undefined; base = base.prototype.tp$base) {
+        for (let base = parent; base !== undefined; base = base.prototype.tp$base) {
             if (!base.sk$abstract && Sk.builtins[base.tp$name]) {
                 // check the base is not an abstract class and that it is in the builtins dict
                 bases.push(base);
@@ -82,7 +79,7 @@ Sk.doOneTimeInitialization = function (canSuspend) {
         }
 
         child.tp$mro = new Sk.builtin.tuple([child].concat(bases));
-        if (!child.tp$base){
+        if (!child.hasOwnProperty("tp$base")){
             child.tp$base = bases[0];
         }
         child["$d"] = new Sk.builtin.dict([]);
@@ -91,8 +88,8 @@ Sk.doOneTimeInitialization = function (canSuspend) {
         child["$d"].mp$ass_subscript(new Sk.builtin.str("__name__"), new Sk.builtin.str(child.prototype.tp$name));
     };
 
-    for (x in Sk.builtin) {
-        type = Sk.builtin[x];
+    for (let x in Sk.builtin) {
+        const type = Sk.builtin[x];
         if (type instanceof Sk.builtin.type && type.sk$abstract === undefined) {
             setUpClass(type);
         }
@@ -100,13 +97,13 @@ Sk.doOneTimeInitialization = function (canSuspend) {
 
     // Wrap the inner Javascript code of Sk.builtin.object's Python methods inside
     // Sk.builtin.func, as that class was undefined when these functions were declared
-    typesWithFunctionsToWrap = [Sk.builtin.object, Sk.builtin.type, Sk.builtin.func, Sk.builtin.method];
+    const typesWithFunctionsToWrap = [Sk.builtin.object, Sk.builtin.type, Sk.builtin.func, Sk.builtin.method];
 
-    for (i = 0; i < typesWithFunctionsToWrap.length; i++) {
-        builtin_type = typesWithFunctionsToWrap[i];
-        proto = builtin_type.prototype;
-        for (j = 0; j < builtin_type.pythonFunctions.length; j++) {
-            name = builtin_type.pythonFunctions[j];
+    for (let i = 0; i < typesWithFunctionsToWrap.length; i++) {
+        const builtin_type = typesWithFunctionsToWrap[i];
+        const proto = builtin_type.prototype;
+        for (let j = 0; j < builtin_type.pythonFunctions.length; j++) {
+            const name = builtin_type.pythonFunctions[j];
 
             if (proto[name] instanceof Sk.builtin.func) {
                 // If functions have already been initialized, do not wrap again.

--- a/src/import.js
+++ b/src/import.js
@@ -60,7 +60,7 @@ Sk.importSearchPathForName = function (name, ext, searchPath) {
  * @return {undefined}
  */
 Sk.doOneTimeInitialization = function (canSuspend) {
-    var proto, name, i, x, func, typesWithFunctionsToWrap, builtin_type, j;
+    var proto, name, i, x, type, typesWithFunctionsToWrap, builtin_type, j;
 
     // can't fill these out when making the type because tuple/dict aren't
     // defined yet.
@@ -89,16 +89,12 @@ Sk.doOneTimeInitialization = function (canSuspend) {
         child["$d"].mp$ass_subscript(Sk.builtin.type.basesStr_, child.tp$base ? new Sk.builtin.tuple([child.tp$base]) : new Sk.builtin.tuple([]));
         child["$d"].mp$ass_subscript(Sk.builtin.type.mroStr_, child.tp$mro);
         child["$d"].mp$ass_subscript(new Sk.builtin.str("__name__"), new Sk.builtin.str(child.prototype.tp$name));
-        child.tp$setattr = function(pyName, value, canSuspend) {
-            throw new Sk.builtin.TypeError("can't set attributes of built-in/extension type '" + this.tp$name + "'");
-        };
     };
 
     for (x in Sk.builtin) {
-        func = Sk.builtin[x];
-        if ((func.prototype instanceof Sk.builtin.object ||
-             func === Sk.builtin.object) && !func.sk$abstract) {
-            setUpClass(func);
+        type = Sk.builtin[x];
+        if (type instanceof Sk.builtin.type && type.sk$abstract === undefined) {
+            setUpClass(type);
         }
     }
 

--- a/src/object.js
+++ b/src/object.js
@@ -38,11 +38,11 @@ Object.defineProperties(Sk.builtin.object.prototype, /**@lends {Sk.builtin.objec
  * using `Object.setPrototypeOf`
  *
  * ```
- * type.__proto__             = type   (type instanceof type)
- * type.__proto__.__proto__   = object (type instanceof object)
- * type.prototype.__proto__   = object (type subclasssof object)
- * object.__proto__           = type   (object instanceof type)
- * object.__proto__.__proto__ = object (object instanceof object)
+ * type.__proto__             = type.prototype   (type   instanceof type  )
+ * type.__proto__.__proto__   = object.prototype (type   instanceof object)
+ * type.prototype.__proto__   = object.prototype (type   subclassof object)
+ * object.__proto__           = type.prototype   (object instanceof type  )
+ * object.__proto__.__proto__ = object.prototype (object instanceof object)
  * ```
  *
  * while `Object.setPrototypeOf` is not considered [good practice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf)

--- a/src/object.js
+++ b/src/object.js
@@ -16,6 +16,50 @@ Sk.builtin.object = function () {
     return this;
 };
 
+Object.defineProperties(Sk.builtin.object.prototype, /**@lends {Sk.builtin.object.prototype}*/ {
+    ob$type: { value: Sk.builtin.object, writable: true },
+    tp$name: { value: "object", writable: true },
+    tp$base: { value: undefined, writable: true },
+    sk$object: { value: true },
+});
+
+/**
+ * @description
+ * We aim to match python and javascript inheritance like
+ * type   instanceof object => true
+ * object instanceof type   => true
+ * type   instanceof type   => true
+ * object instanceof object => true
+ *
+ * type   subclassof object => type.prototype   instanceof object => true
+ * object subclassof type   => object.prototype instanceof type   => false
+ * 
+ * this algorithm achieves the equivalent with the following prototypical chains
+ * using `Object.setPrototypeOf`
+ *
+ * ```
+ * type.__proto__             = type   (type instanceof type)
+ * type.__proto__.__proto__   = object (type instanceof object)
+ * type.prototype.__proto__   = object (type subclasssof object)
+ * object.__proto__           = type   (object instanceof type)
+ * object.__proto__.__proto__ = object (object instanceof object)
+ * ```
+ *
+ * while `Object.setPrototypeOf` is not considered [good practice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf)
+ * this is a particularly unique use case and creates a lot of prototypical benefits
+ * all single inheritance classes (i.e. all builtins) now follow prototypical inheritance
+ * similarly it makes metclasses that much easier to implement
+ * Object.setPrototypeOf is also a feature built into the javascript language
+ *
+ * @ignore
+ */
+(function setUpBaseInheritance () {
+    Object.setPrototypeOf(Sk.builtin.type.prototype, Sk.builtin.object.prototype);
+    Object.setPrototypeOf(Sk.builtin.type, Sk.builtin.type.prototype);
+    Object.setPrototypeOf(Sk.builtin.object, Sk.builtin.type.prototype);
+    Sk.builtin.type.prototype.tp$base = Sk.builtin.object;
+})();
+
 Sk.builtin.object.prototype.__init__ = function __init__() {
     return Sk.builtin.none.none$;
 };
@@ -192,18 +236,6 @@ Sk.builtin.object.prototype.tp$setattr = Sk.builtin.object.prototype.GenericSetA
 Sk.builtin.object.prototype["__getattribute__"] = Sk.builtin.object.prototype.GenericPythonGetAttr;
 Sk.builtin.object.prototype["__setattr__"] = Sk.builtin.object.prototype.GenericPythonSetAttr;
 
-/**
- * The name of this class.
- * @type {string}
- */
-Sk.builtin.object.prototype.tp$name = "object";
-
-/**
- * The type object of this class.
- * @type {Sk.builtin.type|Object}
- */
-Sk.builtin.object.prototype.ob$type = Sk.builtin.type.makeIntoTypeObj("object", Sk.builtin.object);
-Sk.builtin.object.prototype.ob$type.sk$klass = undefined;   // Nonsense for closure compiler
 Sk.builtin.object.prototype.tp$descr_set = undefined;   // Nonsense for closure compiler
 
 /** Default implementations of dunder methods found in all Python objects */

--- a/src/type.js
+++ b/src/type.js
@@ -654,21 +654,6 @@ Sk.builtin.type.buildMRO = function (klass) {
     return new Sk.builtin.tuple(Sk.builtin.type.buildMRO_(klass));
 };
 
-Sk.builtin.type.prototype.tp$richcompare = function (other, op) {
-    var r2;
-    var r1;
-    if (other.ob$type != Sk.builtin.type) {
-        return undefined;
-    }
-    if (!this["$r"] || !other["$r"]) {
-        return undefined;
-    }
-
-    r1 = this["$r"]();
-    r2 = other["$r"]();
-
-    return r1.tp$richcompare(r2, op);
-};
 
 Sk.builtin.type.prototype["__format__"] = function(self, format_spec) {
     Sk.builtin.pyCheckArgsLen("__format__", arguments.length, 1, 2);

--- a/test/unit3/test_inheritance.py
+++ b/test/unit3/test_inheritance.py
@@ -93,7 +93,7 @@ class InheritanceTesting(unittest.TestCase):
         self.assertTrue(issubclass(Foo,object))
         self.assertTrue(issubclass(Frob,XXX))
 
-    def test_builtins(self):
+    def test_skulpt_bugs(self):
         for _cls in (int, dict, set, list, object, tuple):
             self.assertTrue(issubclass(_cls, object))
         
@@ -103,6 +103,14 @@ class InheritanceTesting(unittest.TestCase):
         self.assertEqual(int.__mro__, (int, object))
         self.assertEqual(Exception.__mro__, (Exception, BaseException, object))
         self.assertEqual(TypeError.__bases__, (Exception,))
+
+        # test type and object
+        self.assertTrue(isinstance(type, object))
+        self.assertTrue(isinstance(type, type))
+        self.assertTrue(isinstance(object, object))
+        self.assertTrue(isinstance(object, type))
+        # self.assertTrue(issubclass(type, object)) # commenting out until issubclass returns a pyBool
+        # self.assertFalse(issubclass(object, type))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_inheritance.py
+++ b/test/unit3/test_inheritance.py
@@ -109,8 +109,8 @@ class InheritanceTesting(unittest.TestCase):
         self.assertTrue(isinstance(type, type))
         self.assertTrue(isinstance(object, object))
         self.assertTrue(isinstance(object, type))
-        # self.assertTrue(issubclass(type, object)) # commenting out until issubclass returns a pyBool
-        # self.assertFalse(issubclass(object, type))
+        self.assertTrue(issubclass(type, object))
+        self.assertFalse(issubclass(object, type))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is the fundamental building block for #1092 presented here as the minimum required, non-breaking change

It leads to this prototypical inheritance chain for `type` and `object`
```javascript

type.__proto__             = type   (type instanceof type)      // isinstance(type, type)     => True
type.__proto__.__proto__   = object (type instanceof object)    // isinstance(type, object)   => True
type.prototype.__proto__   = object (type subclasssof object)   // issubclass(type, object)   => True
object.__proto__           = type   (object instanceof type)    // isinstance(object, type)   => True
object.__proto__.__proto__ = object (object instanceof object)  // isinstance(object, object) => True

```
Since function is no longer down the prototypical chain we add this back on to the `prototype` of `type` so that type objects remain callable... useful when they need to be constructors... 😉 
```
Sk.builtin.type.prototype.call = Function.prototype.call
Sk.builtin.type.prototype.apply = Function.prototype.apply
```

---

I would add the tests below:
```python
self.assertTrue(issubclass(type, object))
self.assertFalse(issubclass(object, type))
```
which are now fixed in this pr...
But `issubclass` returns a javascript `boolean` rather than a `Sk.builtin.bool`! 
That can be a separate pr... 


---
In the second commit... 

I remove `Sk.builtin.type.prototype.tp$richcompare` 
This is not a thing in python. 
What this function does is already taken care of in `misceval.richCompareBool`
To hack back in `type(int('1'*600)) == int` in py3 mode I make `Sk.builtin.lng.prototype.ob$type = Sk.builtin.int_`
in `env.js`