### PR TITLE
adjust constructor for float and move overflowerror

### DIFF
--- a/src/float.js
+++ b/src/float.js
@@ -15,81 +15,48 @@
  * @return {Sk.builtin.float_} Python float
  */
 Sk.builtin.float_ = function (x) {
-    var tmp;
-    if (x === undefined) {
-        return new Sk.builtin.float_(0.0);
-    }
-
     if (!(this instanceof Sk.builtin.float_)) {
         return new Sk.builtin.float_(x);
     }
 
-
-    if (x instanceof Sk.builtin.str) {
-        return Sk.builtin._str_to_float(x.v);
-    }
-
-    // Floats are just numbers
-    if (typeof x === "number" || x instanceof Sk.builtin.int_ || x instanceof Sk.builtin.lng || x instanceof Sk.builtin.float_) {
-        tmp = Sk.builtin.asnum$(x);
-        if (typeof tmp === "string") {
-            return Sk.builtin._str_to_float(tmp);
+    if (x === undefined) {
+        this.v = 0.0;
+    } else if (typeof x === "number") {
+        this.v = x;
+    } else if (x.nb$float_) {
+        const tmp = x.nb$float_();
+        if (tmp.constructor !== Sk.builtin.float_) {
+            throw new Sk.builtin.TypeError("__float__ returned non-float (type " + Sk.abstr.typeName(tmp) + ")");
         }
-        this.v = tmp;
-        return this;
-    }
-
-    // Convert booleans
-    if (x instanceof Sk.builtin.bool) {
-        this.v = Sk.builtin.asnum$(x);
-        return this;
-    }
-
-    // this is a special internal case
-    if(typeof x === "boolean") {
+        this.v = tmp.v;
+    } else if (Sk.builtin.checkString(x)) {
+        this.v = _str_to_float(x.$jsstr()).v;
+    } else if (typeof x === "boolean") {
         this.v = x ? 1.0 : 0.0;
-        return this;
-    }
-
-    if (typeof x === "string") {
+    } else if (typeof x === "string") {
         this.v = parseFloat(x);
-        if (this.v == Infinity || this.v == -Infinity){ //trying to convert a large js string to a float
-            throw new Sk.builtin.OverflowError("int too large to convert to float");
-        }
-        return this;
+    } else {
+        throw new Sk.builtin.TypeError("float() argument must be a string or a number");
     }
-
-    // try calling __float__
-    var special = Sk.abstr.lookupSpecial(x, Sk.builtin.str.$float_);
-    if (special != null) {
-        // method on builtin, provide this arg
-        return Sk.misceval.callsimArray(special, [x]);
-    }
-
-    throw new Sk.builtin.TypeError("float() argument must be a string or a number");
 };
 
 Sk.abstr.setUpInheritance("float", Sk.builtin.float_, Sk.builtin.numtype);
 
-Sk.builtin._str_to_float = function (str) {
-    var tmp;
-
+function _str_to_float(str) {
+    let ret;
     if (str.match(/^-inf$/i)) {
-        tmp = -Infinity;
+        ret = -Infinity;
     } else if (str.match(/^[+]?inf$/i)) {
-        tmp = Infinity;
+        ret = Infinity;
     } else if (str.match(/^[-+]?nan$/i)) {
-        tmp = NaN;
+        ret = NaN;
     } else if (!isNaN(str)) {
-        tmp = parseFloat(str);
-        if (tmp === Infinity || tmp === -Infinity) {
-            throw new Sk.builtin.OverflowError("int too large to convert to float");
-        }
+        ret = parseFloat(str);
     } else {
         throw new Sk.builtin.ValueError("float: Argument: " + str + " is not number");
     }
-    return new Sk.builtin.float_(tmp);
-};
+    return new Sk.builtin.float_(ret);
+}
 
 Sk.builtin.float_.prototype.nb$int_ = function () {
     var v = this.v;

--- a/src/long.js
+++ b/src/long.js
@@ -118,7 +118,12 @@ Sk.builtin.lng.prototype.nb$lng_ = function () {
 };
 
 Sk.builtin.lng.prototype.nb$float_ = function() {
-    return new Sk.builtin.float_(Sk.ffi.remapToJs(this));
+    let tmp = Sk.builtin.asnum$(this);
+    tmp = parseFloat(tmp);
+    if (!isFinite(tmp)) {
+        throw new Sk.builtin.OverflowError("int too large to convert to float");
+    }
+    return new Sk.builtin.float_(tmp);
 };
 
 //    Threshold to determine when types should be converted to long

--- a/test/unit3/test_float.py
+++ b/test/unit3/test_float.py
@@ -36,7 +36,8 @@ class FloatTestCases(unittest.TestCase):
     def test_overflow(self):
         self.assertRaises(OverflowError, float, 2**1024)
         self.assertRaises(OverflowError, float, -2**1024)
-        self.assertRaises(OverflowError, float, str(2**1024))
+        self.assertEqual(float('inf'), float(str(2**1024)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
this pr adjusts the constructor of `Sk.builtin.float_`

There are two motivations
1. in #828, I incorrectly asserted that an overflow error should be raised for large strings. But actually this is not the case 
```python
# python
float(str(2**1024)) # inf

# skulpt
float(str(2**1024)) # Overflow Error
```
Overflow Error should only be raised for large ints (in skulpt's case large longs)

2. returning inside a constructor stops a builtin from being subclassable. We were testing some instance of subclassing float but not all. e.g.
```python
>>> class MySimpleFloat(float): pass
>>> MySimpleFloat()
nan # failed because the constructor was doing... return new Sk.builtin.float_(0.0); rather than this.v = 0.0;
>>> MySimpleFloat('5')
nan # failed for a similar reason
```

---

- to fix 1 I move the `Overflow` error to `Sk.builtin.lng.prototype.nb$float_` and call `nb$float_` inside `Sk.builtin.float_` constructor. 
- to fix 2 I don't return inside the constructor and only set `this.v`


note we no longer need to lookup `__float__` since `nb$float_` is added upon `klass` creation.  