### PR TITLE
frozenset hash

### DIFF
--- a/src/frozenset.js
+++ b/src/frozenset.js
@@ -61,6 +61,9 @@ Sk.builtin.frozenset.prototype["$r"] = function () {
     }
 };
 
+Sk.builtin.frozenset.prototype.sk$asarray = function () {
+    return this.v.sk$asarray();
+};
 Sk.builtin.frozenset.prototype.ob$eq = function (other) {
 
     if (this === other) {

--- a/src/frozenset.js
+++ b/src/frozenset.js
@@ -64,6 +64,22 @@ Sk.builtin.frozenset.prototype["$r"] = function () {
 Sk.builtin.frozenset.prototype.sk$asarray = function () {
     return this.v.sk$asarray();
 };
+
+Sk.builtin.frozenset.prototype.tp$hash = function () {
+    // numbers taken from Cpython 2.7 hash function
+    let hash = 1927868237;
+    const entries = this.sk$asarray();
+    hash *= entries.length + 1;
+    for (let i = 0; i < entries.length; i++) {
+        const h = Sk.builtin.hash(entries[i]).v;
+        hash ^= (h ^ (h << 16) ^ 89869747) * 3644798167;
+    }
+    hash = hash * 69069 + 907133923;
+    hash = new Sk.builtin.int_(hash);
+    this.$savedHash_ = hash;
+    return hash;
+};
+
 Sk.builtin.frozenset.prototype.ob$eq = function (other) {
 
     if (this === other) {

--- a/src/set.js
+++ b/src/set.js
@@ -63,6 +63,10 @@ Sk.builtin.set.prototype["$r"] = function () {
     }
 };
 
+Sk.builtin.set.prototype.sk$asarray = function () {
+    return this.v.sk$asarray();
+};
+
 Sk.builtin.set.prototype.ob$eq = function (other) {
 
     if (this === other) {

--- a/test/unit3/test_frozenset.py
+++ b/test/unit3/test_frozenset.py
@@ -1,5 +1,7 @@
 """ Unit testing for frozensets (2)"""
 import unittest
+from random import randrange, shuffle
+
 
 s = frozenset(range(9))
 s1 = frozenset(range(5))
@@ -181,6 +183,44 @@ class FrozenSetTests(unittest.TestCase):
         self.assertRaises(TypeError, lambda: a | c)
         self.assertRaises(TypeError, lambda: a ^ c)
         self.assertRaises(TypeError, lambda: a - c)
+
+
+    thetype = frozenset
+    def test_hash(self):
+        self.assertEqual(hash(self.thetype('abcdeb')),
+                         hash(self.thetype('ebecda')))
+
+        # make sure that all permutations give the same hash value
+        n = 100
+        seq = [randrange(n) for i in range(n)]
+        results = set()
+        for i in range(200):
+            shuffle(seq)
+            results.add(hash(self.thetype(seq)))
+        self.assertEqual(len(results), 1)
+
+    def test_frozen_as_dictkey(self):
+        seq = list(range(10)) + list('abcdefg') + ['apple']
+        key1 = self.thetype(seq)
+        key2 = self.thetype(reversed(seq))
+        self.assertEqual(key1, key2)
+        self.assertNotEqual(id(key1), id(key2))
+        d = {}
+        d[key1] = 42
+        self.assertEqual(d[key2], 42)
+
+    def test_hash_caching(self):
+        f = self.thetype('abcdcda')
+        self.assertEqual(hash(f), hash(f))
+
+    def test_hash_effectiveness(self):
+        n = 13
+        hashvalues = set()
+        addhashvalue = hashvalues.add
+        elemmasks = [(i+1, 1<<i) for i in range(n)]
+        for i in range(2**n):
+            addhashvalue(hash(frozenset([e for e, m in elemmasks if m&i])))
+        self.assertEqual(len(hashvalues), 2**n)
    
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Builtin on top of #1091**

I built this ontop of #1091 since it relies on `Sk.builtin.dict` having an `sk$asarray` method which that pr adds. 

I also add the `sk$asarray` method to `frozenset` and `set`


One of the benefits of a `frozenset` is that it is `hashable`. But in order to be `keys` of a `dict` the `hash` function must be consistent. 

This pr takes the general approach of python 2.7 https://github.com/python/cpython/blob/8d21aa21f2cbc6d50aab3f420bb23be1d081dac4/Objects/setobject.c#L775

Mostly because it was easier to follow 🤷‍♂️ 

I add the relevant tests from `python3` that test the `frozenset` `hash` function being consistent...

For the diff see https://github.com/s-cork/skulpt/pull/6