### PR TITLE
adjust richCompareBool

### DIFF
--- a/src/bool.js
+++ b/src/bool.js
@@ -49,6 +49,46 @@ Sk.builtin.bool.prototype.__format__ = new Sk.builtin.func(function(self) {
     return self.$r();
 });
 
+Sk.builtin.bool.prototype.nb$and = function (other) {
+    if (other.ob$type === Sk.builtin.bool) {
+        return new Sk.builtin.bool(this.v & other.v);
+    }
+    return Sk.builtin.int_.prototype.nb$and.call(this, other);
+};
+
+Sk.builtin.bool.prototype.nb$or = function (other) {
+    if (other.ob$type === Sk.builtin.bool) {
+        return new Sk.builtin.bool(this.v | other.v);
+    }
+    return Sk.builtin.int_.prototype.nb$or.call(this, other);
+};
+
+Sk.builtin.bool.prototype.nb$xor = function (other) {
+    if (other.ob$type === Sk.builtin.bool) {
+        return new Sk.builtin.bool(this.v ^ other.v);
+    }
+    return Sk.builtin.int_.prototype.nb$xor.call(this, other);
+};
+
+Sk.builtin.bool.prototype.ob$eq = function (other) {
+    return Sk.builtin.int_.prototype.ob$eq.call(this, other);
+};
+Sk.builtin.bool.prototype.ob$ne = function (other) {
+    return Sk.builtin.int_.prototype.ob$ne.call(this, other);
+};
+Sk.builtin.bool.prototype.ob$lt = function (other) {
+    return Sk.builtin.int_.prototype.ob$lt.call(this, other);
+};
+Sk.builtin.bool.prototype.ob$le = function (other) {
+    return Sk.builtin.int_.prototype.ob$le.call(this, other);
+};
+Sk.builtin.bool.prototype.ob$gt = function (other) {
+    return Sk.builtin.int_.prototype.ob$gt.call(this, other);
+};
+Sk.builtin.bool.prototype.ob$ge = function (other) {
+    return Sk.builtin.int_.prototype.ob$ge.call(this, other);
+};
+
 Sk.exportSymbol("Sk.builtin.bool", Sk.builtin.bool);
 
 /**

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -236,62 +236,42 @@ Sk.misceval.opSymbols = {
 Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     // v and w must be Python objects. will return Javascript true or false for internal use only
     // if you want to return a value from richCompareBool to Python you must wrap as Sk.builtin.bool first
-    var wname,
-        vname,
-        ret,
-        swapped_method,
-        method,
+    var ret,
         swapped_shortcut,
-        shortcut,
-        v_has_shortcut,
-        w_has_shortcut,
-        op2shortcut,
-        vcmp,
-        wcmp,
-        w_seq_type,
-        w_num_type,
-        v_seq_type,
-        v_num_type,
-        sequence_types,
-        numeric_types,
-        w_type,
-        v_type;
+        shortcut;
 
     Sk.asserts.assert((v !== null) && (v !== undefined), "passed null or undefined parameter to Sk.misceval.richCompareBool");
     Sk.asserts.assert((w !== null) && (w !== undefined), "passed null or undefined parameter to Sk.misceval.richCompareBool");
 
-    v_type = v.ob$type;
-    w_type = w.ob$type;
+    const v_type = v.ob$type;
+    const w_type = w.ob$type;
 
     // Python 2 has specific rules when comparing two different builtin types
     // currently, this code will execute even if the objects are not builtin types
     // but will fall through and not return anything in this section
-    if (!Sk.__future__.python3 &&
-        (v_type !== w_type) &&
-        (op === "GtE" || op === "Gt" || op === "LtE" || op === "Lt")) {
+    if (!Sk.__future__.python3 && v_type !== w_type && (op === "GtE" || op === "Gt" || op === "LtE" || op === "Lt")) {
         // note: sets are omitted here because they can only be compared to other sets
-        numeric_types = [Sk.builtin.float_.prototype.ob$type,
-                         Sk.builtin.int_.prototype.ob$type,
-                         Sk.builtin.lng.prototype.ob$type,
-                         Sk.builtin.bool.prototype.ob$type];
-        sequence_types = [Sk.builtin.dict.prototype.ob$type,
-                          Sk.builtin.enumerate.prototype.ob$type,
-                          Sk.builtin.filter_.prototype.ob$type,
-                          Sk.builtin.list.prototype.ob$type,
-                          Sk.builtin.map_.prototype.ob$type,
-                          Sk.builtin.str.prototype.ob$type,
-                          Sk.builtin.tuple.prototype.ob$type,
-                          Sk.builtin.zip_.prototype.ob$type];
+        const numeric_types = [Sk.builtin.float_, Sk.builtin.int_, Sk.builtin.lng, Sk.builtin.bool];
+        const sequence_types = [
+            Sk.builtin.dict,
+            Sk.builtin.enumerate,
+            Sk.builtin.filter_,
+            Sk.builtin.list,
+            Sk.builtin.map_,
+            Sk.builtin.str,
+            Sk.builtin.tuple,
+            Sk.builtin.zip_,
+        ];
 
-        v_num_type = numeric_types.indexOf(v_type);
-        v_seq_type = sequence_types.indexOf(v_type);
-        w_num_type = numeric_types.indexOf(w_type);
-        w_seq_type = sequence_types.indexOf(w_type);
+        const v_num_type = numeric_types.indexOf(v_type);
+        const v_seq_type = sequence_types.indexOf(v_type);
+        const w_num_type = numeric_types.indexOf(w_type);
+        const w_seq_type = sequence_types.indexOf(w_type);
 
         // NoneTypes are considered less than any other type in Python
         // note: this only handles comparing NoneType with any non-NoneType.
         // Comparing NoneType with NoneType is handled further down.
-        if (v_type === Sk.builtin.none.prototype.ob$type) {
+        if (v === Sk.builtin.none.none$) {
             switch (op) {
                 case "Lt":
                     return true;
@@ -304,7 +284,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
             }
         }
 
-        if (w_type === Sk.builtin.none.prototype.ob$type) {
+        if (w === Sk.builtin.none.none$) {
             switch (op) {
                 case "Lt":
                     return false;
@@ -360,29 +340,32 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
         }
     }
 
-
     // handle identity and membership comparisons
     if (op === "Is") {
-        if (v instanceof Sk.builtin.int_ && w instanceof Sk.builtin.int_) {
-            return v.numberCompare(w) === 0;
-        } else if (v instanceof Sk.builtin.float_ && w instanceof Sk.builtin.float_) {
-            return v.numberCompare(w) === 0;
-        } else if (v instanceof Sk.builtin.lng && w instanceof Sk.builtin.lng) {
-            return v.longCompare(w) === 0;
+        if (v_type === w_type) {
+            if (v === w) {
+                return true;
+            } else if (v_type === Sk.builtin.float_) {
+                return v.v === w.v;
+            } else if (v_type === Sk.builtin.int_) {
+                return v.v === w.v;
+            } else if (v_type === Sk.builtin.lng) {
+                return v.longCompare(w) === 0;
+            }
         }
-
-        return v === w;
+        return false;
     }
 
     if (op === "IsNot") {
-        if (v instanceof Sk.builtin.int_ && w instanceof Sk.builtin.int_) {
-            return v.numberCompare(w) !== 0;
-        } else if (v instanceof Sk.builtin.float_ && w instanceof Sk.builtin.float_) {
-            return v.numberCompare(w) !== 0;
-        }else if (v instanceof Sk.builtin.lng && w instanceof Sk.builtin.lng) {
+        if (v_type !== w_type) {
+            return true;
+        } else if (v_type === Sk.builtin.float_) {
+            return v.v !== w.v;
+        } else if (v_type === Sk.builtin.int_) {
+            return v.v !== w.v;
+        } else if (v_type === Sk.builtin.lng) {
             return v.longCompare(w) !== 0;
         }
-
         return v !== w;
     }
 
@@ -398,7 +381,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
 
     // Call Javascript shortcut method if exists for either object
 
-    op2shortcut = {
+    var op2shortcut = {
         "Eq"   : "ob$eq",
         "NotEq": "ob$ne",
         "Gt"   : "ob$gt",
@@ -408,7 +391,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     };
 
     shortcut = op2shortcut[op];
-    v_has_shortcut = v.constructor.prototype.hasOwnProperty(shortcut);
+    const v_has_shortcut = v.constructor.prototype.hasOwnProperty(shortcut);
     if (v_has_shortcut) {
         if ((ret = v[shortcut](w)) !== Sk.builtin.NotImplemented.NotImplemented$) {
             return Sk.misceval.isTrue(ret);
@@ -416,7 +399,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     }
 
     swapped_shortcut = op2shortcut[Sk.misceval.swappedOp_[op]];
-    w_has_shortcut = w.constructor.prototype.hasOwnProperty(swapped_shortcut);
+    const w_has_shortcut = w.constructor.prototype.hasOwnProperty(swapped_shortcut);
     if (w_has_shortcut) {
 
         if ((ret = w[swapped_shortcut](v)) !== Sk.builtin.NotImplemented.NotImplemented$) {
@@ -441,7 +424,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     // depending on the op, try left:op:right, and if not, then
     // right:reversed-top:left
 
-    method = Sk.abstr.lookupSpecial(v, Sk.misceval.op2method_[op]);
+    const method = Sk.abstr.lookupSpecial(v, Sk.misceval.op2method_[op]);
     if (method && !v_has_shortcut) {
         ret = Sk.misceval.callsimArray(method, [v, w]);
         if (ret != Sk.builtin.NotImplemented.NotImplemented$) {
@@ -449,7 +432,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
         }
     }
 
-    swapped_method = Sk.abstr.lookupSpecial(w, Sk.misceval.op2method_[Sk.misceval.swappedOp_[op]]);
+    const swapped_method = Sk.abstr.lookupSpecial(w, Sk.misceval.op2method_[Sk.misceval.swappedOp_[op]]);
     if (swapped_method && !w_has_shortcut) {
         ret = Sk.misceval.callsimArray(swapped_method, [w, v]);
         if (ret != Sk.builtin.NotImplemented.NotImplemented$) {
@@ -457,7 +440,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
         }
     }
     if (!Sk.__future__.python3) {
-        vcmp = Sk.abstr.lookupSpecial(v, Sk.builtin.str.$cmp);
+        const vcmp = Sk.abstr.lookupSpecial(v, Sk.builtin.str.$cmp);
         if (vcmp) {
             try {
                 ret = Sk.misceval.callsimArray(vcmp, [v, w]);
@@ -477,7 +460,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
                         return ret >= 0;
                     }
                 }
-    
+
                 if (ret !== Sk.builtin.NotImplemented.NotImplemented$) {
                     throw new Sk.builtin.TypeError("comparison did not return an int");
                 }
@@ -485,7 +468,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
                 throw new Sk.builtin.TypeError("comparison did not return an int");
             }
         }
-        wcmp = Sk.abstr.lookupSpecial(w, Sk.builtin.str.$cmp);
+        const wcmp = Sk.abstr.lookupSpecial(w, Sk.builtin.str.$cmp);
         if (wcmp) {
             // note, flipped on return value and call
             try {
@@ -514,55 +497,43 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
                 throw new Sk.builtin.TypeError("comparison did not return an int");
             }
         }
+        // handle special cases for comparing None with None or Bool with Bool
+        if (v === Sk.builtin.none.none$ && w === Sk.builtin.none.none$) {
+            // Javascript happens to return the same values when comparing null
+            // with null or true/false with true/false as Python does when
+            // comparing None with None or True/False with True/False
 
-    }
-    
-
-    
-    // handle special cases for comparing None with None or Bool with Bool
-    if (((v === Sk.builtin.none.none$) && (w === Sk.builtin.none.none$)) ||
-        ((v instanceof Sk.builtin.bool) && (w instanceof Sk.builtin.bool))) {
-        // Javascript happens to return the same values when comparing null
-        // with null or true/false with true/false as Python does when
-        // comparing None with None or True/False with True/False
-
-        if (op === "Eq") {
-            return v.v === w.v;
-        }
-        if (op === "NotEq") {
-            return v.v !== w.v;
-        }
-        if (op === "Gt") {
-            return v.v > w.v;
-        }
-        if (op === "GtE") {
-            return v.v >= w.v;
-        }
-        if (op === "Lt") {
-            return v.v < w.v;
-        }
-        if (op === "LtE") {
-            return v.v <= w.v;
+            if (op === "Eq") {
+                return v.v === w.v;
+            }
+            if (op === "NotEq") {
+                return v.v !== w.v;
+            }
+            if (op === "Gt") {
+                return v.v > w.v;
+            }
+            if (op === "GtE") {
+                return v.v >= w.v;
+            }
+            if (op === "Lt") {
+                return v.v < w.v;
+            }
+            if (op === "LtE") {
+                return v.v <= w.v;
+            }
         }
     }
-
 
     // handle equality comparisons for any remaining objects
     if (op === "Eq") {
-        if ((v instanceof Sk.builtin.str) && (w instanceof Sk.builtin.str)) {
-            return v.v === w.v;
-        }
         return v === w;
     }
     if (op === "NotEq") {
-        if ((v instanceof Sk.builtin.str) && (w instanceof Sk.builtin.str)) {
-            return v.v !== w.v;
-        }
         return v !== w;
     }
 
-    vname = Sk.abstr.typeName(v);
-    wname = Sk.abstr.typeName(w);
+    const vname = Sk.abstr.typeName(v);
+    const wname = Sk.abstr.typeName(w);
     throw new Sk.builtin.TypeError("'" + Sk.misceval.opSymbols[op] + "' not supported between instances of '" + vname + "' and '" + wname + "'");
     //throw new Sk.builtin.ValueError("don't know how to compare '" + vname + "' and '" + wname + "'");
 };


### PR DESCRIPTION
this pr adjusts richCompareBool and fixes an issue where 
```python
>>> None < None
False # yes in py2 No in py3
``` 
in py3 mode this should be an Error. 

It simplifies some of the logic in the function. 
It is also fixes a couple of issues with number types and the `is` operator. 
e.g. 
```python
>>> True is 1 #should be false
True # in skulpt we treat is the same for instances of number but shouldn't
>>> class A(int): pass
>>> A(1) is 1
True # should be False - same issue with bool - A(1) is an instance of int...
```

Because the above was a hidden bug in skulpt it meant that we were not getting correct results from
```python
self.assertTrue(True & True) 
# in skulpt this is 1 but because the `is` operator treated True and 1 the same hence we didn't notice this was a bug
```

So I override `Bool` number slots [as per Cpython](https://github.com/python/cpython/blob/master/Objects/boolobject.c#L95). 

For this pr I also needed to add slots for `ob$eq` for `bool` because `bool` is an unusual builtin (in that it inherits from `int`) and because `richCompareBool` is still weird. 

`richCopareBool` is still weird because there are 3 ways we can do any comparison operation... the slot `ob$eq` the `tp$richcompare` or the dunder method (More fixes in a future pr see richcompare bool [here](https://github.com/s-cork/skulpt/blob/prototypical_getsets_mappingproxy/src/misceval.js#L394) in #1092 where there is 1 way it can be called)

