### PR TITLE
arrayFromIterable - (tuple suspension aware)

### DIFF
--- a/src/lib/itertools.js
+++ b/src/lib/itertools.js
@@ -175,20 +175,15 @@ var $builtinmodule = function (name) {
 
     var _combinations = function (iterable, r) {
         Sk.builtin.pyCheckArgsLen("combinations", arguments.length, 2, 2);
-        if (!Sk.builtin.checkIterable(iterable)) {
-            throw new Sk.builtin.TypeError(
-                "'" + Sk.abstr.typeName(iterable) + "' object is not iterable"
-            );
-        }
+        const pool = Sk.misceval.arrayFromIterable(iterable); // want pool as an array
         Sk.builtin.pyCheckType("r", "int", Sk.builtin.checkInt(r));
 
-        pool = new Sk.builtin.tuple(iterable).v; // want pool as an array
-        n = pool.length;
+        const n = pool.length;
         r = Sk.builtin.asnum$(r);
         if (r < 0) {
             throw new Sk.builtin.ValueError("r must be non-negative");
         }
-        indices = new Array(r).fill().map((_, i) => i);
+        const indices = new Array(r).fill().map((_, i) => i);
         return new Sk.builtin.itertools_gen(_combinations_gen, mod, [indices, pool, n, r]);
     };
 
@@ -238,14 +233,9 @@ var $builtinmodule = function (name) {
 
     var _combinations_with_replacement = function (iterable, r) {
         Sk.builtin.pyCheckArgsLen("combinations", arguments.length, 2, 2);
-        if (!Sk.builtin.checkIterable(iterable)) {
-            throw new Sk.builtin.TypeError(
-                "'" + Sk.abstr.typeName(iterable) + "' object is not iterable"
-            );
-        }
+        const pool = Sk.misceval.arrayFromIterable(iterable); // want pool as an array
         Sk.builtin.pyCheckType("r", "int", Sk.builtin.checkInt(r));
 
-        const pool = new Sk.builtin.tuple(iterable).v; // want pool as an array
         const n = pool.length;
         r = Sk.builtin.asnum$(r);
         if (r < 0) {
@@ -642,12 +632,7 @@ var $builtinmodule = function (name) {
 
     var _permutations = function (iterable, r) {
         Sk.builtin.pyCheckArgsLen("permutations", arguments.length, 1, 2);
-        if (!Sk.builtin.checkIterable(iterable)) {
-            throw new Sk.builtin.TypeError(
-                "'" + Sk.abstr.typeName(iterable) + "' object is not iterable"
-            );
-        }
-        const pool = new Sk.builtin.tuple(iterable).v; // want pool as an array
+        const pool = Sk.misceval.arrayFromIterable(iterable); // want pool as an array
         const n = pool.length;
         r = Sk.builtin.checkNone(r) ? new Sk.builtin.int_(n) : r;
         Sk.builtin.pyCheckType("r", "int", Sk.builtin.checkInt(r));
@@ -721,7 +706,7 @@ var $builtinmodule = function (name) {
                     "'" + Sk.abstr.typeName(args[i]) + "' object is not iterable"
                 );
             }
-            args[i] = new Sk.builtin.tuple(args[i]).v; // want each arg as an array
+            args[i] = Sk.misceval.arrayFromIterable(args[i]); // want each arg as an array
         }
         const pools = [].concat(...Array(repeat).fill(args)); // js equivalent to [arg for arg in args] * repeat
         const n = pools.length;

--- a/src/list.js
+++ b/src/list.js
@@ -5,49 +5,22 @@
  * @extends Sk.builtin.object
  */
 Sk.builtin.list = function (L, canSuspend) {
-    var v, it, thisList;
-    var canSusp;
-
-    if (this instanceof Sk.builtin.list) {
-        canSusp = canSuspend || false;
-    } else {
+    if (!(this instanceof Sk.builtin.list)) {
         // Called from Python
         Sk.builtin.pyCheckArgsLen("list", arguments.length, 0, 1);
         return new Sk.builtin.list(L, true);
     }
-
     if (L === undefined) {
-        v = [];
-    } else if (Object.prototype.toString.apply(L) === "[object Array]") {
-        v = L;
-    } else if (L.sk$asarray) {
-        v = L.sk$asarray();
-    } else if (Sk.builtin.checkIterable(L)) {
-        v = [];
-        it = Sk.abstr.iter(L);
-
-        thisList = this;
-
-        return (function next(i) {
-            while(true) {
-                if (i instanceof Sk.misceval.Suspension) {
-                    return new Sk.misceval.Suspension(next, i);
-                } else if (i === undefined) {
-                    // done!
-                    thisList.v = v;
-                    return thisList;
-                } else {
-                    v.push(i);
-                    i = it.tp$iternext(canSusp);
-                }
-            }
-        })(it.tp$iternext(canSusp));
+        this.v = [];
+    } else if (Array.isArray(L)) {
+        this.v = L;
     } else {
-        throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(L) + "' " + "object is not iterable");
+        const self = this;
+        return Sk.misceval.chain(Sk.misceval.arrayFromIterable(L, canSuspend), (v) => {
+            self.v = v;
+            return self;
+        });
     }
-
-    this.v = v;
-    return this;
 };
 
 Sk.abstr.setUpInheritance("list", Sk.builtin.list, Sk.builtin.seqtype);

--- a/src/list.js
+++ b/src/list.js
@@ -15,10 +15,9 @@ Sk.builtin.list = function (L, canSuspend) {
     } else if (Array.isArray(L)) {
         this.v = L;
     } else {
-        const self = this;
         return Sk.misceval.chain(Sk.misceval.arrayFromIterable(L, canSuspend), (v) => {
-            self.v = v;
-            return self;
+            this.v = v;
+            return this;
         });
     }
 };

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1161,6 +1161,35 @@ Sk.misceval.iterFor = function (iter, forFn, initialValue) {
 Sk.exportSymbol("Sk.misceval.iterFor", Sk.misceval.iterFor);
 
 /**
+ * @function
+ *
+ * @description
+ * Convert a Python iterable into a javascript array
+ *
+ * @param {*} iterable
+ * @param {boolean=} canSuspend - Can this function suspend
+ *
+ * @returns {!Array}
+ */
+Sk.misceval.arrayFromIterable = function (iterable, canSuspend) {
+    if (iterable === undefined) {
+        return [];
+    }
+    const hptype = iterable.hp$type || undefined;
+    if (hptype === undefined && iterable.sk$asarray !== undefined) {
+        // use sk$asarray only if we're a builtin
+        return iterable.sk$asarray();
+    }
+    const L = [];
+    const ret = Sk.misceval.chain(
+        Sk.misceval.iterFor(Sk.abstr.iter(iterable), (i) => {
+            L.push(i);
+        }),
+        () => L
+    );
+    return canSuspend ? ret : Sk.misceval.retryOptionalSuspensionOrThrow(ret);
+};
+/**
  * A special value to return from an iterFor() function,
  * to abort the iteration. Optionally supply a value for iterFor() to return
  * (defaults to 'undefined')

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -15,10 +15,9 @@ Sk.builtin.tuple = function (L, canSuspend) {
     } else if (Array.isArray(L)) {
         this.v = L;
     } else {
-        const self = this;
         return Sk.misceval.chain(Sk.misceval.arrayFromIterable(L, canSuspend), (v) => {
-            self.v = v;
-            return self;
+            this.v = v;
+            return this;
         });
     }
 };

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -1,31 +1,26 @@
 /**
  * @constructor
  * @param {Array.<Object>|Object} L
+ * @param {boolean=} canSuspend
  */
-Sk.builtin.tuple = function (L) {
-    var v, it, i;
+Sk.builtin.tuple = function (L, canSuspend) {
     if (!(this instanceof Sk.builtin.tuple)) {
+        // called from python
         Sk.builtin.pyCheckArgsLen("tuple", arguments.length, 0, 1);
-        return new Sk.builtin.tuple(L);
+        return new Sk.builtin.tuple(L, true);
     }
 
     if (L === undefined) {
-        v = [];
-    } else if (Object.prototype.toString.apply(L) === "[object Array]") {
-        v = L;
-    } else if (L.sk$asarray) {
-        v = L.sk$asarray();
-    } else if (Sk.builtin.checkIterable(L)) {
-        v = [];
-        for (it = Sk.abstr.iter(L), i = it.tp$iternext(); i !== undefined; i = it.tp$iternext()) {
-            v.push(i);
-        }
+        this.v = [];
+    } else if (Array.isArray(L)) {
+        this.v = L;
     } else {
-        throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(L) + "' " + "object is not iterable");
+        const self = this;
+        return Sk.misceval.chain(Sk.misceval.arrayFromIterable(L, canSuspend), (v) => {
+            self.v = v;
+            return self;
+        });
     }
-
-    this.v = v;
-    return this;
 };
 
 Sk.abstr.setUpInheritance("tuple", Sk.builtin.tuple, Sk.builtin.seqtype);

--- a/src/type.js
+++ b/src/type.js
@@ -255,6 +255,7 @@ Sk.builtin.type = function (name, bases, dict) {
         klass["__class__"] = klass;
         klass["__name__"] = name;
         klass.sk$klass = true;
+        klass.prototype.hp$type = true;
         klass.prototype["$r"] = function () {
             const reprf = Sk.abstr.lookupSpecial(this, Sk.builtin.str.$repr);
             if (reprf !== undefined && reprf !== Sk.builtin.object.prototype["__repr__"]) {

--- a/test/unit3/test_suspensions.py
+++ b/test/unit3/test_suspensions.py
@@ -42,6 +42,9 @@ class Test_Suspensions(unittest.TestCase):
         self.assertIs(sum(sleeping_gen([1, 2.0, 3])), 6.0)
         self.assertEqual(sum(sleeping_gen([[1], [2]]), []), [1, 2])
 
+    def test_builtin_types(self):
+        self.assertEqual(list(sleeping_gen([1, 2, 3])), [1, 2, 3])
+        self.assertEqual(tuple(sleeping_gen([1, 2, 3])), (1, 2, 3))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This Pr adds a helper function `Sk.misceval.arrayFromIterable`

it is suspension aware and uses the `sk$asarray` architecture from #1054  where possible.
The function will raise a `TypeError` if the object is not iterable.
As well as a suspension error if the iterator suspends but `canSuspend` is `undefined || false`

I adjust the constructors of `tuple` and `list` to use this function. 
This adjustment allows `tuple` to be suspension aware. (tests added in `test_suspensions.py`

I also identify a few places in `itertools` where this function is beneficial. 

`sk$asarray` is designed for builtins so I add the flag `hp$type` to all instance of `klass` objects and check this flag before using the `sk$asarray` architecture within `arrayFromIterable`. 

