### PR TITLE
change null to none

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -587,7 +587,7 @@ Compiler.prototype.cyield = function(e)
     if (this.u.ste.blockType !== Sk.SYMTAB_CONSTS.FunctionBlock) {
         throw new Sk.builtin.SyntaxError("'yield' outside function", this.filename, e.lineno);
     }
-    var val = "null",
+    var val = "Sk.builtin.none.none$",
         nextBlock;
     if (e.value) {
         val = this.vexpr(e.value);
@@ -596,7 +596,7 @@ Compiler.prototype.cyield = function(e)
     // return a pair: resume target block and yielded value
     out("return [/*resume*/", nextBlock, ",/*ret*/", val, "];");
     this.setBlock(nextBlock);
-    return "$gen.gi$sentvalue"; // will either be null if none sent, or the value from gen.send(value)
+    return "$gen.gi$sentvalue"; // will either be none if none sent, or the value from gen.send(value)
 };
 
 Compiler.prototype.ccompare = function (e) {

--- a/src/generator.js
+++ b/src/generator.js
@@ -62,7 +62,7 @@ Sk.builtin.generator.prototype.tp$iternext = function (canSuspend, yielded) {
     var self = this;
     this["gi$running"] = true;
     if (yielded === undefined) {
-        yielded = null;
+        yielded = Sk.builtin.none.none$;
     }
     this["gi$sentvalue"] = yielded;
 


### PR DESCRIPTION
a niche bug

```python
def f():
   x = yield
   yield x

>>> gen = f()
>>> next(gen) is None
Error can't read ob$type of null
```

We send null rather than `Sk.builtin.none.none$`
