### PR TITLE
remove StandardError from error.js

### DIFF
--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -125,7 +125,7 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["zip"] = new Sk.builtin.func(Sk.builtin.zip);
         Sk.builtins["range"] = new Sk.builtin.func(Sk.builtin.range);
         Sk.builtins["xrange"] = new Sk.builtin.func(Sk.builtin.xrange);
-        Sk.builtins["StandardError"] = Sk.builtin.StandardError;
+        Sk.builtins["StandardError"] = Sk.builtin.Exception;
         Sk.builtins["unicode"] = Sk.builtin.str;
     }
 };

--- a/src/errors.js
+++ b/src/errors.js
@@ -103,23 +103,6 @@ Sk.exportSymbol("Sk.builtin.Exception", Sk.builtin.Exception);
  * @extends Sk.builtin.Exception
  * @param {...*} args
  */
-Sk.builtin.StandardError = function (args) {
-    var o;
-    if (!(this instanceof Sk.builtin.StandardError)) {
-        o = Object.create(Sk.builtin.StandardError.prototype);
-        o.constructor.apply(o, arguments);
-        return o;
-    }
-    Sk.builtin.Exception.apply(this, arguments);
-};
-Sk.abstr.setUpInheritance("StandardError", Sk.builtin.StandardError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.StandardError", Sk.builtin.StandardError);
-
-/**
- * @constructor
- * @extends Sk.builtin.StandardError
- * @param {...*} args
- */
 Sk.builtin.AssertionError = function (args) {
     var o;
     if (!(this instanceof Sk.builtin.AssertionError)) {
@@ -127,14 +110,14 @@ Sk.builtin.AssertionError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("AssertionError", Sk.builtin.AssertionError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("AssertionError", Sk.builtin.AssertionError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.AssertionError", Sk.builtin.AssertionError);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.AttributeError = function (args) {
@@ -144,13 +127,13 @@ Sk.builtin.AttributeError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("AttributeError", Sk.builtin.AttributeError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("AttributeError", Sk.builtin.AttributeError, Sk.builtin.Exception);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.ImportError = function (args) {
@@ -160,13 +143,13 @@ Sk.builtin.ImportError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("ImportError", Sk.builtin.ImportError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("ImportError", Sk.builtin.ImportError, Sk.builtin.Exception);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.IndentationError = function (args) {
@@ -176,13 +159,13 @@ Sk.builtin.IndentationError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("IndentationError", Sk.builtin.IndentationError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("IndentationError", Sk.builtin.IndentationError, Sk.builtin.Exception);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.IndexError = function (args) {
@@ -192,13 +175,13 @@ Sk.builtin.IndexError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("IndexError", Sk.builtin.IndexError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("IndexError", Sk.builtin.IndexError, Sk.builtin.Exception);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.KeyError = function (args) {
@@ -208,13 +191,13 @@ Sk.builtin.KeyError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("KeyError", Sk.builtin.KeyError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("KeyError", Sk.builtin.KeyError, Sk.builtin.Exception);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.NameError = function (args) {
@@ -224,13 +207,13 @@ Sk.builtin.NameError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("NameError", Sk.builtin.NameError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("NameError", Sk.builtin.NameError, Sk.builtin.Exception);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.UnboundLocalError = function (args) {
@@ -240,13 +223,13 @@ Sk.builtin.UnboundLocalError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("UnboundLocalError", Sk.builtin.UnboundLocalError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("UnboundLocalError", Sk.builtin.UnboundLocalError, Sk.builtin.Exception);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.OverflowError = function (args) {
@@ -256,14 +239,14 @@ Sk.builtin.OverflowError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("OverflowError", Sk.builtin.OverflowError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("OverflowError", Sk.builtin.OverflowError, Sk.builtin.Exception);
 
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.SyntaxError = function (args) {
@@ -273,13 +256,13 @@ Sk.builtin.SyntaxError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("SyntaxError", Sk.builtin.SyntaxError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("SyntaxError", Sk.builtin.SyntaxError, Sk.builtin.Exception);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.RuntimeError = function (args) {
@@ -289,15 +272,15 @@ Sk.builtin.RuntimeError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("RuntimeError", Sk.builtin.RuntimeError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("RuntimeError", Sk.builtin.RuntimeError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.RuntimeError", Sk.builtin.RuntimeError);
 
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.SuspensionError = function (args) {
@@ -307,9 +290,9 @@ Sk.builtin.SuspensionError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("SuspensionError", Sk.builtin.SuspensionError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("SuspensionError", Sk.builtin.SuspensionError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.SuspensionError", Sk.builtin.SuspensionError);
 
 
@@ -333,7 +316,7 @@ Sk.exportSymbol("Sk.builtin.SystemExit", Sk.builtin.SystemExit);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.TypeError = function (args) {
@@ -343,13 +326,13 @@ Sk.builtin.TypeError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("TypeError", Sk.builtin.TypeError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("TypeError", Sk.builtin.TypeError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.TypeError", Sk.builtin.TypeError);
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.ValueError = function (args) {
@@ -359,14 +342,14 @@ Sk.builtin.ValueError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("ValueError", Sk.builtin.ValueError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("ValueError", Sk.builtin.ValueError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.ValueError", Sk.builtin.ValueError);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.ZeroDivisionError = function (args) {
@@ -376,13 +359,13 @@ Sk.builtin.ZeroDivisionError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("ZeroDivisionError", Sk.builtin.ZeroDivisionError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("ZeroDivisionError", Sk.builtin.ZeroDivisionError, Sk.builtin.Exception);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.TimeLimitError = function (args) {
@@ -392,14 +375,14 @@ Sk.builtin.TimeLimitError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("TimeLimitError", Sk.builtin.TimeLimitError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("TimeLimitError", Sk.builtin.TimeLimitError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.TimeLimitError", Sk.builtin.TimeLimitError);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.IOError = function (args) {
@@ -409,15 +392,15 @@ Sk.builtin.IOError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("IOError", Sk.builtin.IOError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("IOError", Sk.builtin.IOError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.IOError", Sk.builtin.IOError);
 
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.NotImplementedError = function (args) {
@@ -427,14 +410,14 @@ Sk.builtin.NotImplementedError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("NotImplementedError", Sk.builtin.NotImplementedError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("NotImplementedError", Sk.builtin.NotImplementedError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.NotImplementedError", Sk.builtin.NotImplementedError);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.NegativePowerError = function (args) {
@@ -444,14 +427,14 @@ Sk.builtin.NegativePowerError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("NegativePowerError", Sk.builtin.NegativePowerError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("NegativePowerError", Sk.builtin.NegativePowerError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.NegativePowerError", Sk.builtin.NegativePowerError);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {*} nativeError
  * @param {...*} args
  */
@@ -469,14 +452,14 @@ Sk.builtin.ExternalError = function (nativeError, args) {
     if (!(args[0] instanceof Sk.builtin.str)) {
         args[0] = ""+args[0];
     }
-    Sk.builtin.StandardError.apply(this, args);
+    Sk.builtin.Exception.apply(this, args);
 };
-Sk.abstr.setUpInheritance("ExternalError", Sk.builtin.ExternalError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("ExternalError", Sk.builtin.ExternalError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.ExternalError", Sk.builtin.ExternalError);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.OperationError = function (args) {
@@ -486,14 +469,14 @@ Sk.builtin.OperationError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("OperationError", Sk.builtin.OperationError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("OperationError", Sk.builtin.OperationError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.OperationError", Sk.builtin.OperationError);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
+ * @extends Sk.builtin.Exception
  * @param {...*} args
  */
 Sk.builtin.SystemError = function (args) {
@@ -503,9 +486,9 @@ Sk.builtin.SystemError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.StandardError.apply(this, arguments);
+    Sk.builtin.Exception.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("SystemError", Sk.builtin.SystemError, Sk.builtin.StandardError);
+Sk.abstr.setUpInheritance("SystemError", Sk.builtin.SystemError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.SystemError", Sk.builtin.SystemError);
 
 /**
@@ -536,4 +519,3 @@ Sk.builtin.getExcInfo = function(e) {
     return new Sk.builtin.tuple(v);
 };
 // NOT exported
-


### PR DESCRIPTION
This pr takes the opinion that we are preferring `python 3` and making sure `python 2` doesn't break.

To keep StandardError in the game I make `StandardError` = `Exception` in the switch. 
I can't imagine this would break any code since using `StandardError` in code would be unusual, which I guess is why it's not in `python 3`...

But maybe there is a weird case where this will break some code somewhere that I haven't considered.
