### PR TITLE
change object.prototype.$r to be more inline with python

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -51,6 +51,7 @@ Sk.builtin.str.$gt = new Sk.builtin.str("__gt__");
 Sk.builtin.str.$le = new Sk.builtin.str("__le__");
 Sk.builtin.str.$len = new Sk.builtin.str("__len__");
 Sk.builtin.str.$lt = new Sk.builtin.str("__lt__");
+Sk.builtin.str.$module = new Sk.builtin.str("__module__");
 Sk.builtin.str.$name = new Sk.builtin.str("__name__");
 Sk.builtin.str.$ne = new Sk.builtin.str("__ne__");
 Sk.builtin.str.$new = new Sk.builtin.str("__new__");

--- a/src/object.js
+++ b/src/object.js
@@ -361,7 +361,16 @@ Sk.builtin.object.prototype["__ge__"] = function (self, other) {
  * @return {Sk.builtin.str} The Python string representation of this instance.
  */
 Sk.builtin.object.prototype["$r"] = function () {
-    return new Sk.builtin.str("<object>");
+    const mod = Sk.abstr.lookupSpecial(this, Sk.builtin.str.$module);
+    let cname = "";
+    if (mod && Sk.builtin.checkString(mod)) {
+        cname = mod.v + ".";
+    }
+    return new Sk.builtin.str("<" + cname + Sk.abstr.typeName(this) + " object>");
+};
+
+Sk.builtin.object.prototype.tp$str = function () {
+    return this.$r();
 };
 
 Sk.builtin.hashCount = 1;

--- a/src/type.js
+++ b/src/type.js
@@ -256,26 +256,18 @@ Sk.builtin.type = function (name, bases, dict) {
         klass["__name__"] = name;
         klass.sk$klass = true;
         klass.prototype["$r"] = function () {
-            var cname;
-            var mod;
-            var reprf = this.tp$getattr(Sk.builtin.str.$repr);
-            if (reprf !== undefined && reprf.im_func !== Sk.builtin.object.prototype["__repr__"]) {
-                return Sk.misceval.apply(reprf, undefined, undefined, undefined, []);
+            const reprf = Sk.abstr.lookupSpecial(this, Sk.builtin.str.$repr);
+            if (reprf !== undefined && reprf !== Sk.builtin.object.prototype["__repr__"]) {
+                return Sk.misceval.callsimArray(reprf, [this]);
             }
 
             if ((klass.prototype.tp$base !== undefined) &&
-                (klass.prototype.tp$base !== Sk.builtin.object) &&
                 (klass.prototype.tp$base.prototype["$r"] !== undefined)) {
-                // If subclass of a builtin which is not object, use that class' repr
+                // If subclass of a builtin, use that class' repr
                 return klass.prototype.tp$base.prototype["$r"].call(this);
             } else {
-                // Else, use default repr for a user-defined class instance
-                mod = dict.mp$subscript(module_lk); // lookup __module__
-                cname = "";
-                if (mod) {
-                    cname = mod.v + ".";
-                }
-                return new Sk.builtin.str("<" + cname + _name + " object>");
+                // Else, use object repr for a user-defined class instance
+                return Sk.builtin.object.prototype["$r"].call(this);
             }
         };
 
@@ -299,9 +291,9 @@ Sk.builtin.type = function (name, bases, dict) {
         // __getattribute__, rather than checking on every tp$getattr() call
 
         klass.prototype.tp$str = function () {
-            var strf = this.tp$getattr(Sk.builtin.str.$str);
-            if (strf !== undefined && strf.im_func !== Sk.builtin.object.prototype["__str__"]) {
-                return Sk.misceval.apply(strf, undefined, undefined, undefined, []);
+            const strf = Sk.abstr.lookupSpecial(this, Sk.builtin.str.$str);
+            if (strf !== undefined && strf !== Sk.builtin.object.prototype["__str__"]) {
+                return Sk.misceval.callsimArray(strf, [this]);
             }
             if ((klass.prototype.tp$base !== undefined) &&
                 (klass.prototype.tp$base !== Sk.builtin.object) &&

--- a/src/type.js
+++ b/src/type.js
@@ -236,9 +236,8 @@ Sk.builtin.type = function (name, bases, dict) {
         klass.prototype.ob$type = Sk.builtin.type.makeIntoTypeObj(_name, klass);
 
         // set __module__ if not present (required by direct type(name, bases, dict) calls)
-        var module_lk = new Sk.builtin.str("__module__");
-        if(dict.mp$lookup(module_lk) === undefined) {
-            dict.mp$ass_subscript(module_lk, Sk.globals["__name__"]);
+        if(dict.mp$lookup(Sk.builtin.str.$module) === undefined) {
+            dict.mp$ass_subscript(Sk.builtin.str.$module, Sk.globals["__name__"]);
         }
 
         // copy properties into our klass object

--- a/src/type.js
+++ b/src/type.js
@@ -263,7 +263,7 @@ Sk.builtin.type = function (name, bases, dict) {
 
             if ((klass.prototype.tp$base !== undefined) &&
                 (klass.prototype.tp$base.prototype["$r"] !== undefined)) {
-                // If subclass of a builtin, use that class' repr
+                // use superclass $r
                 return klass.prototype.tp$base.prototype["$r"].call(this);
             } else {
                 // Else, use object repr for a user-defined class instance

--- a/test/run/t421.py.real
+++ b/test/run/t421.py.real
@@ -9,6 +9,6 @@
 {1: 2, 3: 4}
 ''
 'hello world'
-<object>
+<object object>
 <__main__.A object>
 custom repr

--- a/test/run/t421.py.real.force
+++ b/test/run/t421.py.real.force
@@ -9,6 +9,6 @@
 {1: 2, 3: 4}
 ''
 'hello world'
-<object>
+<object object>
 <__main__.A object>
 custom repr


### PR DESCRIPTION
this pr adjusts `object.prototype.$r`

It basically takes the `else` part of `klass.prototype.$r` and moves it to `object.prototype.$r`
which i think is more correct.

it adjusts a previous test
```python
>>> object()
<object object> # previously <object> in python this is <object object at 0x123...>
```

while i'm here I adjust `klass.prototype.$r` and `tp$str` to use `callsimArray`
As well as adding a constant `Sk.builtin.str.$module`
