### PR TITLE
This shouldn't improve performance

### DIFF
--- a/src/dict.js
+++ b/src/dict.js
@@ -456,17 +456,7 @@ Sk.builtin.dict.prototype.py3$values = function (self) {
 
 Sk.builtin.dict.prototype["values"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py2$values);
 
-Sk.setupDictIterators = function (python3) {
-    if (python3) {
-        Sk.builtin.dict.prototype["keys"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py3$keys);
-        Sk.builtin.dict.prototype["values"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py3$values);
-        Sk.builtin.dict.prototype["items"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py3$items);
-    } else {
-        Sk.builtin.dict.prototype["keys"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py2$keys);
-        Sk.builtin.dict.prototype["values"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py2$values);
-        Sk.builtin.dict.prototype["items"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py2$items);
-    }
-};
+
 
 Sk.builtin.dict.prototype["clear"] = new Sk.builtin.func(function (self) {
     Sk.builtin.pyCheckArgsLen("clear()", arguments.length, 0, 0, false, true);

--- a/src/env.js
+++ b/src/env.js
@@ -210,7 +210,7 @@ Sk.configure = function (options) {
 
     Sk.setupOperators(Sk.__future__.python3);
     Sk.setupDunderMethods(Sk.__future__.python3);
-    Sk.setupDictIterators(Sk.__future__.python3);
+    setupDictIterators(Sk.__future__.python3);
     Sk.setupObjects(Sk.__future__.python3);
 };
 
@@ -398,3 +398,16 @@ Sk.switch_version = function (method_to_map, python3) {
 
 Sk.exportSymbol("Sk.__future__", Sk.__future__);
 Sk.exportSymbol("Sk.inputfun", Sk.inputfun);
+
+function setupDictIterators (python3) {
+    if (python3) {
+        Sk.builtin.dict.prototype["keys"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py3$keys);
+        Sk.builtin.dict.prototype["values"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py3$values);
+        Sk.builtin.dict.prototype["items"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py3$items);
+    } else {
+        Sk.builtin.dict.prototype["keys"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py2$keys);
+        Sk.builtin.dict.prototype["values"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py2$values);
+        Sk.builtin.dict.prototype["items"] = new Sk.builtin.func(Sk.builtin.dict.prototype.py2$items);
+    }
+};
+


### PR DESCRIPTION
I don't know why this seems to improve performance on my machine... 
It seems trivial and I was hoping someone could confirm/explain what's going on here!


it accounts for my claim that #1013 improved speed significantly. It's not that #1013 significantly improved speed but more that the #1013 branch was prior to the inclusion of `Sk.setupDictIterators` which seemed to slow down speed by approx 50% somehow...

It doesn't matter if I do `npm run build` or `npm run devbuild`
I was using `fields.py` `100 Ticks` `10 loops`
I got `3.4 seconds` vs `1.9 seconds` which seems ridiculous.

I hope there's a sensible explanation 🙏 