### PR TITLE
fix error message regression

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -25,7 +25,7 @@ Sk.builtin.BaseException = function (...args) {
     // If args[0] is a string then we're an internal call
     if (typeof args[0] === "string") {
         this.args = new Sk.builtin.tuple([new Sk.builtin.str(args[0])]);
-        if (args.length === 3) {
+        if (args.length >= 3) {
             // For errors occurring during normal execution, the line/col/etc
             // of the error are populated by each stack frame of the runtime code,
             // but we can seed it with the supplied parameters.


### PR DESCRIPTION
I introduced a regression - not realising there are two occasions when the internally called `SyntaxError` has 4 arguments. 

This very minor adjustment fixes that regression. 

I think this should be a quick merge.

```python
print 'foo'

# regression
# SyntaxError: bad input at <unkown>
# previously 
# SyntaxError: bad input on line 1
```
