### PR TITLE
adjust call signature and implementation of sssiter

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -293,9 +293,8 @@ Sk.builtin.list.prototype.list_subscript_ = function (index) {
         }
     } else if (index instanceof Sk.builtin.slice) {
         const ret = [];
-        const lst = this.v;
-        index.sssiter$(lst.length, (i) => {
-            ret.push(lst[i]);
+        index.sssiter$(this.v.length, (i) => {
+            ret.push(this.v[i]);
         });
         return new Sk.builtin.list(ret, false);
     }

--- a/src/list.js
+++ b/src/list.js
@@ -277,10 +277,8 @@ Sk.builtin.list.prototype.__contains__ = new Sk.builtin.func(function(self, item
  */
 
 Sk.builtin.list.prototype.list_subscript_ = function (index) {
-    var ret;
-    var i;
     if (Sk.misceval.isIndex(index)) {
-        i = Sk.misceval.asIndex(index);
+        let i = Sk.misceval.asIndex(index);
         if (typeof i !== "number") {
             throw new Sk.builtin.IndexError("cannot fit '" + Sk.abstr.typeName(index) + "' into an index-sized integer");
         }
@@ -294,9 +292,10 @@ Sk.builtin.list.prototype.list_subscript_ = function (index) {
             return this.v[i];
         }
     } else if (index instanceof Sk.builtin.slice) {
-        ret = [];
-        index.sssiter$(this, function (i, wrt) {
-            ret.push(wrt.v[i]);
+        const ret = [];
+        const lst = this.v;
+        index.sssiter$(lst.length, (i) => {
+            ret.push(lst[i]);
         });
         return new Sk.builtin.list(ret, false);
     }
@@ -305,12 +304,8 @@ Sk.builtin.list.prototype.list_subscript_ = function (index) {
 };
 
 Sk.builtin.list.prototype.list_ass_subscript_ = function (index, value) {
-    var i;
-    var j;
-    var tosub;
-    var indices;
     if (Sk.misceval.isIndex(index)) {
-        i = Sk.misceval.asIndex(index);
+        let i = Sk.misceval.asIndex(index);
         if (typeof i !== "number") {
             throw new Sk.builtin.IndexError("cannot fit '" + Sk.abstr.typeName(index) + "' into an index-sized integer");
         }
@@ -322,19 +317,19 @@ Sk.builtin.list.prototype.list_ass_subscript_ = function (index, value) {
             return;
         }
     } else if (index instanceof Sk.builtin.slice) {
-        indices = index.slice_indices_(this.v.length);
+        const indices = index.slice_indices_(this.v.length);
         if (indices[2] === 1) {
             this.list_ass_slice_(indices[0], indices[1], value);
         } else {
-            tosub = [];
-            index.sssiter$(this, function (i, wrt) {
+            const tosub = [];
+            index.sssiter$(this.v.length, (i) => {
                 tosub.push(i);
             });
-            j = 0;
+            let j = 0;
             if (tosub.length !== value.v.length) {
                 throw new Sk.builtin.ValueError("attempt to assign sequence of size " + value.v.length + " to extended slice of size " + tosub.length);
             }
-            for (i = 0; i < tosub.length; ++i) {
+            for (let i = 0; i < tosub.length; ++i) {
                 this.v.splice(tosub[i], 1, value.v[j]);
                 j += 1;
             }
@@ -346,13 +341,8 @@ Sk.builtin.list.prototype.list_ass_subscript_ = function (index, value) {
 };
 
 Sk.builtin.list.prototype.list_del_subscript_ = function (index) {
-    var offdir;
-    var dec;
-    var self;
-    var indices;
-    var i;
     if (Sk.misceval.isIndex(index)) {
-        i = Sk.misceval.asIndex(index);
+        let i = Sk.misceval.asIndex(index);
         if (i !== undefined) {
             if (i < 0) {
                 i = this.v.length + i;
@@ -361,15 +351,15 @@ Sk.builtin.list.prototype.list_del_subscript_ = function (index) {
             return;
         }
     } else if (index instanceof Sk.builtin.slice) {
-        indices = index.slice_indices_(this.v.length);
+        const indices = index.slice_indices_(this.v.length);
         if (indices[2] === 1) {
             this.list_del_slice_(indices[0], indices[1]);
         } else {
-            self = this;
-            dec = 0; // offset of removal for next index (because we'll have removed, but the iterator is giving orig indices)
-            offdir = indices[2] > 0 ? 1 : 0;
-            index.sssiter$(this, function (i, wrt) {
-                self.v.splice(i - dec, 1);
+            const lst = this.v;
+            let dec = 0; // offset of removal for next index (because we'll have removed, but the iterator is giving orig indices)
+            const offdir = indices[2] > 0 ? 1 : 0;
+            index.sssiter$(lst.length, (i) => {
+                lst.splice(i - dec, 1);
                 dec += offdir;
             });
         }

--- a/src/slice.js
+++ b/src/slice.js
@@ -161,23 +161,24 @@ Sk.builtin.slice.prototype["indices"] = new Sk.builtin.func(function (self, leng
     ]);
 });
 
-Sk.builtin.slice.prototype.sssiter$ = function (wrt, f) {
-    var i;
-    var wrtv = Sk.builtin.asnum$(wrt);
-    var sss = this.slice_indices_(typeof wrtv === "number" ? wrtv : wrt.v.length);
-    if (sss[2] > 0) {
-        for (i = sss[0]; i < sss[1]; i += sss[2]) {
-            if (f(i, wrtv) === false) {
-                return;
-            }
-        }	//	wrt or wrtv? RNL
+/**
+ * used by objects like str, list, tuple that can return a slice
+ * @param {number} len
+ * @param {Function} f
+ */
+Sk.builtin.slice.prototype.sssiter$ = function (len, f) {
+    const sss = this.slice_indices_(len);
+    const start = sss[0];
+    const stop = sss[1];
+    const step = sss[2];
+    if (step > 0) {
+        for (let i = start; i < stop; i += step) {
+            f(i);
+        }
     } else {
-        for (i = sss[0]; i > sss[1]; i += sss[2]) {
-            if (f(i, wrtv) === false) {
-                return;
-            }
-        }	//	wrt or wrtv? RNL
-
+        for (let i = start; i > stop; i += step) {
+            f(i);
+        }
     }
 };
 

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -67,9 +67,8 @@ Sk.builtin.tuple.prototype.mp$subscript = function (index) {
         }
     } else if (index instanceof Sk.builtin.slice) {
         const ret = [];
-        const lst = this.v;
-        index.sssiter$(lst.length, (i) => {
-            ret.push(lst[i]);
+        index.sssiter$(this.v.length, (i) => {
+            ret.push(this.v[i]);
         });
         return new Sk.builtin.tuple(ret);
     }

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -50,8 +50,7 @@ Sk.builtin.tuple.prototype["$r"] = function () {
 };
 
 Sk.builtin.tuple.prototype.mp$subscript = function (index) {
-    var ret;
-    var i;
+    let i;
     if (Sk.misceval.isIndex(index)) {
         i = Sk.misceval.asIndex(index);
         if (typeof i !== "number") {
@@ -67,9 +66,10 @@ Sk.builtin.tuple.prototype.mp$subscript = function (index) {
             return this.v[i];
         }
     } else if (index instanceof Sk.builtin.slice) {
-        ret = [];
-        index.sssiter$(this, function (i, wrt) {
-            ret.push(wrt.v[i]);
+        const ret = [];
+        const lst = this.v;
+        index.sssiter$(lst.length, (i) => {
+            ret.push(lst[i]);
         });
         return new Sk.builtin.tuple(ret);
     }


### PR DESCRIPTION
this pr aims to simplify `sssiter$` and make the function more readable.

it now takes two arguments
- `len - number`  (instead of a `length` or an `object` whose `v` property has a `length`) 
- `function` which expects javascript `index` at each iteration.
  (rather than using an argument `wrt` at each iteration (previously defined as the outcome of `Sk.builtin.asnum$(wrt)`), it instead relies on closure in the same way that `Sk.misceval.chain` would use closure.)

I don't think this is breaking since it's fairly obscure function buried in the core. Used for `str`, `tuple` and `list`

In the functions that use `sssiter$` I also adjust `const/let/var`
