### PR TITLE
don't set __module__ unless globals.__name__ exists

### DIFF
--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -152,9 +152,10 @@ $builtinmodule = function (name) {
         });
     };
 
+    mod.__name__ = new Sk.builtin.str('array');
+
     mod.array = Sk.misceval.buildClass(mod, array, "array", []);
 
-    mod.__name__ = new Sk.builtin.str('array');
 
     return mod;
 };

--- a/src/lib/document.js
+++ b/src/lib/document.js
@@ -1,6 +1,6 @@
 var $builtinmodule = function (name) {
     var elementClass;
-    var mod = {};
+    var mod = {__name__: new Sk.builtin.str("document")};
 
     mod.getElementById = new Sk.builtin.func(function (id) {
         var result = document.getElementById(id.v);

--- a/src/lib/image.js
+++ b/src/lib/image.js
@@ -10,7 +10,7 @@ $builtinmodule = function (name) {
     var screen;
     var pixel;
     var eImage;
-    var mod = {};
+    var mod = {__name__: new Sk.builtin.str("image")};
     var updateCanvasAndSuspend;
     var initializeImage;
     var checkPixelRange;

--- a/src/lib/processing.js
+++ b/src/lib/processing.js
@@ -22,7 +22,7 @@ var $builtinmodule = function (name) {
     var mouseClass;
     var vectorClass
 
-    var mod = {};
+    var mod = {__name__: new Sk.builtin.str("processing")};
     var imList = [];
     var looping = true;
     var instance = null;

--- a/src/lib/re.js
+++ b/src/lib/re.js
@@ -1,5 +1,5 @@
 var $builtinmodule = function (name) {
-    var mod = {};
+    var mod = {__name__: new Sk.builtin.str("re")};
 
     var validGroups, convert, getFlags, _split, _findall, matchobj, _search, _match, regexobj;
 

--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -16,7 +16,7 @@ function getConfiguredTarget() {
 }
 
 function generateTurtleModule(_target) {
-    var _module              = {},
+    var _module              = {__name__: new Sk.builtin.str("turtle")},
         _durationSinceRedraw = 0,
         _focus               = true,
         OPTIMAL_FRAME_RATE   = 1000/30,

--- a/src/lib/webgl/__init__.js
+++ b/src/lib/webgl/__init__.js
@@ -1,6 +1,6 @@
 var $builtinmodule = function(name)
 {
-  var mod = {};
+  var mod = {__name__: new Sk.builtin.str("webgl")};
 
   var makeFailHTML = function(msg) {
     return '' +

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1305,7 +1305,10 @@ Sk.misceval.buildClass = function (globals, func, name, bases, cell) {
     // new Syntax would be different
 
     // file's __name__ is class's __module__
-    locals.__module__ = globals["__name__"];
+    if (globals["__name__"]) {
+        // some js modules haven't set their module name and we shouldn't set a dictionary value to be undefined;
+        locals.__module__ = globals["__name__"];
+    }
     var _name = new Sk.builtin.str(name);
     var _bases = new Sk.builtin.tuple(bases);
     var _locals = [];


### PR DESCRIPTION
this pr makes a minor adjustment to `Sk.misceval.buildClass`

there are some cases in `lib` `js` files when the global object passed to `Sk.misceval.buildClass` does not have a `__name__` property. 

This is true of the `re.js` module for example. 
This might become problematic because when `locals.__module__` is set to `undefined` it will later create a dictionary where the `__module__` value is also `undefined`.

This hasn't caused issues in the codebase but I think it would be good to eliminate setting a value of a dictionary to be undefined. 
In cpython doing the equivalent of `mp$ass_subscript(key, undefined)` would be the equivalent of deleting that item from the dictionary. 

the `klass` `__module__` will be set to `Sk.globals.__name__` later anyway if it was not set in `locals`. 
