### PR TITLE
decorators run in reverse order

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2180,7 +2180,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         var res;
         if (decos.length > 0) {
             out("$ret = new Sk.builtins['function'](", scopename, ",$gbl", frees, ");");
-            for (let decorator of decos) {
+            for (let decorator of decos.reverse()) {
                 out("$ret = Sk.misceval.callsimOrSuspendArray(", decorator, ",[$ret]);");
                 this._checkSuspension();
             }

--- a/test/unit3/test_decorators.py
+++ b/test/unit3/test_decorators.py
@@ -318,7 +318,7 @@ class TestDecorators(unittest.TestCase):
             return x
 
         self.assertEqual(42, f(42))
-        self.assertEqual(['inner', 'outer'], calls)
+        self.assertEqual(['outer', 'inner'], calls)
 
 
     def test_class_decorator(self):


### PR DESCRIPTION
fix #1147 

This seemed a sensible fix but perhaps there's a better way.