### PR TITLE
combine #989 #983

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -2651,9 +2651,12 @@ function parsestrplus (c, n) {
             let r = parsestr(c, CHILD(n, i).value);
             str = r[0];
             fmode = r[1];
+            this_bytesmode = r[2];
         } catch (e) {
             if (e instanceof Sk.builtin.SyntaxError) {
-                ast_error(c, CHILD(n, i), e.tp$str().v); 
+                ast_error(c, CHILD(n, i), e.tp$str().v);
+            } else {
+                ast_error(c, CHILD(n, i), "invalid string (possibly contains a unicode character)");
             }
             throw new Sk.builtin.SyntaxError("invalid string (possibly contains a unicode character)", c.c_filename, CHILD(n, i).lineno);
         }

--- a/src/ast.js
+++ b/src/ast.js
@@ -2647,8 +2647,10 @@ function parsestrplus (c, n) {
     let bytesmode;
 
     for (let i = 0; i < NCH(n); ++i) {
+        let chstr = CHILD(n, i).value;
+        let str, fmode, this_bytesmode;
         try {
-            let r = parsestr(c, CHILD(n, i).value);
+            let r = parsestr(c, CHILD(n,i), chstr);
             str = r[0];
             fmode = r[1];
             this_bytesmode = r[2];
@@ -2658,7 +2660,6 @@ function parsestrplus (c, n) {
             } else {
                 ast_error(c, CHILD(n, i), "invalid string (possibly contains a unicode character)");
             }
-            throw new Sk.builtin.SyntaxError("invalid string (possibly contains a unicode character)", c.c_filename, CHILD(n, i).lineno);
         }
 
         /* Check that we're not mixing bytes with unicode. */

--- a/src/ast.js
+++ b/src/ast.js
@@ -2246,7 +2246,7 @@ function astForIfexpr (c, n) {
  * s is a python-style string literal, including quote characters and u/r/b
  * prefixes. Returns [decoded string object, is-an-fstring]
  */
-function parsestr (c, s) {
+function parsestr (c, n, s) {
     var encodeUtf8 = function (s) {
         return unescape(encodeURIComponent(s));
     };
@@ -2258,70 +2258,79 @@ function parsestr (c, s) {
         var d2;
         var d1;
         var d0;
-        var c;
+        var ch;
         var i;
         var len = s.length;
         var ret = "";
         for (i = 0; i < len; ++i) {
-            c = s.charAt(i);
-            if (c === "\\") {
+            ch = s.charAt(i);
+            if (ch === "\\") {
                 ++i;
-                c = s.charAt(i);
-                if (c === "n") {
+                ch = s.charAt(i);
+                if (ch === "n") {
                     ret += "\n";
                 }
-                else if (c === "\\") {
+                else if (ch === "\\") {
                     ret += "\\";
                 }
-                else if (c === "t") {
+                else if (ch === "t") {
                     ret += "\t";
                 }
-                else if (c === "r") {
+                else if (ch === "r") {
                     ret += "\r";
                 }
-                else if (c === "b") {
+                else if (ch === "b") {
                     ret += "\b";
                 }
-                else if (c === "f") {
+                else if (ch === "f") {
                     ret += "\f";
                 }
-                else if (c === "v") {
+                else if (ch === "v") {
                     ret += "\v";
                 }
-                else if (c === "0") {
+                else if (ch === "0") {
                     ret += "\0";
                 }
-                else if (c === '"') {
+                else if (ch === '"') {
                     ret += '"';
                 }
-                else if (c === '\'') {
+                else if (ch === '\'') {
                     ret += '\'';
                 }
-                else if (c === "\n") /* escaped newline, join lines */ {
+                else if (ch === "\n") /* escaped newline, join lines */ {
                 }
-                else if (c === "x") {
-                    d0 = s.charAt(++i);
-                    d1 = s.charAt(++i);
-                    ret += encodeUtf8(String.fromCharCode(parseInt(d0 + d1, 16)));
+                else if (ch === "x") {
+                    if (i+2 >= len) {
+                        ast_error(c, n, "Truncated \\xNN escape");
+                    }
+                    ret += String.fromCharCode(parseInt(s.substr(i+1,2), 16));
+                    i += 2;
                 }
-                else if (c === "u" || c === "U") {
-                    d0 = s.charAt(++i);
-                    d1 = s.charAt(++i);
-                    d2 = s.charAt(++i);
-                    d3 = s.charAt(++i);
-                    ret += encodeUtf8(String.fromCharCode(parseInt(d0 + d1, 16), parseInt(d2 + d3, 16)));
+                else if (ch === "u") {
+                    if (i+4 >= len) {
+                        ast_error(c, n, "Truncated \\uXXXX escape");
+                    }
+                    ret += String.fromCharCode(parseInt(s.substr(i+1, 4), 16))
+                    i += 4;
+                }
+                else if (ch === "U") {
+                    if (i+8 >= len) {
+                        ast_error(c, n, "Truncated \\UXXXXXXXX escape");
+                    }
+                    ret += String.fromCodePoint(parseInt(s.substr(i+1, 8), 16))
+                    i += 8;
                 }
                 else {
                     // Leave it alone
-                    ret += "\\" + c;
-                    // Sk.asserts.fail("unhandled escape: '" + c.charCodeAt(0) + "'");
+                    ret += "\\" + ch;
+                    // Sk.asserts.fail("unhandled escape: '" + ch.charCodeAt(0) + "'");
                 }
             }
             else {
-                ret += c;
+                ret += ch;
             }
         }
-        return decodeUtf8(ret);
+        return ret;
     };
 
     //console.log("parsestr", s);
@@ -2331,6 +2340,7 @@ function parsestr (c, s) {
     var unicode = false;
     var bytes = false;
     var fmode = false;
+    var bytesmode = false;
 
     // treats every sequence as unicodes even if they are not treated with uU prefix
     // kinda hacking though working for most purposes
@@ -2348,7 +2358,7 @@ function parsestr (c, s) {
             rawmode = true;
         }
         else if (quote === "b" || quote === "B") {
-            bytes = true;
+            bytesmode = true;
         }
         else if (quote === "f" || quote === "F") {
             fmode = true;
@@ -2362,9 +2372,6 @@ function parsestr (c, s) {
 
     Sk.asserts.assert(quote === "'" || quote === '"' && s.charAt(s.length - 1) === quote);
     s = s.substr(1, s.length - 2);
-    if (unicode) {
-        s = encodeUtf8(s);
-    }
 
     if (s.length >= 4 && s.charAt(0) === quote && s.charAt(1) === quote) {
         Sk.asserts.assert(s.charAt(s.length - 1) === quote && s.charAt(s.length - 2) === quote);
@@ -2372,18 +2379,9 @@ function parsestr (c, s) {
     }
 
     if (rawmode || s.indexOf("\\") === -1) {
-        if (bytes && Sk.__future__.python3) {
-            return [bytesobj(decodeUtf8(s)), fmode];
-        } else {
-            return [strobj(decodeUtf8(s)), fmode];
-        }
+        return [strobj(s), fmode, bytesmode];
     }
-
-    if (bytes && Sk.__future__.python3) {
-        return [bytesobj(decodeEscape(s, quote)), fmode];
-    } else {
-        return [strobj(decodeEscape(s, quote)), fmode];
-    }
+    return [strobj(decodeEscape(s, quote)), fmode, bytesmode];
 }
 
 function fstring_compile_expr(str, expr_start, expr_end, c, n) {
@@ -2635,21 +2633,35 @@ function fstring_parse(str, start, end, raw, recurse_lvl, c, n) {
 function parsestrplus (c, n) {
     let strs = [];
     let lastStrNode;
+    let bytesmode;
 
     for (let i = 0; i < NCH(n); ++i) {
         let chstr = CHILD(n, i).value;
-        let str, fmode;
+        let str, fmode, this_bytesmode;
         try {
-            let r = parsestr(c, chstr);
+            let r = parsestr(c, CHILD(n,i), chstr);
             str = r[0];
             fmode = r[1];
+            this_bytesmode = r[2];
         } catch (x) {
-            throw new Sk.builtin.SyntaxError("invalid string (possibly contains a unicode character)", c.c_filename, CHILD(n, i).lineno);
+            if (x instanceof Sk.builtin.SyntaxError) {
+                throw x;
+            } else {
+                throw new Sk.builtin.SyntaxError("invalid string (possibly contains a unicode character)", c.c_filename, CHILD(n, i).lineno);
+            }
         }
+
+        /* Check that we're not mixing bytes with unicode. */
+        if (i != 0 && bytesmode !== this_bytesmode) {
+            ast_error(c, n, "cannot mix bytes and nonbytes literals");
+        }
+        bytesmode = this_bytesmode;
+
         if (fmode) {
             if (!Sk.__future__.python3) {
                 throw new Sk.builtin.SyntaxError("invalid string (f-strings are not supported in Python 2)", c.c_filename, CHILD(n, i).lineno);
             }
+
             let jss = str.$jsstr();
             let [astnode, _] = fstring_parse(jss, 0, jss.length, false, 0, c, CHILD(n, i));
             strs.push.apply(strs, astnode.values);
@@ -2658,7 +2670,8 @@ function parsestrplus (c, n) {
             if (lastStrNode) {
                 lastStrNode.s = lastStrNode.s.sq$concat(str);
             } else {
-                lastStrNode = new Sk.astnodes.Str(str, LINENO(n), n.col_offset, c.end_lineno, n.end_col_offset)
+                let type = bytesmode ? Sk.astnodes.Bytes : Sk.astnodes.Str;
+                lastStrNode = new type(str, LINENO(n), n.col_offset, c.end_lineno, n.end_col_offset)
                 strs.push(lastStrNode);
             }
         }

--- a/src/ast.js
+++ b/src/ast.js
@@ -82,7 +82,7 @@ function strobj (s) {
 
 function bytesobj (s) {
     Sk.asserts.assert(typeof s === "string", "expecting string, got " + (typeof s));
-    return new Sk.builtin.bytes(s, Sk.builtin.str.$ascii);
+    return new Sk.builtin.bytes(new Sk.builtin.str(s), Sk.builtin.str.$ascii);
 }
 
 /** @return {number} */

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -605,12 +605,13 @@ Sk.builtin.fabs = function fabs(x) {
 Sk.builtin.ord = function ord (x) {
     Sk.builtin.pyCheckArgsLen("ord", arguments.length, 1, 1);
 
-    if (!Sk.builtin.checkString(x)) {
+    if (!Sk.builtin.checkString(x) && !Sk.builtin.checkBytes(x)) {
         throw new Sk.builtin.TypeError("ord() expected a string of length 1, but " + Sk.abstr.typeName(x) + " found");
-    } else if (x.v.length !== 1) {
+    } else if (x.v.length !== 1 && x.sq$length() !== 1) {
+        // ^^ avoid the astral check unless necessary ^^
         throw new Sk.builtin.TypeError("ord() expected a character, but string of length " + x.v.length + " found");
     }
-    return new Sk.builtin.int_(x.v.charCodeAt(0));
+    return new Sk.builtin.int_((x.v).codePointAt(0));
 };
 
 Sk.builtin.chr = function chr (x) {
@@ -621,11 +622,17 @@ Sk.builtin.chr = function chr (x) {
     x = Sk.builtin.asnum$(x);
 
 
-    if ((x < 0) || (x > 255)) {
-        throw new Sk.builtin.ValueError("chr() arg not in range(256)");
+    if (Sk.__future__.python3) {
+        if ((x < 0) || (x >= 0x110000)) {
+            throw new Sk.builtin.ValueError("chr() arg not in range(0x110000)");
+        }
+    } else {
+        if ((x < 0) || (x >= 256)) {
+            throw new Sk.builtin.ValueError("chr() arg not in range(256)");
+        }
     }
 
-    return new Sk.builtin.str(String.fromCharCode(x));
+    return new Sk.builtin.str(String.fromCodePoint(x));
 };
 
 Sk.builtin.unichr = function unichr (x) {

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -611,7 +611,7 @@ Sk.builtin.ord = function ord (x) {
         // ^^ avoid the astral check unless necessary ^^
         throw new Sk.builtin.TypeError("ord() expected a character, but string of length " + x.v.length + " found");
     }
-    return new Sk.builtin.int_((x.v).codePointAt(0));
+    return new Sk.builtin.int_(x.v.codePointAt(0));
 };
 
 Sk.builtin.chr = function chr (x) {

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -604,14 +604,19 @@ Sk.builtin.fabs = function fabs(x) {
 
 Sk.builtin.ord = function ord (x) {
     Sk.builtin.pyCheckArgsLen("ord", arguments.length, 1, 1);
-
-    if (!Sk.builtin.checkString(x) && !Sk.builtin.checkBytes(x)) {
-        throw new Sk.builtin.TypeError("ord() expected a string of length 1, but " + Sk.abstr.typeName(x) + " found");
-    } else if (x.v.length !== 1 && x.sq$length() !== 1) {
-        // ^^ avoid the astral check unless necessary ^^
-        throw new Sk.builtin.TypeError("ord() expected a character, but string of length " + x.v.length + " found");
+    if (Sk.builtin.checkString(x)) {
+        if (x.v.length !== 1 && x.sq$length() !== 1) {
+            // ^^ avoid the astral check unless necessary ^^
+            throw new Sk.builtin.TypeError("ord() expected a character, but string of length " + x.v.length + " found");
+        }
+        return new Sk.builtin.int_(x.v.codePointAt(0));
+    } else if (Sk.builtin.checkBytes(x)) {
+        if (x.sq$length() !== 1) {
+            throw new Sk.builtin.TypeError("ord() expected a character, but string of length " + x.v.length + " found");
+        }
+        return new Sk.builtin.int_(x.v[0]);
     }
-    return new Sk.builtin.int_(x.v.codePointAt(0));
+    throw new Sk.builtin.TypeError("ord() expected a string of length 1, but " + Sk.abstr.typeName(x) + " found");
 };
 
 Sk.builtin.chr = function chr (x) {

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -123,6 +123,7 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["xrange"];
         delete Sk.builtins["StandardError"];
         delete Sk.builtins["unicode"];
+        delete Sk.builtins["basestring"];
         Sk.builtins["bytes"] = Sk.builtin.bytes;
         delete Sk.builtin.str.prototype.decode;
     } else {
@@ -133,6 +134,7 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["xrange"] = new Sk.builtin.func(Sk.builtin.xrange);
         Sk.builtins["StandardError"] = Sk.builtin.Exception;
         Sk.builtins["unicode"] = Sk.builtin.str;
+        Sk.builtins["basestring"] = Sk.builtin.str;
         delete Sk.builtins["bytes"];
     }
 };

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -125,7 +125,6 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["unicode"];
         delete Sk.builtins["basestring"];
         Sk.builtins["bytes"] = Sk.builtin.bytes;
-        delete Sk.builtin.str.prototype.decode;
         Sk.builtins["ascii"] = new Sk.builtin.func(Sk.builtin.ascii);
     } else {
         Sk.builtins["filter"] = new Sk.builtin.func(Sk.builtin.filter);
@@ -137,7 +136,6 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["unicode"] = Sk.builtin.str;
         Sk.builtins["basestring"] = Sk.builtin.str;
         delete Sk.builtins["bytes"];
-        Sk.builtin.str.prototype.decode = Sk.builtin.bytes.prototype.decode;
         delete Sk.builtins["ascii"];
     }
 };

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -123,6 +123,8 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["xrange"];
         delete Sk.builtins["StandardError"];
         delete Sk.builtins["unicode"];
+        Sk.builtins["bytes"] = Sk.builtin.bytes;
+        delete Sk.builtin.str.prototype.decode;
     } else {
         Sk.builtins["filter"] = new Sk.builtin.func(Sk.builtin.filter);
         Sk.builtins["map"] = new Sk.builtin.func(Sk.builtin.map);
@@ -131,9 +133,7 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["xrange"] = new Sk.builtin.func(Sk.builtin.xrange);
         Sk.builtins["StandardError"] = Sk.builtin.Exception;
         Sk.builtins["unicode"] = Sk.builtin.str;
-        if (Sk.builtins["bytes"]) {
-            delete Sk.builtins["bytes"];
-        }
+        delete Sk.builtins["bytes"];
     }
 };
 Sk.exportSymbol("Sk.setupObjects", Sk.setupObjects);

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -124,6 +124,7 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["StandardError"];
         delete Sk.builtins["unicode"];
         delete Sk.builtins["basestring"];
+        delete Sk.builtin.str.decode;
         Sk.builtins["bytes"] = Sk.builtin.bytes;
         Sk.builtins["ascii"] = new Sk.builtin.func(Sk.builtin.ascii);
     } else {
@@ -135,6 +136,7 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["StandardError"] = Sk.builtin.Exception;
         Sk.builtins["unicode"] = Sk.builtin.str;
         Sk.builtins["basestring"] = Sk.builtin.str;
+        Sk.builtin.str.decode = Sk.builtin.str.$py2decode;
         delete Sk.builtins["bytes"];
         delete Sk.builtins["ascii"];
     }

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -126,6 +126,7 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["basestring"];
         Sk.builtins["bytes"] = Sk.builtin.bytes;
         delete Sk.builtin.str.prototype.decode;
+        Sk.builtins["ascii"] = new Sk.builtin.func(Sk.builtin.ascii);
     } else {
         Sk.builtins["filter"] = new Sk.builtin.func(Sk.builtin.filter);
         Sk.builtins["map"] = new Sk.builtin.func(Sk.builtin.map);
@@ -136,6 +137,8 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["unicode"] = Sk.builtin.str;
         Sk.builtins["basestring"] = Sk.builtin.str;
         delete Sk.builtins["bytes"];
+        Sk.builtin.str.prototype.decode = Sk.builtin.bytes.prototype.decode;
+        delete Sk.builtins["ascii"];
     }
 };
 Sk.exportSymbol("Sk.setupObjects", Sk.setupObjects);

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -78,6 +78,9 @@ Sk.builtin.bytes.prototype.__class__ = Sk.builtin.bytes;
 function strEncode(pyStr, encoding, errors) {
     const source = pyStr.$jsstr();
     encoding = normalizeEncoding(encoding);
+    if (!(errors === "strict" || errors === "ignore" || errors === "replace")) {
+        throw new Sk.builtin.NotImplementedError("'" + errors + "' error handling not implemented in Skulpt");
+    }
     let uint8;
     if (encoding === "ascii") {
         uint8 = encodeAscii(source, errors);

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -115,6 +115,8 @@ function tp$new(args) {
     if (args.length <= 1) {
         pySource = args[0];
     } else {
+        // either encoding is a py object or errors is a py object - currently kwargs not supported
+        // will fail if encoding is not a string || errors is not a string || pySource is not a string
         [pySource, encoding, errors] = args;
         encoding = encoding || null;
         errors = errors || null;

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -64,7 +64,9 @@ Sk.builtin.bytes = function (source) {
     } else if (typeof source === "number") {
         this.v = new Uint8Array(source);
     } else {
-        Sk.asserts.fail("got a " + Sk.abstr.typeName(source));
+        // fall through case for subclassing called by Sk.abstr.superConstructor
+        const bytes_obj = tp$new([...arguments]);
+        this.v = bytes_obj.v;
     }
 };
 

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -48,7 +48,7 @@ Sk.builtin.bytes = function (source) {
     if (!(this instanceof Sk.builtin.bytes)) {
         // called from python
         Sk.builtin.pyCheckArgsLen("bytes", arguments.length, 0, 3);
-        return tp$new([...arguments]);
+        return newBytesFromPy(...arguments);
     }
 
     // deal with internal calls
@@ -65,7 +65,7 @@ Sk.builtin.bytes = function (source) {
         this.v = new Uint8Array(source);
     } else {
         // fall through case for subclassing called by Sk.abstr.superConstructor
-        const bytes_obj = tp$new([...arguments]);
+        const bytes_obj = newBytesFromPy(...arguments);
         this.v = bytes_obj.v;
     }
 };
@@ -106,7 +106,7 @@ function encodeAscii(source, errors) {
     return Uint8ArrayFromArray(data);
 }
 
-function tp$new(args) {
+function newBytesFromPy(...args) {
     let source,
         pySource,
         dunderBytes,
@@ -242,8 +242,10 @@ Sk.builtin.bytes.prototype["$r"] = function () {
 };
 
 Sk.builtin.bytes.prototype.mp$subscript = function (index) {
+    var ret;
+    var i;
     if (Sk.misceval.isIndex(index)) {
-        let i = Sk.misceval.asIndex(index);
+        i = Sk.misceval.asIndex(index);
         if (i !== undefined) {
             if (i < 0) {
                 i = this.v.byteLength + i;
@@ -254,7 +256,7 @@ Sk.builtin.bytes.prototype.mp$subscript = function (index) {
             return new Sk.builtin.int_(this.v[i]);
         }
     } else if (index instanceof Sk.builtin.slice) {
-        const ret = [];
+        ret = [];
         index.sssiter$(this.v.byteLength, (i) => {
             ret.push(this.v[i]);
         });

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -867,7 +867,7 @@ Sk.builtin.bytes.prototype["rpartition"] = new Sk.builtin.func(function (self, s
     if (val === -1) {
         final1 = new Sk.builtin.bytes(0);
         final2 = new Sk.builtin.bytes(0);
-        final3 = new Sk.builtin.bytes(self);
+        final3 = self;
         return new Sk.builtin.tuple([final1, final2, final3]);
 
     }
@@ -1568,7 +1568,7 @@ Sk.builtin.bytes.prototype["splitlines"] = new Sk.builtin.func(function (self, k
                 eol = i;
             }
 
-            final.push(Sk.builtin.bytes(self.v.subarray(sol, eol)));
+            final.push(new Sk.builtin.bytes(self.v.subarray(sol, eol)));
 
             sol = rn ? i + 2 : i + 1;
             i = sol;
@@ -1579,7 +1579,7 @@ Sk.builtin.bytes.prototype["splitlines"] = new Sk.builtin.func(function (self, k
                 eol = i;
             }
 
-            final.push(Sk.builtin.bytes(self.v.subarray(sol, eol)));
+            final.push(new Sk.builtin.bytes(self.v.subarray(sol, eol)));
 
             sol = i + 1;
             i = sol;
@@ -1589,7 +1589,7 @@ Sk.builtin.bytes.prototype["splitlines"] = new Sk.builtin.func(function (self, k
     }
 
     if (sol < self.v.byteLength) {
-        final.push(Sk.builtin.bytes(self.v.subarray(sol, self.v.byteLength)));
+        final.push(new Sk.builtin.bytes(self.v.subarray(sol, self.v.byteLength)));
     }
 
     return new Sk.builtin.list(final);

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -202,6 +202,8 @@ function makehexform(num) {
 };
 
 Sk.builtin.bytes.prototype.$jsstr = function () {
+    // returns bytes string - not a bidirectional conversion - use with caution
+    // i.e. new Sk.builtin.bytes(x.$jsstr()).v  is different to x.v;
     let ret = "";
     for (let i = 0; i <= this.v.byteLength; i++) {
         ret += String.fromCharCode(this.v[i]);

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -8,7 +8,7 @@ const supportedEncodings = {
     "ascii": "ascii"
 };
 
-function normalizeEncoding (encoding) {
+function normalizeEncoding(encoding) {
     const normalized = encoding.replace(/\s+/g, "").toLowerCase();
     const supported = supportedEncodings[normalized];
     if (supported === undefined) {
@@ -20,7 +20,11 @@ function normalizeEncoding (encoding) {
 
 // Stop gap until Uint8Array.from (or new Uint8Array(iterable)) gets wider support
 // This only handles the simple case used in this file
-function Uint8ArrayFromArray (source) {
+function Uint8ArrayFromArray(source) {
+    if (Uint8Array.from) {
+        return Uint8Array.from(source);
+    }
+
     const uarr = new Uint8Array(source.length);
 
     for (let idx = 0; idx < source.length; idx++) {
@@ -142,7 +146,7 @@ Sk.builtin.bytes = function (source, encoding, errors) {
     return this;
 };
 
-function makehexform (num) {
+function makehexform(num) {
     var leading;
     if (num <= 265) {
         leading = "\\x";
@@ -483,7 +487,7 @@ Sk.builtin.bytes.prototype["hex"] = new Sk.builtin.func(function (self) {
     return new Sk.builtin.str(final);
 });
 
-function indices (self, start, end) {
+function indices(self, start, end) {
     if (start === undefined) {
         start = 0;
     } else if (!Sk.misceval.isIndex(start)) {

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -162,10 +162,10 @@ function newBytesFromPy(pySource, encoding, errors) {
     } else if (Sk.builtin.checkIterable(pySource)) {
         source = [];
         const r = Sk.misceval.iterFor(Sk.abstr.iter(pySource), (byte) => {
-            if (!Sk.builtin.checkInt(byte)) {
+            if (!Sk.misceval.isIndex(byte)) {
                 throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(byte) + "' object cannot be interpreted as an integer");
             };
-            const n = Sk.builtin.asnum$(byte);
+            const n = Sk.misceval.asIndex(byte);
             if (n < 0 || n > 255) {
                 throw new Sk.builtin.ValueError("bytes must be in range(0, 256)");
             }

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -64,10 +64,12 @@ Sk.builtin.bytes = function (source, encoding, errors) {
         this.v = new Uint8Array(source);
     } else {
         // fall through case for subclassing called by Sk.abstr.superConstructor
-        return Sk.misceval.chain(newBytesFromPy(...arguments), (pyBytes) => {
+        const ret = Sk.misceval.chain(newBytesFromPy(...arguments), (pyBytes) => {
             this.v = pyBytes.v;
             return this;
         });
+        // Sk.abstr.superConstructor is not suspension aware
+        return Sk.misceval.retryOptionalSuspensionOrThrow(ret);
     }
 };
 

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -38,18 +38,16 @@ function Uint8ArrayFromArray(source) {
 
 /**
  * @constructor
- * @param {*} source
- * @param {Sk.builtin.str=} encoding
- * @param {Sk.builtin.str=} errors
+ * @param {*} source Using constructor with new should be a js object
+ * @param {Sk.builtin.str=} encoding Only called from python
+ * @param {Sk.builtin.str=} errors Only called from python
  * @return {Sk.builtin.bytes}
- * @extends Sk.builtin.object
+ * @extends {Sk.builtin.object}
  */
 Sk.builtin.bytes = function (source) {
     if (!(this instanceof Sk.builtin.bytes)) {
         // called from python
         Sk.builtin.pyCheckArgsLen("bytes", arguments.length, 0, 3);
-        return tp$new([...arguments]);
-    } else if (arguments.length > 1) {
         return tp$new([...arguments]);
     }
 

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -97,7 +97,7 @@ Sk.builtin.bytes.$strEncode = strEncode;
 function encodeAscii(source, errors) {
     const data = [];
     for (let i in source) {
-        const val = source[i].charCodeAt(0);
+        const val = source.charCodeAt(i);
         if (val < 0 || val > 127) {
             if (errors === "strict") {
                 const hexval = makehexform(val);

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -198,7 +198,11 @@ function makehexform(num) {
 };
 
 Sk.builtin.bytes.prototype.$jsstr = function () {
-    return Decoder.decode(this.v);
+    let ret = "";
+    for (let i = 0; i <= this.v.byteLength; i++) {
+        ret += String.fromCharCode(this.v[i]);
+    }
+    return ret;
 };
 
 Sk.builtin.bytes.prototype["$r"] = function () {
@@ -298,7 +302,7 @@ function slotCompareUint8(f) {
         if (!(other instanceof Sk.builtin.bytes)) {
             return Sk.builtin.NotImplemented.NotImplemented$;
         }
-        return f(this.v, other.v);
+        return f(this.$jsstr(), other.$jsstr());
     };
 }
 Sk.builtin.bytes.prototype.ob$lt = slotCompareUint8((v, w) => new Sk.builtin.bool(v < w));

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -809,8 +809,6 @@ Sk.builtin.bytes.prototype["partition"] = new Sk.builtin.func(function (self, se
     var final2;
     var final3;
     var val;
-    var index;
-    var len;
     Sk.builtin.pyCheckArgsLen("partition", arguments.length - 1, 1, 1);
     if (!(sep instanceof Sk.builtin.bytes)) {
         throw new Sk.builtin.TypeError("a bytes-like object is required, not '" +  Sk.abstr.typeName(sep) + "'");
@@ -826,7 +824,6 @@ Sk.builtin.bytes.prototype["partition"] = new Sk.builtin.func(function (self, se
         final2 = new Sk.builtin.bytes(self.v.subarray(val, val + sep.v.byteLength));
         final3 = new Sk.builtin.bytes(self.v.subarray(val + sep.v.byteLength, self.v.byteLength));
     }
-    len = sep.v.byteLength;
 
     return new Sk.builtin.tuple([final1, final2, final3]);
 });
@@ -837,9 +834,6 @@ Sk.builtin.bytes.prototype["replace"] = new Sk.builtin.func(function (self, old,
     var i;
     var sep;
     var tot;
-    var idx;
-    var index;
-    var val;
     Sk.builtin.pyCheckArgsLen("replace", arguments.length - 1, 2, 3);
     if (!(old instanceof Sk.builtin.bytes)) {
         throw new Sk.builtin.TypeError("a bytes-like object is required, not '" + Sk.abstr.typeName(old) + "'");
@@ -907,7 +901,6 @@ Sk.builtin.bytes.prototype["rpartition"] = new Sk.builtin.func(function (self, s
     var final1;
     var final2;
     var final3;
-    var index;
     Sk.builtin.pyCheckArgsLen("rpartition", arguments.length - 1, 1, 1);
 
     if (!(sep instanceof Sk.builtin.bytes)) {
@@ -1392,7 +1385,6 @@ Sk.builtin.bytes.prototype["expandtabs"] = new Sk.builtin.func(function (self, t
     }
 
     let final = [];
-    let spaces;
     let linepos = 0;
 
     for (let i = 0; i < self.v.byteLength; i++) {
@@ -1501,7 +1493,6 @@ Sk.builtin.bytes.prototype["islower"] = new Sk.builtin.func(function (self) {
 Sk.builtin.bytes.prototype["isspace"] = new Sk.builtin.func(function (self) {
     var i;
     var val;
-    var flag;
     Sk.builtin.pyCheckArgsLen("isspace", arguments.length - 1, 0, 0);
     if (self.v.byteLength === 0) {
         return Sk.builtin.bool.false$;

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -168,11 +168,12 @@ function makehexform(num) {
 Sk.abstr.setUpInheritance("bytes", Sk.builtin.bytes, Sk.builtin.seqtype);
 
 Sk.builtin.bytes.prototype["$r"] = function () {
-    var ret;
-    var i;
-    var num;
-    ret = "";
-    for (i = 0; i < this.v.byteLength; i++) {
+    let num;
+    let quote = "'";
+    const hasdbl = this.v.indexOf(34) !== -1;
+    let ret = "";
+    
+    for (let i = 0; i < this.v.byteLength; i++) {
         num = this.v[i];
         if ((num < 9) || (num > 10 && num < 13) || (num > 13 && num < 32) || (num > 126)) {
             ret += makehexform(num);
@@ -188,7 +189,12 @@ Sk.builtin.bytes.prototype["$r"] = function () {
                     ret += "\\r";
                     break;
                 case 39:
-                    ret += "\\'";
+                    if (hasdbl) {
+                        ret += "\\'";
+                    } else {
+                        ret += "'";     
+                        quote = '"';
+                    }
                     break;
                 case 92:
                     ret += "\\\\";
@@ -198,7 +204,7 @@ Sk.builtin.bytes.prototype["$r"] = function () {
             ret += String.fromCharCode(num);
         }
     }
-    ret = "b'" + ret + "'";
+    ret = "b" + quote + ret + quote;
     return new Sk.builtin.str(ret);
 };
 

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -192,7 +192,6 @@ function makehexform(num) {
     return num;
 };
 
-
 Sk.builtin.bytes.prototype.$jsstr = function () {
     return Decoder.decode(this.v);
 };

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -18,22 +18,16 @@ function normalizeEncoding (encoding) {
     }
 }
 
-// Simple polyfill for older browsers
-if (!Uint8Array.from) {
-    Uint8Array.from = function (source, mapFn, thisArg) {
-        const uarr = new Uint8Array(source.length);
+// Stop gap until Uint8Array.from (or new Uint8Array(iterable)) gets wider support
+// This only handles the simple case used in this file
+function Uint8ArrayFromArray (source) {
+    const uarr = new Uint8Array(source.length);
 
-        let fxn = (arg) => arg;
-        if (mapFn !== undefined) {
-            fxn = thisArg === undefined ? (arg) => mapFn(arg) : (arg) => mapFn.call(thisArg, arg);
-        }
+    for (let idx = 0; idx < source.length; idx++) {
+        uarr[idx] = source[idx];
+    }
 
-        for (let idx = 0; idx < source.length; idx++) {
-            uarr[idx] = fxn(source[idx]);
-        }
-
-        return uarr;
-    };
+    return uarr;
 }
 
 /**
@@ -78,7 +72,7 @@ Sk.builtin.bytes = function (source, encoding, errors) {
             // Internal fast path
             Sk.asserts.assert(source.every((x) => (x >= 0) && (x < 256)),
                               "Bad internal call to bytes with array object");
-            arr = Uint8Array.from(source);
+            arr = Uint8ArrayFromArray(source);
         } else if (source instanceof Uint8Array) {
             // Internal fast path
             arr = source;
@@ -98,7 +92,7 @@ Sk.builtin.bytes = function (source, encoding, errors) {
                     throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(item) + "' " + "object cannot be interpreted as an integer");
                 }
             }
-            arr = Uint8Array.from(final);
+            arr = Uint8ArrayFromArray(final);
         } else if ((source instanceof Sk.builtin.str) || (typeof source === "string")) {
             throw new Sk.builtin.TypeError("string argument without an encoding");
         } else {
@@ -128,7 +122,7 @@ Sk.builtin.bytes = function (source, encoding, errors) {
                             data.push(val);
                         }
                     }
-                    arr = Uint8Array.from(data);
+                    arr = Uint8ArrayFromArray(data);
                 } else if (encoding === "utf-8") {
                     arr = new TextEncoder().encode(source);
                 } else {

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -371,7 +371,7 @@ Sk.builtin.bytes.prototype.sq$contains = function (item) {
     return false;
 };
 
-Sk.builtin.bytes.prototype.$decode = function (self, encoding, errors) {
+Sk.builtin.bytes.$decode = function (self, encoding, errors) {
     var i;
     var val;
     var final;
@@ -438,7 +438,7 @@ Sk.builtin.bytes.prototype.$decode = function (self, encoding, errors) {
     return new Sk.builtin.str(final);
 };
 
-Sk.builtin.bytes.prototype["decode"] = new Sk.builtin.func(Sk.builtin.bytes.prototype.$decode);
+Sk.builtin.bytes.prototype["decode"] = new Sk.builtin.func(Sk.builtin.bytes.$decode);
 
 Sk.builtin.bytes.prototype["fromhex"] = new Sk.builtin.func(function (string) {
     var final;

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -257,15 +257,6 @@ Sk.builtin.bytes.prototype.sq$length = function () {
     return this.v.byteLength;
 };
 
-Sk.builtin.bytes.prototype.bytes_copy_ = function () {
-    var i;
-    var final;
-    final = [];
-    for (i = 0; i < this.v.byteLength; i++) {
-        final.push(this.v[i]);
-    }
-    return new Sk.builtin.bytes(final);
-};
 Sk.builtin.bytes.prototype.sq$concat = function (other) {
     var i;
     var lis;

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -77,7 +77,7 @@ function strEncode(str, encoding, errors) {
     let uint8;
     if (encoding === "ascii") {
         uint8 = encodeAscii(source, errors);
-    } else if (encoding === "utf-8" || encoding === "utf8" || encoding === "utf") {
+    } else if (encoding === "utf-8") {
         uint8 = Encoder.encode(source);
     } else {
         throw new Sk.builtin.LookupError("unknown encoding: " + encoding);
@@ -105,14 +105,13 @@ function encodeAscii(source, errors) {
     return Uint8Array.from(data);
 }
 
-function tp$new(args, kwargs) {
-    kwargs = kwargs || [];
+function tp$new(args) {
     let source,
         pySource,
         dunderBytes,
         encoding = null,
         errors = null;
-    if (args.length <= 1 && +kwargs.length === 0) {
+    if (args.length <= 1) {
         pySource = args[0];
     } else {
         [pySource, encoding, errors] = args;
@@ -139,8 +138,8 @@ function tp$new(args, kwargs) {
         if (encoding === null) {
             throw new Sk.builtin.TypeError("string argument without an encoding");
         }
-        errors = errors === null ? "strict" : errors.$jsstr().trim().toLowerCase();
-        encoding = encoding.$jsstr().trim().toLowerCase();
+        errors = errors === null ? "strict" : errors.$jsstr();
+        encoding = normalizeEncoding(encoding.$jsstr());
         return strEncode(pySource, encoding, errors);
     } else if (Sk.builtin.checkInt(pySource)) {
         source = Sk.builtin.asnum$(pySource);

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -291,6 +291,19 @@ Sk.builtin.bytes.prototype.ob$ne = function (other) {
     return Sk.misceval.isTrue(ret) ? Sk.builtin.bool.false$ : Sk.builtin.bool.true$;
 };
 
+function slotCompareUint8(f) {
+    return function (other) {
+        if (!(other instanceof Sk.builtin.bytes)) {
+            return Sk.builtin.NotImplemented.NotImplemented$;
+        }
+        return f(this.v, other.v);
+    };
+}
+Sk.builtin.bytes.prototype.ob$lt = slotCompareUint8((v, w) => new Sk.builtin.bool(v < w));
+Sk.builtin.bytes.prototype.ob$le = slotCompareUint8((v, w) => new Sk.builtin.bool(v <= w));
+Sk.builtin.bytes.prototype.ob$gt = slotCompareUint8((v, w) => new Sk.builtin.bool(v > w));
+Sk.builtin.bytes.prototype.ob$ge = slotCompareUint8((v, w) => new Sk.builtin.bool(v >= w));
+
 Sk.builtin.bytes.prototype.sq$length = function () {
     return this.v.byteLength;
 };

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -58,7 +58,7 @@ Sk.builtin.bytes = function (source) {
         this.v = source;
     } else if (Array.isArray(source)) {
         Sk.asserts.assert(source.every((x) => x >= 0 && x < 256), "bad internal call to bytes with array");
-        this.v = Uint8Array.from(source);
+        this.v = Uint8ArrayFromArray(source);
     } else if (typeof source === "string") {
         this.v = Encoder.encode(source);
     } else if (typeof source === "number") {
@@ -103,7 +103,7 @@ function encodeAscii(source, errors) {
             data.push(val);
         }
     }
-    return Uint8Array.from(data);
+    return Uint8ArrayFromArray(data);
 }
 
 function tp$new(args) {

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -126,6 +126,10 @@ function newBytesFromPy(pySource, encoding, errors) {
         if (errors !== undefined && !Sk.builtin.checkString(errors)) {
             throw new Sk.builtin.TypeError("bytes() argument 3 must be str not " + Sk.abstr.typeName(encoding));
         }
+        if (!Sk.builtin.checkString(pySource)) {
+            // think ahead for kwarg support
+            throw new Sk.builtin.TypeError((encoding !== undefined ? "encoding" : "errors") + " without a string argument");
+        }
     }
 
     if (pySource === undefined) {
@@ -141,6 +145,8 @@ function newBytesFromPy(pySource, encoding, errors) {
         source = Sk.builtin.asnum$(pySource);
         if (Math.abs(source) > Number.MAX_SAFE_INTEGER) {
             throw new Sk.builtin.OverflowError("cannot fit 'int' into an index-sized integer");
+        } else if (source < 0) {
+            throw new Sk.builtin.ValueError("negative count");
         }
         return new Sk.builtin.bytes(source);
     } else if (Sk.builtin.checkBytes(pySource)) {

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -74,6 +74,7 @@ Sk.abstr.setUpInheritance("bytes", Sk.builtin.bytes, Sk.builtin.seqtype);
 
 function strEncode(str, encoding, errors) {
     const source = str.$jsstr();
+    encoding = normalizeEncoding(encoding);
     let uint8;
     if (encoding === "ascii") {
         uint8 = encodeAscii(source, errors);
@@ -139,7 +140,7 @@ function tp$new(args) {
             throw new Sk.builtin.TypeError("string argument without an encoding");
         }
         errors = errors === null ? "strict" : errors.$jsstr();
-        encoding = normalizeEncoding(encoding.$jsstr());
+        encoding = encoding.$jsstr();
         return strEncode(pySource, encoding, errors);
     } else if (Sk.builtin.checkInt(pySource)) {
         source = Sk.builtin.asnum$(pySource);

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -70,6 +70,8 @@ Sk.builtin.bytes = function (source) {
     }
 };
 
+Sk.abstr.setUpInheritance("bytes", Sk.builtin.bytes, Sk.builtin.seqtype);
+
 function strEncode(str, encoding, errors) {
     const source = str.$jsstr();
     let uint8;
@@ -192,7 +194,10 @@ function makehexform(num) {
     return num;
 };
 
-Sk.abstr.setUpInheritance("bytes", Sk.builtin.bytes, Sk.builtin.seqtype);
+
+Sk.builtin.bytes.prototype.$jsstr = function () {
+    return Decoder.decode(this.v);
+};
 
 Sk.builtin.bytes.prototype["$r"] = function () {
     let num;
@@ -371,7 +376,7 @@ Sk.builtin.bytes.prototype.$decode = function (self, encoding, errors) {
     var i;
     var val;
     var final;
-    Sk.builtin.pyCheckArgsLen("decode", arguments.length - 1, 1, 2);
+    Sk.builtin.pyCheckArgsLen("decode", arguments.length - 1, 0, 2);
 
     if (encoding === undefined) {
         encoding = "utf-8";

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -202,10 +202,10 @@ function makehexform(num) {
 };
 
 Sk.builtin.bytes.prototype.$jsstr = function () {
-    // returns bytes string - not a bidirectional conversion - use with caution
-    // i.e. new Sk.builtin.bytes(x.$jsstr()).v  is different to x.v;
+    // returns binary string - not bidirectional for non ascii characters - use with caution
+    // i.e. new Sk.builtin.bytes(x.$jsstr()).v  may be different to x.v;
     let ret = "";
-    for (let i = 0; i <= this.v.byteLength; i++) {
+    for (let i = 0; i < this.v.byteLength; i++) {
         ret += String.fromCharCode(this.v[i]);
     }
     return ret;

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -525,7 +525,7 @@ function indices(self, start, end) {
             start += self.v.byteLength;
         }
     }
-    if (end === undefined) {
+    if (end === undefined || end === Sk.builtin.none.none$) {
         end = self.v.byteLength;
     } else if (!Sk.misceval.isIndex(end)) {
         throw new Sk.builtin.TypeError("slice indices must be integers or None or have an __index__ method");

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -153,7 +153,7 @@ function newBytesFromPy(pySource, encoding, errors) {
         return new Sk.builtin.bytes(source);
     } else if (Sk.builtin.checkBytes(pySource)) {
         return new Sk.builtin.bytes(pySource.v);
-    } else if ((dunderBytes = Sk.abstr.lookupSpecial(pySource, Sk.builtin.str.$bytes)) !== undefined) {
+    } else if ((dunderBytes = Sk.abstr.lookupSpecial(pySource, Sk.builtin.str.$bytes)) != null) {
         const ret = Sk.misceval.callsimOrSuspendArray(dunderBytes, [pySource]);
         return Sk.misceval.chain(ret, (bytesSource) => {
             if (!Sk.builtin.checkBytes(bytesSource)) {
@@ -175,7 +175,11 @@ function newBytesFromPy(pySource, encoding, errors) {
         });
         return Sk.misceval.chain(r, () => new Sk.builtin.bytes(source));
     }
-    throw new Sk.builtin.TypeError("cannot convert '" + Sk.abstr.typeName(pySource) + "' object into bytes");
+    let msg = "";
+    if (pySource.sk$object === undefined) {
+        msg += ", if calling constructor with a javascript object use 'new'";
+    }
+    throw new Sk.builtin.TypeError("cannot convert '" + Sk.abstr.typeName(pySource) + "' object into bytes" + msg);
 }
 
 function makehexform(num) {

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -145,11 +145,11 @@ function newBytesFromPy(pySource, encoding, errors) {
         return strEncode(pySource, encoding, errors);
     } else if (Sk.builtin.checkInt(pySource)) {
         source = Sk.builtin.asnum$(pySource);
-        if (Math.abs(source) > Number.MAX_SAFE_INTEGER) {
-            throw new Sk.builtin.OverflowError("cannot fit 'int' into an index-sized integer");
-        } else if (source < 0) {
+        if (source < 0) {
             throw new Sk.builtin.ValueError("negative count");
-        }
+        } else if (source > Number.MAX_SAFE_INTEGER) {
+            throw new Sk.builtin.OverflowError("cannot fit 'int' into an index-sized integer");
+        } 
         return new Sk.builtin.bytes(source);
     } else if (Sk.builtin.checkBytes(pySource)) {
         return new Sk.builtin.bytes(pySource.v);

--- a/src/compile.js
+++ b/src/compile.js
@@ -821,12 +821,9 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
                 const str = e.s.$jsstr();
                 for (let i = 0; i < str.length; i++) {
                     const c = str.charCodeAt(i);
-                    if (c > 0xff) {
-                        throw new Sk.builtin.SyntaxError("bytes can only contain ASCII literal characters");
-                    }
                     source.push(c);
                 }
-                return this.makeConstant("new Sk.builtin.bytes(new Uint8Array([", source.toString(), "]))");
+                return this.makeConstant("new Sk.builtin.bytes(new Uint8Array([", source.join(", "), "]))");
             }
             // else fall through and make a string instead
         case Sk.astnodes.Str:

--- a/src/compile.js
+++ b/src/compile.js
@@ -823,7 +823,7 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
                     const c = str.charCodeAt(i);
                     source.push(c);
                 }
-                return this.makeConstant("new Sk.builtin.bytes(new Uint8Array([", source.join(", "), "]))");
+                return this.makeConstant("new Sk.builtin.bytes([", source.join(", "), "])");
             }
             // else fall through and make a string instead
         case Sk.astnodes.Str:

--- a/src/compile.js
+++ b/src/compile.js
@@ -817,12 +817,16 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
             Sk.asserts.fail("unhandled Num type");
         case Sk.astnodes.Bytes:
             if (Sk.__future__.python3) {
-                for (let i = 0; i < e.s.length; i++) {
-                    if (e.s[i] > String.fromCharCode(0x7f)) {
+                const source = [];
+                const str = e.s.$jsstr();
+                for (let i = 0; i < str.length; i++) {
+                    const c = str.charCodeAt(i);
+                    if (c > 0xff) {
                         throw new Sk.builtin.SyntaxError("bytes can only contain ASCII literal characters");
                     }
+                    source.push(c);
                 }
-                return this.makeConstant("new Sk.builtin.bytes(", getJsLiteralForString(e.s.$jsstr()), ")");
+                return this.makeConstant("new Sk.builtin.bytes(new Uint8Array([", source.toString(), "]))");
             }
             // else fall through and make a string instead
         case Sk.astnodes.Str:

--- a/src/compile.js
+++ b/src/compile.js
@@ -820,8 +820,7 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
                 const source = [];
                 const str = e.s.$jsstr();
                 for (let i = 0; i < str.length; i++) {
-                    const c = str.charCodeAt(i);
-                    source.push(c);
+                    source.push(str.charCodeAt(i));
                 }
                 return this.makeConstant("new Sk.builtin.bytes([", source.join(", "), "])");
             }

--- a/src/compile.js
+++ b/src/compile.js
@@ -709,9 +709,8 @@ Compiler.prototype.cformattedvalue = function(e) {
             value = this._gr("value", "new Sk.builtin.str(",value,")");
             break;
         case 'a':
-            // TODO when repr() becomes more unicode-aware,
-            // we'll want to handle repr() and ascii() differently.
-            // For now, they're the same
+            value = this._gr("value", "Sk.builtin.ascii(",value,")");
+            break;
         case 'r':
             value = this._gr("value", "Sk.builtin.repr(",value,")");
             break;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 Sk.builtin.str.$emptystr = new Sk.builtin.str("");
+Sk.builtin.bytes.$emptystr = new Sk.builtin.bytes("");
 
 
 /* Constants used for kwargs */
@@ -30,6 +31,7 @@ Sk.builtin.str.$imag = new Sk.builtin.str("imag");
 Sk.builtin.str.$real = new Sk.builtin.str("real");
 
 Sk.builtin.str.$abs = new Sk.builtin.str("__abs__");
+Sk.builtin.str.$bytes = new Sk.builtin.str("__bytes__");
 Sk.builtin.str.$call = new Sk.builtin.str("__call__");
 Sk.builtin.str.$cmp = new Sk.builtin.str("__cmp__");
 Sk.builtin.str.$complex = new Sk.builtin.str("__complex__");

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,4 @@
 Sk.builtin.str.$emptystr = new Sk.builtin.str("");
-Sk.builtin.bytes.$emptystr = new Sk.builtin.bytes("");
-
 
 /* Constants used for kwargs */
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -493,6 +493,40 @@ Sk.exportSymbol("Sk.builtin.SystemError", Sk.builtin.SystemError);
 
 /**
  * @constructor
+ * @extends Sk.builtin.StandardError
+ * @param {...*} args
+ */
+Sk.builtin.UnicodeEncodeError = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.UnicodeEncodeError)) {
+        o = Object.create(Sk.builtin.UnicodeEncodeError.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.StandardError.apply(this, arguments);
+};
+Sk.abstr.setUpInheritance("UnicodeEncodeError", Sk.builtin.UnicodeEncodeError, Sk.builtin.StandardError);
+Sk.exportSymbol("Sk.builtin.UnicodeEncodeError", Sk.builtin.UnicodeEncodeError);
+
+/**
+ * @constructor
+ * @extends Sk.builtin.StandardError
+ * @param {...*} args
+ */
+Sk.builtin.UnicodeDecodeError = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.UnicodeDecodeError)) {
+        o = Object.create(Sk.builtin.UnicodeDecodeError.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.StandardError.apply(this, arguments);
+};
+Sk.abstr.setUpInheritance("UnicodeDecodeError", Sk.builtin.UnicodeDecodeError, Sk.builtin.StandardError);
+Sk.exportSymbol("Sk.builtin.UnicodeDecodeError", Sk.builtin.UnicodeDecodeError);
+
+/**
+ * @constructor
  * @extends Sk.builtin.Exception
  * @param {...*} args
  */

--- a/src/errors.js
+++ b/src/errors.js
@@ -493,40 +493,6 @@ Sk.exportSymbol("Sk.builtin.SystemError", Sk.builtin.SystemError);
 
 /**
  * @constructor
- * @extends Sk.builtin.StandardError
- * @param {...*} args
- */
-Sk.builtin.UnicodeEncodeError = function (args) {
-    var o;
-    if (!(this instanceof Sk.builtin.UnicodeEncodeError)) {
-        o = Object.create(Sk.builtin.UnicodeEncodeError.prototype);
-        o.constructor.apply(o, arguments);
-        return o;
-    }
-    Sk.builtin.StandardError.apply(this, arguments);
-};
-Sk.abstr.setUpInheritance("UnicodeEncodeError", Sk.builtin.UnicodeEncodeError, Sk.builtin.StandardError);
-Sk.exportSymbol("Sk.builtin.UnicodeEncodeError", Sk.builtin.UnicodeEncodeError);
-
-/**
- * @constructor
- * @extends Sk.builtin.StandardError
- * @param {...*} args
- */
-Sk.builtin.UnicodeDecodeError = function (args) {
-    var o;
-    if (!(this instanceof Sk.builtin.UnicodeDecodeError)) {
-        o = Object.create(Sk.builtin.UnicodeDecodeError.prototype);
-        o.constructor.apply(o, arguments);
-        return o;
-    }
-    Sk.builtin.StandardError.apply(this, arguments);
-};
-Sk.abstr.setUpInheritance("UnicodeDecodeError", Sk.builtin.UnicodeDecodeError, Sk.builtin.StandardError);
-Sk.exportSymbol("Sk.builtin.UnicodeDecodeError", Sk.builtin.UnicodeDecodeError);
-
-/**
- * @constructor
  * @extends Sk.builtin.Exception
  * @param {...*} args
  */

--- a/src/function.js
+++ b/src/function.js
@@ -184,6 +184,11 @@ Sk.builtin.checkString = function (arg) {
 };
 Sk.exportSymbol("Sk.builtin.checkString", Sk.builtin.checkString);
 
+Sk.builtin.checkBytes = function (arg) {
+    return (arg !== null && arg.__class__ == (Sk.builtin.__python3__ ? Sk.builtin.bytes : Sk.builtin.str));
+};
+Sk.exportSymbol("Sk.builtin.checkBytes", Sk.builtin.checkBytes);
+
 Sk.builtin.checkClass = function (arg) {
     return (arg !== null && arg.sk$type);
 };

--- a/src/function.js
+++ b/src/function.js
@@ -185,7 +185,7 @@ Sk.builtin.checkString = function (arg) {
 Sk.exportSymbol("Sk.builtin.checkString", Sk.builtin.checkString);
 
 Sk.builtin.checkBytes = function (arg) {
-    return (arg !== null && arg.__class__ == (Sk.builtin.__python3__ ? Sk.builtin.bytes : Sk.builtin.str));
+    return (arg !== null && arg.__class__ == (Sk.__future__.python3 ? Sk.builtin.bytes : Sk.builtin.str));
 };
 Sk.exportSymbol("Sk.builtin.checkBytes", Sk.builtin.checkBytes);
 

--- a/src/function.js
+++ b/src/function.js
@@ -499,3 +499,17 @@ Sk.builtin.func.prototype["$r"] = function () {
         return new Sk.builtin.str("<function " + name + ">");
     }
 };
+
+// a Python implementation of @staticmethod
+Sk.builtin.staticfunc = function() {
+    Sk.builtin.func.apply(this, arguments);
+};
+Sk.abstr.setUpInheritance("staticfunction", Sk.builtin.staticfunc, Sk.builtin.func);
+
+Sk.exportSymbol("Sk.builtin.staticfunc", Sk.builtin.staticfunc);
+
+Sk.builtin.staticfunc.prototype.tp$name = "staticmethod";
+
+Sk.builtin.staticfunc.prototype.tp$descr_get = function () {
+    return this;
+};

--- a/src/function.js
+++ b/src/function.js
@@ -498,17 +498,3 @@ Sk.builtin.func.prototype["$r"] = function () {
         return new Sk.builtin.str("<function " + name + ">");
     }
 };
-
-// a Python implementation of @staticmethod
-Sk.builtin.staticfunc = function() {
-    Sk.builtin.func.apply(this, arguments);
-};
-Sk.abstr.setUpInheritance("staticfunction", Sk.builtin.staticfunc, Sk.builtin.func);
-
-Sk.exportSymbol("Sk.builtin.staticfunc", Sk.builtin.staticfunc);
-
-Sk.builtin.staticfunc.prototype.tp$name = "staticmethod";
-
-Sk.builtin.staticfunc.prototype.tp$descr_get = function () {
-    return this;
-};

--- a/src/function.js
+++ b/src/function.js
@@ -185,9 +185,8 @@ Sk.builtin.checkString = function (arg) {
 Sk.exportSymbol("Sk.builtin.checkString", Sk.builtin.checkString);
 
 Sk.builtin.checkBytes = function (arg) {
-    return (arg !== null && arg.__class__ == (Sk.__future__.python3 ? Sk.builtin.bytes : Sk.builtin.str));
+    return arg instanceof Sk.builtin.bytes;
 };
-Sk.exportSymbol("Sk.builtin.checkBytes", Sk.builtin.checkBytes);
 
 Sk.builtin.checkClass = function (arg) {
     return (arg !== null && arg.sk$type);

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1207,39 +1207,6 @@ Sk.misceval.Break = function(brValue) {
 Sk.exportSymbol("Sk.misceval.Break", Sk.misceval.Break);
 
 /**
- * Create a Python iterator that repeatedly calls a given JS function
- * until it returns 'undefined'
- * @constructor
- */
-Sk.misceval.Iterator = function(fn, handlesOwnSuspensions) {
-    this.tp$iter = this;
-    this.tp$iternext = handlesOwnSuspensions ? fn : function (canSuspend) {
-        let x = fn();
-        if (canSuspend || !x.isSuspension) {
-            return x;
-        } else {
-            return Sk.misceval.retryOptionalSuspensionOrThrow(x);
-        }
-    };
-};
-
-Sk.abstr.setUpInheritance("iterator", Sk.misceval.Iterator, Sk.builtin.object);
-Sk.misceval.Iterator.prototype.__class__ = Sk.misceval.Iterator;
-Sk.misceval.Iterator.prototype.__iter__ = new Sk.builtin.func(function (self) {
-    Sk.builtin.pyCheckArgsLen("__iter__", arguments.length, 0, 0, true, false);
-    return self;
-});
-Sk.misceval.Iterator.prototype.next$ = function (self) {
-    var ret = self.tp$iternext();
-    if (ret === undefined) {
-        throw new Sk.builtin.StopIteration();
-    }
-    return ret;
-};
-
-
-
-/**
  * same as Sk.misceval.call except args is an actual array, rather than
  * varargs.
  */

--- a/src/str.js
+++ b/src/str.js
@@ -658,6 +658,8 @@ function indices(self, start, end) {
         end = end >= 0 ? end : len + end;
         if (end < 0) {
             end = 0;
+        } else if (end > len) {
+            end = len;
         }
     }
 

--- a/src/str.js
+++ b/src/str.js
@@ -16,13 +16,14 @@ function setInterned (x, pyStr) {
 Sk.builtin.str = function (x, encoding, errors) {
     var ret;
 
-    Sk.builtin.pyCheckArgsLen("str", arguments.length, 0, Sk.__future__ && Sk.__future__.python3 ? 2 : 1);
-
     if (x === undefined) {
         x = "";
     }
 
     if (encoding) {
+        // only check args if we have more than 1
+        Sk.builtin.pyCheckArgsLen("str", arguments.length, 0, Sk.__future__.python3 ? 3 : 1);
+        
         if (!Sk.builtin.checkBytes(x)) {
             throw new TypeError("decoding " + Sk.abstr.typeName(x) + " is not supported");
         }

--- a/src/str.js
+++ b/src/str.js
@@ -117,7 +117,7 @@ Sk.builtin.str.prototype.$hasAstralCodePoints = function() {
     }
     this.codepoints = null;
     return false;
-}
+};
 
 Sk.builtin.bytes.prototype.$hasAstralCodePoints = () => false;
 
@@ -577,7 +577,7 @@ Sk.builtin.str.prototype["count"] = Sk.builtin.bytes.prototype["count"] = new Sk
     normaltext = pat.v.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
     m = new RegExp(normaltext, "g");
     slice = self.v.slice(self.codepoints ? self.codepoints[start] : start,
-                            self.codepoints ? self.codepoints[end] : end);
+                         self.codepoints ? self.codepoints[end] : end);
     ctl = slice.match(m);
     if (!ctl) {
         return  new Sk.builtin.int_(0);
@@ -591,7 +591,7 @@ function mkJust(isRight, isCenter) {
     return new Sk.builtin.func(function (self, len, fillchar) {
         var newstr;
         Sk.builtin.pyCheckArgsLen(isCenter ? "center" : isRight ? "rjust" : "ljust",
-                                    arguments.length, 2, 3);
+                                  arguments.length, 2, 3);
         if (!Sk.builtin.checkInt(len)) {
             throw new Sk.builtin.TypeError("integer argument expected, got " + Sk.abstr.typeName(len));
         }
@@ -1025,7 +1025,7 @@ Sk.builtin.bytes.prototype["fromhex"] = new Sk.builtin.staticfunc(function(hex) 
     let v = "";
 
     for (let i = 0; i < h.length; i += 2) {
-        let s = h.substr(i, 2)
+        let s = h.substr(i, 2);
         let n = parseInt(s, 16);
         if (isNaN(n) || s.length != 2 || !/^[abcdefABCDEF0123456789]{2}$/.test(s)) {
             throw new Sk.builtin.ValueError("non-hexadecimal number found in fromhex() arg");
@@ -1361,7 +1361,7 @@ Sk.builtin.str_iter_ = function (obj) {
             let r = new this.$cls(this.$obj.substring(this.$codepoints[this.$index], this.$codepoints[this.$index+1]));
             this.$index++;
             return r;
-        }
+        };
     } else {
         this.sq$length = this.$obj.length;
         this.tp$iternext = function () {
@@ -1369,7 +1369,7 @@ Sk.builtin.str_iter_ = function (obj) {
                 return undefined;
             }
             return new Sk.builtin.str(this.$obj.substr(this.$index++, 1));
-        }
+        };
     }
     this.$r = function () {
         return new Sk.builtin.str("iterator");

--- a/src/str.js
+++ b/src/str.js
@@ -333,10 +333,10 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
             ret += "\\n";
         } else if (c === "\r") {
             ret += "\\r";
-        } else if (cc > 0xff && cc < 0xd800 || cc >= 0xe000) {
+        } else if ((cc > 0xff && cc < 0xd800 || cc >= 0xe000) && !Sk.__future__.python3) {
             // BMP
             ret += "\\u" + ("000"+cc.toString(16)).slice(-4);
-        } else if (cc >= 0xd800) {
+        } else if (cc >= 0xd800 && !Sk.__future__.python3) {
             // Surrogate pair stuff
             let val = this.v.codePointAt(i);
             i++;
@@ -348,10 +348,10 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
             } else {
                 ret += "\\u" + s.slice(-4);
             }
-        } else if (cc > 0xff) {
+        } else if (cc > 0xff && !Sk.__future__.python3) {
             // Invalid!
             ret += "\\ufffd";
-        } else if (c < " " || cc >= 0x7f) {
+        } else if (c < " " || cc >= 0x7f && !Sk.__future__.python3) {
             ashex = c.charCodeAt(0).toString(16);
             if (ashex.length < 2) {
                 ashex = "0" + ashex;

--- a/src/str.js
+++ b/src/str.js
@@ -142,15 +142,19 @@ Sk.builtin.str.prototype.mp$subscript = Sk.builtin.bytes.prototype.mp$subscript 
         }
     } else if (index instanceof Sk.builtin.slice) {
         ret = "";
-        index.sssiter$(this, function (i, wrt) {
-            if (wrt.$hasAstralCodePoints()) {
-                if (i >= 0 && i < wrt.codepoints.length) {
-                    ret += wrt.v.substring(wrt.codepoints[i], wrt.codepoints[i+1]);
+        if (this.$hasAstralCodePoints()) {
+            index.sssiter$(this.codepoints.length, (i, wrt) => {
+                if (i >= 0 && i < this.codepoints.length) {
+                    ret += this.v.substring(this.codepoints[i], this.codepoints[i+1]);
                 }
-            } else if (i >= 0 && i < wrt.v.length) {
-                ret += wrt.v.charAt(i);
-            }
-        });
+            });
+        } else {
+            index.sssiter$(this, function (i, wrt) {
+                if (i >= 0 && i < wrt.v.length) {
+                    ret += wrt.v.charAt(i);
+                }
+            });
+        };
         return new this.__class__(ret);
     } else {
         throw new Sk.builtin.TypeError(this.__class__.$englishname + " indices must be integers, not " + Sk.abstr.typeName(index));
@@ -1348,7 +1352,9 @@ Sk.builtin.str_iter_ = function (obj) {
                 return undefined;
             }
 
-            return new this.$cls(this.$obj.substring(this.$codepoints[this.$index], this.$codepoints[this.$index+1]));
+            let r = new this.$cls(this.$obj.substring(this.$codepoints[this.$index], this.$codepoints[this.$index+1]));
+            this.$index++;
+            return r;
         }
     } else {
         this.sq$length = this.$obj.length;

--- a/src/str.js
+++ b/src/str.js
@@ -213,6 +213,7 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
     // single is preferred
     var ashex;
     var c;
+    var cc;
     var i;
     var ret;
     var len;
@@ -226,6 +227,7 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
     ret = (this.__class__ === Sk.builtin.bytes) ? "b" + quote : quote;
     for (i = 0; i < len; ++i) {
         c = this.v.charAt(i);
+        cc = this.v.charCodeAt(i);
         if (c === quote || c === "\\") {
             ret += "\\" + c;
         } else if (c === "\t") {
@@ -234,10 +236,10 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
             ret += "\\n";
         } else if (c === "\r") {
             ret += "\\r";
-        } else if (c > 0xff && c < 0xd800 || c >= 0xe000) {
+        } else if (cc > 0xff && cc < 0xd800 || cc >= 0xe000) {
             // BMP
-            ret += "\\u" + ("000"+this.v.charCodeAt(i).toString(16)).slice(-4);
-        } else if (c >= 0xd800) {
+            ret += "\\u" + ("000"+cc.toString(16)).slice(-4);
+        } else if (cc >= 0xd800) {
             // Surrogate pair stuff
             let val = this.v.codePointAt(i);
             i++;
@@ -249,10 +251,10 @@ Sk.builtin.str.prototype["$r"] = Sk.builtin.bytes.prototype["$r"] = function () 
             } else {
                 ret += "\\u" + s.slice(-4);
             }
-        } else if (c > 0xff) {
+        } else if (cc > 0xff) {
             // Invalid!
             ret += "\\ufffd";
-        } else if (c < " " || c >= 0x7f) {
+        } else if (c < " " || cc >= 0x7f) {
             ashex = c.charCodeAt(0).toString(16);
             if (ashex.length < 2) {
                 ashex = "0" + ashex;
@@ -956,7 +958,7 @@ Sk.builtin.str.prototype["encode"] = new Sk.builtin.func(function (self, encodin
 
     let v;
     try {
-        v = unescape(encodeUriComponent(self.v));
+        v = unescape(encodeURIComponent(self.v));
     } catch (e) {
         throw new Sk.builtin.UnicodeEncodeError("UTF-8 encoding failed");
     }
@@ -979,7 +981,7 @@ Sk.builtin.bytes.prototype["decode"] = new Sk.builtin.func(function (self, encod
 
     let v;
     try {
-        v = decodeUriComponent(escape(self.v));
+        v = decodeURIComponent(escape(self.v));
     } catch (e) {
         throw new Sk.builtin.UnicodeEncodeError("UTF-8 decoding failed");
     }

--- a/src/str.js
+++ b/src/str.js
@@ -1017,6 +1017,36 @@ Sk.builtin.bytes.prototype["decode"] = new Sk.builtin.func(function (self, encod
     return new Sk.builtin.str(v);
 });
 
+Sk.builtin.bytes.prototype["fromhex"] = new Sk.builtin.staticfunc(function(hex) {
+    Sk.builtin.pyCheckArgsLen("decode", arguments.length, 1, 3);
+    Sk.builtin.pyCheckType("hex", "string", Sk.builtin.checkString(hex));
+
+    let h = hex.v.replace(/\s*/g, "");
+    let v = "";
+
+    for (let i = 0; i < h.length; i += 2) {
+        let s = h.substr(i, 2)
+        let n = parseInt(s, 16);
+        if (isNaN(n) || s.length != 2 || !/^[abcdefABCDEF0123456789]{2}$/.test(s)) {
+            throw new Sk.builtin.ValueError("non-hexadecimal number found in fromhex() arg");
+        }
+        v += String.fromCharCode(n);
+    }
+
+    return new Sk.builtin.bytes(v);
+});
+
+Sk.builtin.bytes.prototype["hex"] = new Sk.builtin.func(function(self) {
+    // TODO Python 3.8 has added some args here
+    Sk.builtin.pyCheckArgsLen("hex", arguments.length, 1, 1);
+
+    let r = "";
+    for (let i=0; i < self.v.length; i++) {
+        r += ("0" + self.v.charCodeAt(i).toString(16)).substr(-2);
+    }
+    return new Sk.builtin.str(r);
+});
+
 Sk.builtin.str.prototype.nb$remainder = Sk.builtin.bytes.prototype.nb$remainder = function (rhs) {
     // % format op. rhs can be a value, a tuple, or something with __getitem__ (dict)
 

--- a/src/str.js
+++ b/src/str.js
@@ -1049,7 +1049,18 @@ Sk.builtin.str.prototype["encode"] = new Sk.builtin.func(function (self, encodin
 
 Sk.builtin.str.$py2decode = new Sk.builtin.func(function (self, encoding, errors) {
     Sk.builtin.pyCheckArgsLen("decode", arguments.length, 1, 3);
-    const pyBytes = new Sk.builtin.bytes(self.v);
+    let bytesStrAsArray = [];
+    let cc;
+    const str = self.v;
+    for (let i in str) {
+        cc = str.charCodeAt(i);
+        if (cc <= 0xff) {
+            bytesStrAsArray.push(cc);
+        } else {
+            throw new Sk.builtin.UnicodeDecodeError("invalid string (possibly contains a unicode character)");
+        }
+    }
+    const pyBytes = new Sk.builtin.bytes(bytesStrAsArray);
     return Sk.builtin.bytes.$decode(pyBytes, encoding, errors);
 });
 

--- a/src/str.js
+++ b/src/str.js
@@ -1098,7 +1098,14 @@ Sk.builtin.str.prototype["encode"] = new Sk.builtin.func(function (self, encodin
     } else {
         errors = "strict";
     }
-    return Sk.builtin.bytes.$strEncode(self, encoding, errors);
+    const pyBytes = Sk.builtin.bytes.$strEncode(self, encoding, errors);
+    return Sk.__future__.python3 ? pyBytes : new Sk.builtin.str(pyBytes.$jsstr());
+});
+
+Sk.builtin.str.$py2decode = new Sk.builtin.func(function (self, encoding, errors) {
+    Sk.builtin.pyCheckArgsLen("decode", arguments.length, 1, 3);
+    const pyBytes = new Sk.builtin.bytes(self.v);
+    return Sk.builtin.bytes.$decode(pyBytes, encoding, errors);
 });
 
 Sk.builtin.str.prototype.nb$remainder = function (rhs) {

--- a/src/str.js
+++ b/src/str.js
@@ -26,7 +26,7 @@ Sk.builtin.str = function (x, encoding, errors) {
         if (!Sk.builtin.checkBytes(x)) {
             throw new TypeError("decoding " + Sk.abstr.typeName(x) + " is not supported");
         }
-        return Sk.misceval.callsimArray(x.decode, [x, encoding, errors]);
+        return Sk.builtin.bytes.$decode(x, encoding, errors);
     }
 
     if (x instanceof Sk.builtin.str) {

--- a/src/str.js
+++ b/src/str.js
@@ -1089,8 +1089,16 @@ Sk.builtin.str.prototype["istitle"] = new Sk.builtin.func(function (self) {
 
 Sk.builtin.str.prototype["encode"] = new Sk.builtin.func(function (self, encoding, errors) {
     Sk.builtin.pyCheckArgsLen("encode", arguments.length, 1, 3);
-    
-    return new Sk.builtin.bytes(self, encoding || Sk.builtin.str.$utf8, errors);
+    encoding = encoding || Sk.builtin.str.$utf8;
+    Sk.builtin.pyCheckType("encoding", "string", Sk.builtin.checkString(encoding));
+    encoding = encoding.v;
+    if (errors !== undefined) {
+        Sk.builtin.pyCheckType("errors", "string", Sk.builtin.checkString(errors));
+        errors = errors.v;
+    } else {
+        errors = "strict";
+    }
+    return Sk.builtin.bytes.$strEncode(self, encoding, errors);
 });
 
 Sk.builtin.str.prototype.nb$remainder = function (rhs) {

--- a/src/str.js
+++ b/src/str.js
@@ -942,12 +942,52 @@ Sk.builtin.str.prototype["istitle"] = Sk.builtin.bytes.prototype["istitle"] = ne
 });
 
 Sk.builtin.str.prototype["encode"] = new Sk.builtin.func(function (self, encoding, errors) {
+    // TODO errors are currently always "strict"
+    // (other modes will require manual UTF-8-bashing)
+
     Sk.builtin.pyCheckArgsLen("encode", arguments.length, 1, 3);
-    
-    return new Sk.builtin.bytes(self, encoding, errors);
+
+    if (encoding) {
+        Sk.builtin.pyCheckType("encoding", "string", Sk.builtin.checkString(encoding));
+        if (!/^utf-?8$/i.test(encoding.v)) {
+            throw new Sk.builtin.ValueError("Only UTF-8 or ASCII encoding and decoding is supported");
+        }
+    }
+
+    let v;
+    try {
+        v = unescape(encodeUriComponent(self.v));
+    } catch (e) {
+        throw new Sk.builtin.UnicodeEncodeError("UTF-8 encoding failed");
+    }
+
+    return Sk.__future__.python3 ? new Sk.builtin.bytes(v) : new Sk.builtin.str(v);
 });
 
-Sk.builtin.str.prototype.nb$remainder = function (rhs) {
+Sk.builtin.bytes.prototype["decode"] = new Sk.builtin.func(function (self, encoding, errors) {
+    // TODO errors are currently always "strict"
+    // (other modes will require manual UTF-8-bashing)
+
+    Sk.builtin.pyCheckArgsLen("decode", arguments.length, 1, 3);
+
+    if (encoding) {
+        Sk.builtin.pyCheckType("encoding", "string", Sk.builtin.checkString(encoding));
+        if (!/^utf-?8$/i.test(encoding.v)) {
+            throw new Sk.builtin.ValueError("Only UTF-8 encoding and decoding is supported");
+        }
+    }
+
+    let v;
+    try {
+        v = decodeUriComponent(escape(self.v));
+    } catch (e) {
+        throw new Sk.builtin.UnicodeEncodeError("UTF-8 decoding failed");
+    }
+
+    return new Sk.builtin.str(v);
+});
+
+Sk.builtin.str.prototype.nb$remainder = Sk.builtin.bytes.prototype.nb$remainder = function (rhs) {
     // % format op. rhs can be a value, a tuple, or something with __getitem__ (dict)
 
     // From http://docs.python.org/library/stdtypes.html#string-formatting the

--- a/src/str.js
+++ b/src/str.js
@@ -1030,22 +1030,8 @@ Sk.builtin.str.prototype["encode"] = new Sk.builtin.func(function (self, encodin
     // (other modes will require manual UTF-8-bashing)
 
     Sk.builtin.pyCheckArgsLen("encode", arguments.length, 1, 3);
-
-    if (encoding) {
-        Sk.builtin.pyCheckType("encoding", "string", Sk.builtin.checkString(encoding));
-        if (!/^utf-?8$/i.test(encoding.v)) {
-            throw new Sk.builtin.ValueError("Only UTF-8 or ASCII encoding and decoding is supported");
-        }
-    }
-
-    let v;
-    try {
-        v = unescape(encodeURIComponent(self.v));
-    } catch (e) {
-        throw new Sk.builtin.UnicodeEncodeError("UTF-8 encoding failed");
-    }
-
-    return Sk.__future__.python3 ? new Sk.builtin.bytes(v) : new Sk.builtin.str(v);
+    
+    return new Sk.builtin.bytes(self, encoding || Sk.builtin.str.$utf8, errors);
 });
 
 Sk.builtin.bytes.prototype["decode"] = new Sk.builtin.func(function (self, encoding, errors) {

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -744,6 +744,7 @@ SymbolTable.prototype.visitExpr = function (e) {
             break;
         case Sk.astnodes.Num:
         case Sk.astnodes.Str:
+        case Sk.astnodes.Bytes:
             break;
         case Sk.astnodes.JoinedStr:
             for (let s of e.values) {

--- a/test/unit/test_unicode.py
+++ b/test/unit/test_unicode.py
@@ -9,5 +9,30 @@ class TestUnicode(unittest.TestCase):
         unicode_string = u"这是\n这这这"
         self.assertIn(u"是", unicode_string)
 
+    def test_encoding(self):
+        # Unicode snowman: BMP emoji
+        self.assertEqual(u'\u2603'.encode(), '\xe2\x98\x83')
+        self.assertEqual('\xe2\x98\x83'.decode(), u'\u2603')
+
+        self.assertEqual(ord(u'\u2603'), 0x2603) 
+        self.assertRaises(ValueError, chr, 0x2603)
+        self.assertEqual(unichr(0x2603), u'\u2603') 
+
+        # String repr in Python 2 is ascii
+        self.assertEqual(repr(u'\x01\xf0\u2603'), "'\\x01\\xf0\\u2603'")
+        # ...and there is no explicit ascii() function
+        self.assertRaises(NameError, lambda: ascii('hi there'))
+
+        # Piece of pizza: Astral emoji
+        self.assertEqual(u'\U0001f355'.encode(), b'\xf0\x9f\x8d\x95')
+        self.assertEqual('\xf0\x9f\x8d\x95'.decode(), u'\U0001f355')
+
+        # Python 2 silently accepts b'' strings
+        self.assertEqual(b'hello world', 'hello world')
+        self.assertEqual(type(b'hello world'), str)
+
+        # We do not distinguish between str and unicode in Skulpt
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_bytes.py
+++ b/test/unit3/test_bytes.py
@@ -161,6 +161,15 @@ class BytesTests(unittest.TestCase):
         self.assertRaises(UnicodeDecodeError, d0.decode, "utf-8")
         self.assertRaises(UnicodeDecodeError, d0.decode, "ascii")
 
+    def test_expandtabs(self):
+        self.assertEqual(b'abc\rab\tdef\ng\thi'.expandtabs(), b'abc\rab      def\ng       hi');
+        self.assertEqual(b'abc\rab\tdef\ng\thi'.expandtabs(8), b'abc\rab      def\ng       hi');
+        self.assertEqual(b'abc\rab\tdef\ng\thi'.expandtabs(4), b'abc\rab  def\ng   hi')
+        self.assertEqual(b'abc\r\nab\tdef\ng\thi'.expandtabs(), b'abc\r\nab      def\ng       hi')
+        self.assertEqual(b'abc\r\nab\tdef\ng\thi'.expandtabs(8), b'abc\r\nab      def\ng       hi')
+        self.assertEqual(b'abc\r\nab\tdef\ng\thi'.expandtabs(4), b'abc\r\nab  def\ng   hi')
+        self.assertEqual(b'abc\r\nab\r\ndef\ng\r\nhi'.expandtabs(4), b'abc\r\nab\r\ndef\ng\r\nhi')
+        
     def test_iteration(self):
         a = bytes("abc", "ascii")
         self.assertEqual(list(a), [97,98,99])
@@ -432,6 +441,16 @@ class BytesTests(unittest.TestCase):
         self.assertRaises(TypeError, a.replace, b, c, "1")
         self.assertRaises(TypeError, a.replace, b)
 
+    def test_rsplit(self):
+        self.assertEqual(b'a b'.rsplit(), [b'a', b'b']);
+        self.assertEqual(b' a b '.rsplit(), [b'a', b'b']);
+        self.assertEqual(b'a b'.rsplit(b' '), [b'a', b'b']);
+        self.assertEqual(b'a b '.rsplit(b' '), [b'a', b'b', b'']);
+        self.assertRaises(TypeError, b'a b'.rsplit, ' ')
+        self.assertRaises(TypeError, b'a b'.rsplit, 32)
+        # b = b"\x09\x0A\x0B\x0C\x0D\x1C\x1D\x1E\x1F"
+        # self.assertEqual(b.rsplit(), [b'\x1c\x1d\x1e\x1f'])        
+        
     def test_rfind(self):
         a = bytes([1, 2, 1, 4, 5, 4, 5])
         self.assertEqual(a.rfind(1), 2)
@@ -521,6 +540,24 @@ class BytesTests(unittest.TestCase):
         self.assertEqual(a.partition(b), (bytes([1]), bytes([2, 2]), bytes([2, 4, 2, 2])))
         self.assertRaises(TypeError, a.partition, 2)
         self.assertRaises(TypeError, a.partition, bytes([2]), bytes([2]))
+
+    def test_title(self):
+        self.assertEqual(b' hello '.title(), b' Hello ')
+        self.assertEqual(b'hello '.title(), b'Hello ')
+        self.assertEqual(b'Hello '.title(), b'Hello ')
+        self.assertEqual(b"fOrMaT thIs aS titLe String".title(), b'Format This As Title String')
+        self.assertEqual(b"fOrMaT,thIs-aS*titLe;String".title(), b'Format,This-As*Title;String')
+        self.assertEqual(b"getInt".title(), b'Getint')
+
+    def test_splitlines(self):
+        self.assertEqual(b'abc\ndef\n\rghi'.splitlines(), [b'abc', b'def', b'', b'ghi']) 
+        self.assertEqual(b'abc\ndef\n\r\nghi'.splitlines(), [b'abc', b'def', b'', b'ghi']) 
+        self.assertEqual(b'abc\ndef\r\nghi'.splitlines(), [b'abc', b'def', b'ghi'])
+        self.assertEqual(b'abc\ndef\r\nghi\n'.splitlines(), [b'abc', b'def', b'ghi'])
+        self.assertEqual(b'abc\ndef\r\nghi\n\r'.splitlines(), [b'abc', b'def', b'ghi', b''])
+        self.assertEqual(b'\nabc\ndef\r\nghi\n\r'.splitlines(), [b'', b'abc', b'def', b'ghi', b''])
+        self.assertEqual(b'\nabc\ndef\r\nghi\n\r'.splitlines(False), [b'', b'abc', b'def', b'ghi', b''])                        
+        self.assertEqual(b'\nabc\ndef\r\nghi\n\r'.splitlines(True), [b'\n', b'abc\n', b'def\r\n', b'ghi\n', b'\r'])
 
     def test_startswith(self):
         a = bytes([1, 2, 2, 3])
@@ -723,6 +760,19 @@ class BytesTests(unittest.TestCase):
         self.assertFalse(d.islower())
 
         self.assertRaises(TypeError, d.islower, 1)
+
+    def test_istitle(self):
+        self.assertFalse(b''.istitle())
+        self.assertFalse(b'a'.istitle())
+        self.assertTrue(b'A'.istitle())
+        self.assertFalse(b'\n'.istitle())
+        self.assertTrue(b'A Titlecased Line'.istitle())
+        self.assertTrue(b'A\nTitlecased Line'.istitle())
+        self.assertTrue(b'A Titlecased, Line'.istitle())
+        self.assertFalse(b'Not a capitalized String'.istitle())
+        self.assertFalse(b'Not\ta Titlecase String'.istitle())
+        self.assertFalse(b'Not--a Titlecase String'.istitle())
+        self.assertFalse(b'NOT'.istitle())
 
     def test_isspace(self):
         a = bytes([])

--- a/test/unit3/test_bytes.py
+++ b/test/unit3/test_bytes.py
@@ -984,5 +984,43 @@ class BytesTests(unittest.TestCase):
         self.assertEqual([ord(b[i:i+1]) for i in range(len(b))],
                             [0, 65, 127, 128, 255])
 
+
+    def test_custom(self):
+        class BytesSubclass(bytes):
+            pass
+        class OtherBytesSubclass(bytes):
+            pass
+
+        class A:
+            def __bytes__(self):
+                return b'abc'
+        self.assertEqual(bytes(A()), b'abc')
+        class A: pass
+        self.assertRaises(TypeError, bytes, A())
+        class A:
+            def __bytes__(self):
+                return None
+        self.assertRaises(TypeError, bytes, A())
+        class A:
+            def __bytes__(self):
+                return b'a'
+            def __index__(self):
+                return 42
+        self.assertEqual(bytes(A()), b'a')
+        # Issue #25766
+        class A(str):
+            def __bytes__(self):
+                return b'abc'
+        self.assertEqual(bytes(A('\u20ac')), b'abc')
+        # self.assertEqual(bytes(A('\u20ac'), 'iso8859-15'), b'\xa4')
+        # Issue #24731
+        class A:
+            def __bytes__(self):
+                return OtherBytesSubclass(b'abc')
+        self.assertEqual(bytes(A()), b'abc')
+        self.assertIs(type(bytes(A())), OtherBytesSubclass)
+        self.assertEqual(BytesSubclass(A()), b'abc')
+        self.assertIs(type(BytesSubclass(A())), BytesSubclass)
+
 if __name__ == '__main__':
     unittest.main()  

--- a/test/unit3/test_bytes.py
+++ b/test/unit3/test_bytes.py
@@ -2,6 +2,24 @@
 import unittest
 
 class BytesTests(unittest.TestCase):
+    def test_repr_str(self):
+        for f in str, repr:
+            # self.assertEqual(f(bytearray()), "bytearray(b'')")
+            # self.assertEqual(f(bytearray([0])), "bytearray(b'\\x00')")
+            # self.assertEqual(f(bytearray([0, 1, 254, 255])),
+            #                  "bytearray(b'\\x00\\x01\\xfe\\xff')")
+            self.assertEqual(f(b"abc"), "b'abc'")
+            self.assertEqual(f(b"'"), '''b"'"''') # '''
+            self.assertEqual(f(b"'\""), r"""b'\'"'""") # '
+
+    def test_to_str(self):
+        self.assertEqual(str(b''), "b''")
+        self.assertEqual(str(b'x'), "b'x'")
+        self.assertEqual(str(b'\x80'), "b'\\x80'")
+        # self.assertEqual(str(bytearray(b'')), "bytearray(b'')")
+        # self.assertEqual(str(bytearray(b'x')), "bytearray(b'x')")
+        # self.assertEqual(str(bytearray(b'\x80')), "bytearray(b'\\x80')")
+
     def test_integer_arg(self):
         self.assertRaises(TypeError, bytes, "3")
         a = bytes(4)
@@ -110,6 +128,35 @@ class BytesTests(unittest.TestCase):
         self.assertNotIn(bytes(b"d"), b)
         self.assertNotIn(bytes(b"dab"), b)
         self.assertNotIn(bytes(b"abd"), b)
+
+    def test_compare_bytes_to_bytearray(self):
+        self.assertEqual(b"abc" == bytes(b"abc"), True)
+        self.assertEqual(b"ab" != bytes(b"abc"), True)
+        # self.assertEqual(b"ab" <= bytes(b"abc"), True)
+        # self.assertEqual(b"ab" < bytes(b"abc"), True)
+        # self.assertEqual(b"abc" >= bytes(b"ab"), True)
+        # self.assertEqual(b"abc" > bytes(b"ab"), True)
+
+        self.assertEqual(b"abc" != bytes(b"abc"), False)
+        self.assertEqual(b"ab" == bytes(b"abc"), False)
+        # self.assertEqual(b"ab" > bytes(b"abc"), False)
+        # self.assertEqual(b"ab" >= bytes(b"abc"), False)
+        # self.assertEqual(b"abc" < bytes(b"ab"), False)
+        # self.assertEqual(b"abc" <= bytes(b"ab"), False)
+
+        self.assertEqual(bytes(b"abc") == b"abc", True)
+        self.assertEqual(bytes(b"ab") != b"abc", True)
+        # self.assertEqual(bytes(b"ab") <= b"abc", True)
+        # self.assertEqual(bytes(b"ab") < b"abc", True)
+        # self.assertEqual(bytes(b"abc") >= b"ab", True)
+        # self.assertEqual(bytes(b"abc") > b"ab", True)
+
+        self.assertEqual(bytes(b"abc") != b"abc", False)
+        self.assertEqual(bytes(b"ab") == b"abc", False)
+        # self.assertEqual(bytes(b"ab") > b"abc", False)
+        # self.assertEqual(bytes(b"ab") >= b"abc", False)
+        # self.assertEqual(bytes(b"abc") < b"ab", False)
+        # self.assertEqual(bytes(b"abc") <= b"ab", False)
 
     def test_decode(self):
         a = bytes("abc", "ascii")
@@ -238,6 +285,40 @@ class BytesTests(unittest.TestCase):
         self.assertEqual(3 * b'dk3', b'dk3dk3dk3')
 
         self.assertRaises(TypeError, lambda x: x * x, a)
+
+    # def test_mod(self):
+    #     b = bytes(b'hello, %b!')
+    #     orig = b
+    #     b = b % b'world'
+    #     self.assertEqual(b, b'hello, world!')
+    #     self.assertEqual(orig, b'hello, %b!')
+    #     self.assertFalse(b is orig)
+    #     b = bytes(b'%s / 100 = %d%%')
+    #     a = b % (b'seventy-nine', 79)
+    #     self.assertEqual(a, b'seventy-nine / 100 = 79%')
+    #     self.assertIs(type(a), bytes)
+    #     # issue 29714
+    #     b = bytes(b'hello,\x00%b!')
+    #     b = b % b'world'
+    #     self.assertEqual(b, b'hello,\x00world!')
+    #     self.assertIs(type(b), bytes)
+
+    # def test_imod(self):
+    #     b = bytes(b'hello, %b!')
+    #     orig = b
+    #     b %= b'world'
+    #     self.assertEqual(b, b'hello, world!')
+    #     self.assertEqual(orig, b'hello, %b!')
+    #     self.assertFalse(b is orig)
+    #     b = bytes(b'%s / 100 = %d%%')
+    #     b %= (b'seventy-nine', 79)
+    #     self.assertEqual(b, b'seventy-nine / 100 = 79%')
+    #     self.assertIs(type(b), bytes)
+    #     # issue 29714
+    #     b = bytes(b'hello,\x00%b!')
+    #     b %= b'world'
+    #     self.assertEqual(b, b'hello,\x00world!')
+    #     self.assertIs(type(b), bytes)
 
     def test_fromhex(self):
         a = "0f34"
@@ -846,6 +927,62 @@ class BytesTests(unittest.TestCase):
         self.assertRaises(TypeError, d.zfill, "2")
         self.assertRaises(TypeError, d.zfill)
         self.assertRaises(TypeError, d.zfill, 3, 3)
+
+    def test_none_arguments(self):
+        # issue 11828
+        b = bytes(b'hello')
+        l = bytes(b'l')
+        h = bytes(b'h')
+        x = bytes(b'x')
+        o = bytes(b'o')
+
+        self.assertEqual(2, b.find(l, None))
+        self.assertEqual(3, b.find(l, -2, None))
+        self.assertEqual(2, b.find(l, None, -2))
+        self.assertEqual(0, b.find(h, None, None))
+
+        self.assertEqual(3, b.rfind(l, None))
+        self.assertEqual(3, b.rfind(l, -2, None))
+        self.assertEqual(2, b.rfind(l, None, -2))
+        self.assertEqual(0, b.rfind(h, None, None))
+
+        self.assertEqual(2, b.index(l, None))
+        self.assertEqual(3, b.index(l, -2, None))
+        self.assertEqual(2, b.index(l, None, -2))
+        self.assertEqual(0, b.index(h, None, None))
+
+        self.assertEqual(3, b.rindex(l, None))
+        self.assertEqual(3, b.rindex(l, -2, None))
+        self.assertEqual(2, b.rindex(l, None, -2))
+        self.assertEqual(0, b.rindex(h, None, None))
+
+        self.assertEqual(2, b.count(l, None))
+        self.assertEqual(1, b.count(l, -2, None))
+        self.assertEqual(1, b.count(l, None, -2))
+        self.assertEqual(0, b.count(x, None, None))
+
+        self.assertEqual(True, b.endswith(o, None))
+        self.assertEqual(True, b.endswith(o, -2, None))
+        self.assertEqual(True, b.endswith(l, None, -2))
+        self.assertEqual(False, b.endswith(x, None, None))
+
+        self.assertEqual(True, b.startswith(h, None))
+        self.assertEqual(True, b.startswith(l, -2, None))
+        self.assertEqual(True, b.startswith(h, None, -2))
+        self.assertEqual(False, b.startswith(x, None, None))
+
+
+    # def test_integer_arguments_out_of_byte_range(self):
+    #     b = bytes(b'hello')
+    #     for method in (b.count, b.find, b.index, b.rfind, b.rindex):
+    #         self.assertRaises(ValueError, method, -1)
+    #         self.assertRaises(ValueError, method, 256)
+    #         self.assertRaises(ValueError, method, 9999)
+
+    def test_ord(self):
+        b = bytes(b'\0A\x7f\x80\xff')
+        self.assertEqual([ord(b[i:i+1]) for i in range(len(b))],
+                            [0, 65, 127, 128, 255])
 
 if __name__ == '__main__':
     unittest.main()  

--- a/test/unit3/test_bytes.py
+++ b/test/unit3/test_bytes.py
@@ -10,6 +10,8 @@ class Indexable:
         return self.value
 
 class BytesTests(unittest.TestCase):
+    type2test = bytes
+
     def test_repr_str(self):
         for f in str, repr:
             # self.assertEqual(f(bytearray()), "bytearray(b'')")
@@ -99,6 +101,42 @@ class BytesTests(unittest.TestCase):
         self.assertRaises(LookupError, bytes, "abc", "asd")
         self.assertRaises(UnicodeEncodeError, bytes, "ÿ", "ascii")
 
+    def test_compare(self):
+        b1 = self.type2test([1, 2, 3])
+        b2 = self.type2test([1, 2, 3])
+        b3 = self.type2test([1, 3])
+
+        self.assertEqual(b1, b2)
+        self.assertTrue(b2 != b3)
+        self.assertTrue(b1 <= b2)
+        self.assertTrue(b1 <= b3)
+        self.assertTrue(b1 <  b3)
+        self.assertTrue(b1 >= b2)
+        self.assertTrue(b3 >= b2)
+        self.assertTrue(b3 >  b2)
+
+        self.assertFalse(b1 != b2)
+        self.assertFalse(b2 == b3)
+        self.assertFalse(b1 >  b2)
+        self.assertFalse(b1 >  b3)
+        self.assertFalse(b1 >= b3)
+        self.assertFalse(b1 <  b2)
+        self.assertFalse(b3 <  b2)
+        self.assertFalse(b3 <= b2)
+
+    def test_compare_to_str(self):
+        # Byte comparisons with unicode should always fail!
+        # Test this for all expected byte orders and Unicode character
+        # sizes.
+        self.assertEqual(self.type2test(b"\0a\0b\0c") == "abc", False)
+        self.assertEqual(self.type2test(b"\0\0\0a\0\0\0b\0\0\0c") == "abc",
+                            False)
+        self.assertEqual(self.type2test(b"a\0b\0c\0") == "abc", False)
+        self.assertEqual(self.type2test(b"a\0\0\0b\0\0\0c\0\0\0") == "abc",
+                            False)
+        self.assertEqual(self.type2test() == str(), False)
+        self.assertEqual(self.type2test() != str(), True)
+
     def test_comparisons(self):
         a = bytes([1, 2, 3])
         b = bytes([1, 2, 3])
@@ -140,31 +178,31 @@ class BytesTests(unittest.TestCase):
     def test_compare_bytes_to_bytearray(self):
         self.assertEqual(b"abc" == bytes(b"abc"), True)
         self.assertEqual(b"ab" != bytes(b"abc"), True)
-        # self.assertEqual(b"ab" <= bytes(b"abc"), True)
-        # self.assertEqual(b"ab" < bytes(b"abc"), True)
-        # self.assertEqual(b"abc" >= bytes(b"ab"), True)
-        # self.assertEqual(b"abc" > bytes(b"ab"), True)
+        self.assertEqual(b"ab" <= bytes(b"abc"), True)
+        self.assertEqual(b"ab" < bytes(b"abc"), True)
+        self.assertEqual(b"abc" >= bytes(b"ab"), True)
+        self.assertEqual(b"abc" > bytes(b"ab"), True)
 
         self.assertEqual(b"abc" != bytes(b"abc"), False)
         self.assertEqual(b"ab" == bytes(b"abc"), False)
-        # self.assertEqual(b"ab" > bytes(b"abc"), False)
-        # self.assertEqual(b"ab" >= bytes(b"abc"), False)
-        # self.assertEqual(b"abc" < bytes(b"ab"), False)
-        # self.assertEqual(b"abc" <= bytes(b"ab"), False)
+        self.assertEqual(b"ab" > bytes(b"abc"), False)
+        self.assertEqual(b"ab" >= bytes(b"abc"), False)
+        self.assertEqual(b"abc" < bytes(b"ab"), False)
+        self.assertEqual(b"abc" <= bytes(b"ab"), False)
 
         self.assertEqual(bytes(b"abc") == b"abc", True)
         self.assertEqual(bytes(b"ab") != b"abc", True)
-        # self.assertEqual(bytes(b"ab") <= b"abc", True)
-        # self.assertEqual(bytes(b"ab") < b"abc", True)
-        # self.assertEqual(bytes(b"abc") >= b"ab", True)
-        # self.assertEqual(bytes(b"abc") > b"ab", True)
+        self.assertEqual(bytes(b"ab") <= b"abc", True)
+        self.assertEqual(bytes(b"ab") < b"abc", True)
+        self.assertEqual(bytes(b"abc") >= b"ab", True)
+        self.assertEqual(bytes(b"abc") > b"ab", True)
 
         self.assertEqual(bytes(b"abc") != b"abc", False)
         self.assertEqual(bytes(b"ab") == b"abc", False)
-        # self.assertEqual(bytes(b"ab") > b"abc", False)
-        # self.assertEqual(bytes(b"ab") >= b"abc", False)
-        # self.assertEqual(bytes(b"abc") < b"ab", False)
-        # self.assertEqual(bytes(b"abc") <= b"ab", False)
+        self.assertEqual(bytes(b"ab") > b"abc", False)
+        self.assertEqual(bytes(b"ab") >= b"abc", False)
+        self.assertEqual(bytes(b"abc") < b"ab", False)
+        self.assertEqual(bytes(b"abc") <= b"ab", False)
 
     def test_decode(self):
         a = bytes("abc", "ascii")
@@ -1029,8 +1067,6 @@ class BytesTests(unittest.TestCase):
         self.assertIs(type(bytes(A())), OtherBytesSubclass)
         self.assertEqual(BytesSubclass(A()), b'abc')
         self.assertIs(type(BytesSubclass(A())), BytesSubclass)
-
-    type2test = bytes
 
 
     def test_empty_sequence(self):

--- a/test/unit3/test_bytes.py
+++ b/test/unit3/test_bytes.py
@@ -1,5 +1,6 @@
 """ Unit testing for bytes object"""
 import unittest
+import sys
 
 class BytesTests(unittest.TestCase):
     def test_repr_str(self):
@@ -1021,6 +1022,38 @@ class BytesTests(unittest.TestCase):
         self.assertIs(type(bytes(A())), OtherBytesSubclass)
         self.assertEqual(BytesSubclass(A()), b'abc')
         self.assertIs(type(BytesSubclass(A())), BytesSubclass)
+
+    type2test = bytes
+    def test_constructor_type_errors(self):
+        self.assertRaises(TypeError, self.type2test, 0.0)
+        class C:
+            pass
+        self.assertRaises(TypeError, self.type2test, ["0"])
+        self.assertRaises(TypeError, self.type2test, [0.0])
+        self.assertRaises(TypeError, self.type2test, [None])
+        self.assertRaises(TypeError, self.type2test, [C()])
+        # self.assertRaises(TypeError, self.type2test, encoding='ascii') # kwargs not yet supportd
+        # self.assertRaises(TypeError, self.type2test, errors='ignore') # kwargs not yet supported
+        self.assertRaises(TypeError, self.type2test, 0, 'ascii')
+        self.assertRaises(TypeError, self.type2test, b'', 'ascii')
+        # self.assertRaises(TypeError, self.type2test, 0, errors='ignore') # kwargs not yet supported
+        # self.assertRaises(TypeError, self.type2test, b'', errors='ignore') # kwargs not yet supported
+        self.assertRaises(TypeError, self.type2test, '')
+        # self.assertRaises(TypeError, self.type2test, '', errors='ignore') # kwargs not yet supported
+        self.assertRaises(TypeError, self.type2test, '', b'ascii')
+        self.assertRaises(TypeError, self.type2test, '', 'ascii', b'ignore')
+
+    def test_constructor_value_errors(self):
+        self.assertRaises(ValueError, self.type2test, [-1])
+        self.assertRaises(ValueError, self.type2test, [-sys.maxsize])
+        self.assertRaises(ValueError, self.type2test, [-sys.maxsize-1])
+        self.assertRaises(ValueError, self.type2test, [-sys.maxsize-2])
+        self.assertRaises(ValueError, self.type2test, [-10**100])
+        self.assertRaises(ValueError, self.type2test, [256])
+        self.assertRaises(ValueError, self.type2test, [257])
+        self.assertRaises(ValueError, self.type2test, [sys.maxsize])
+        self.assertRaises(ValueError, self.type2test, [sys.maxsize+1])
+        self.assertRaises(ValueError, self.type2test, [10**100])
 
 if __name__ == '__main__':
     unittest.main()  

--- a/test/unit3/test_bytes.py
+++ b/test/unit3/test_bytes.py
@@ -124,6 +124,8 @@ class BytesTests(unittest.TestCase):
         self.assertFalse(b3 <  b2)
         self.assertFalse(b3 <= b2)
 
+        self.assertTrue(b'\xfe' < b'\xff') # skulpt test for non utf8 character
+
     def test_compare_to_str(self):
         # Byte comparisons with unicode should always fail!
         # Test this for all expected byte orders and Unicode character

--- a/test/unit3/test_fstring.py
+++ b/test/unit3/test_fstring.py
@@ -611,20 +611,19 @@ class TestCase(unittest.TestCase):
         self.assertEqual(f'{2}\t{3}', '2\t3')
         self.assertEqual(f'\t{3}', '\t3')
 
-        # Skulpt TODO: These will work after PR#983 (real unicode strings) lands
-        # self.assertEqual(f'\u0394', '\u0394')
-        # self.assertEqual(r'\u0394', '\\u0394')
-        # self.assertEqual(rf'\u0394', '\\u0394')
-        # self.assertEqual(f'{2}\u0394', '2\u0394')
-        # self.assertEqual(f'{2}\u0394{3}', '2\u03943')
-        # self.assertEqual(f'\u0394{3}', '\u03943')
+        self.assertEqual(f'\u0394', '\u0394')
+        self.assertEqual(r'\u0394', '\\u0394')
+        self.assertEqual(rf'\u0394', '\\u0394')
+        self.assertEqual(f'{2}\u0394', '2\u0394')
+        self.assertEqual(f'{2}\u0394{3}', '2\u03943')
+        self.assertEqual(f'\u0394{3}', '\u03943')
 
-        # self.assertEqual(f'\U00000394', '\u0394')
-        # self.assertEqual(r'\U00000394', '\\U00000394')
-        # self.assertEqual(rf'\U00000394', '\\U00000394')
-        # self.assertEqual(f'{2}\U00000394', '2\u0394')
-        # self.assertEqual(f'{2}\U00000394{3}', '2\u03943')
-        # self.assertEqual(f'\U00000394{3}', '\u03943')
+        self.assertEqual(f'\U00000394', '\u0394')
+        self.assertEqual(r'\U00000394', '\\U00000394')
+        self.assertEqual(rf'\U00000394', '\\U00000394')
+        self.assertEqual(f'{2}\U00000394', '2\u0394')
+        self.assertEqual(f'{2}\U00000394{3}', '2\u03943')
+        self.assertEqual(f'\U00000394{3}', '\u03943')
 
         # Skulpt doesn't support \N{} escapes, because we don't bundle the
         # Unicode database

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -198,6 +198,27 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual(b'x' + b'y', b'xy')
         self.assertRaises(TypeError, lambda: b'x' + 'y')
 
+        # Repeat
+        self.assertEqual(b'x'*3, b'xxx')
+
+        # Search
+        self.assertTrue(b'y' in b'xyz')
+        self.assertFalse(b'a' in b'xyz')
+        self.assertEqual(b'abc'.find(b'b'), 1)
+        self.assertEqual(b'abc'.find(b'z'), -1)
+        self.assertRaises(TypeError, lambda: 'y' in b'xyz')
+        self.assertRaises(TypeError, lambda: b'xyz'.find('y'))
+        self.assertRaises(TypeError, lambda: b'y' in 'xyz')
+        self.assertRaises(TypeError, lambda: 'xyz'.find(b'y'))
+
+        # Index and slice
+        self.assertEqual(b'xyz'[2], b'z')
+        self.assertEqual(b'xyz'[-1], b'z')
+        self.assertEqual(b'xyz'[:2], b'xy')
+
+        # To and from hex
+        self.assertEqual(bytes.fromhex('2Ef0 F1f2 '), b'.\xf0\xf1\xf2')
+        self.assertEqual(b'\xf0\xf1\xf2'.hex(), 'f0f1f2')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -176,7 +176,7 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual(bytes('Love \U0001f355!', 'utf-8'), b'Love \xf0\x9f\x8d\x95!')
 
         # Construct string from bytestring
-        self.assertEqual(str(b'\xf0\x9f\x8d\x95'), '\U0001f355')
+        # self.assertEqual(str(b'\xf0\x9f\x8d\x95'), '\U0001f355')
         self.assertEqual(str(b'\xf0\x9f\x8d\x95', "utf-8"), '\U0001f355')
 
         # Construct bytestring from bytestring

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -134,8 +134,11 @@ class StringMethodsTests(unittest.TestCase):
 
         self.assertEqual(list('Love \U0001f355!'), ['L', 'o', 'v', 'e', ' ', '\U0001f355', '!'])
 
+        # Lookups and slices happen in Python (ie codepoint) coordinates
         self.assertEqual('Love \U0001f355!'[6], '!')
         self.assertEqual('Love \U0001f355!'[5], '\U0001f355')
+        self.assertEqual('Love \U0001f355!'[-2], '\U0001f355')
+
         self.assertEqual('Love \U0001f355!'[4:6], ' \U0001f355')
         self.assertEqual('Love \U0001f355!'[:6], 'Love \U0001f355')
         self.assertEqual('Love \U0001f355!'[4:], ' \U0001f355!')
@@ -144,10 +147,18 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('abc\U0001f355def'[-2::-2], 'e\U0001f355b')
         self.assertEqual('abc\U0001f355def'[-1::-2], 'fdca')
 
+        # find() happens in codepoint coordinates
         self.assertEqual('Love \U0001f355!'.find('!'), 6)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', 0, 6), 5)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -1), 5)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -2), -1)
+
+        # count() too
+        self.assertEqual('Love \U0001f355!'.count('\U0001f355', -2), 1)
+        self.assertEqual('Love \U0001f355!'.count('\U0001f355', -1), 0)
+
+        # ljust() (same impl as rjust())
+        self.assertEqual('Love \U0001f355!'.ljust(10, '\U0001f355'), 'Love \U0001f355!\U0001f355\U0001f355\U0001f355')
 
     def test_bytes(self):
         # Bytes are not strings
@@ -182,6 +193,10 @@ class StringMethodsTests(unittest.TestCase):
         class D:
             pass
         self.assertRaises(TypeError, lambda: bytes(D()))
+
+        # Concatenate
+        self.assertEqual(b'x' + b'y', b'xy')
+        self.assertRaises(TypeError, lambda: b'x' + 'y')
 
 
 if __name__ == '__main__':

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -110,6 +110,9 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual(ord('\u2603'), 0x2603)
         self.assertEqual(chr(0x2603), '\u2603')
 
+        # Unicode doesn't get escaped in repr(), but escape chars still do
+        self.assertEqual(repr('\x01\xf0\u2603'), "'\\x01\xf0\u2603'")
+
         # Indexing: It's a single character
         self.assertEqual(len('Build a \u2603!'), 10)
         self.assertEqual('Build a \u2603!'[9], '!')

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -169,7 +169,11 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual(bytes('hello', 'utf-8'), b'hello')
         self.assertEqual(bytes('Love \U0001f355!', 'utf-8'), b'Love \xf0\x9f\x8d\x95!')
 
-        # Construct from bytestrings
+        # Construct string from bytestring
+        self.assertEqual(str(b'\xf0\x9f\x8d\x95'), '\U0001f355')
+        self.assertEqual(str(b'\xf0\x9f\x8d\x95', "utf-8"), '\U0001f355')
+
+        # Construct bytestring from bytestring
         self.assertEqual(bytes(b'hello'), b'hello')
 
         # Construct empty bytestrings
@@ -204,6 +208,9 @@ class StringMethodsTests(unittest.TestCase):
         # Search
         self.assertTrue(b'y' in b'xyz')
         self.assertFalse(b'a' in b'xyz')
+        self.assertTrue(120 in b'xyz')
+        self.assertFalse(119 in b'xyz')
+        self.assertRaises(ValueError, lambda: 1000 in b'xyz')
         self.assertEqual(b'abc'.find(b'b'), 1)
         self.assertEqual(b'abc'.find(b'z'), -1)
         self.assertRaises(TypeError, lambda: 'y' in b'xyz')
@@ -212,9 +219,12 @@ class StringMethodsTests(unittest.TestCase):
         self.assertRaises(TypeError, lambda: 'xyz'.find(b'y'))
 
         # Index and slice
-        self.assertEqual(b'xyz'[2], b'z')
-        self.assertEqual(b'xyz'[-1], b'z')
+        self.assertEqual(b'xyz'[2], 122)
+        self.assertEqual(b'xyz'[-1], 122)
         self.assertEqual(b'xyz'[:2], b'xy')
+
+        # Iterate
+        self.assertEqual(list(b'xyz'), [120, 121, 122])
 
         # To and from hex
         self.assertEqual(bytes.fromhex('2Ef0 F1f2 '), b'.\xf0\xf1\xf2')

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -112,6 +112,9 @@ class StringMethodsTests(unittest.TestCase):
 
         # Unicode doesn't get escaped in repr(), but escape chars still do
         self.assertEqual(repr('\x01\xf0\u2603'), "'\\x01\xf0\u2603'")
+        # ...but it *does* get escaped in ascii()
+        self.assertEqual(ascii('hi there'), "'hi there'")
+        self.assertEqual(ascii('x\x01\xf0\u2603\U0001f355'), "'x\\x01\\xf0\\u2603\\U0001f355'")
 
         # Indexing: It's a single character
         self.assertEqual(len('Build a \u2603!'), 10)

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -107,6 +107,9 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('\u2603'.encode(), b'\xe2\x98\x83')
         self.assertEqual(b'\xe2\x98\x83'.decode(), '\u2603')
 
+        self.assertEqual(ord('\u2603'), 0x2603)
+        self.assertEqual(chr(0x2603), '\u2603')
+
         # Indexing: It's a single character
         self.assertEqual(len('Build a \u2603!'), 10)
         self.assertEqual('Build a \u2603!'[9], '!')
@@ -122,14 +125,24 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('\U0001f355'.encode(), b'\xf0\x9f\x8d\x95')
         self.assertEqual(b'\xf0\x9f\x8d\x95'.decode(), '\U0001f355')
 
+        self.assertEqual(ord('\U0001f355'), 0x1f355)
+        self.assertEqual(chr(0x1f355), '\U0001f355')
+
         # It's *still* a single character, even though it's a surrogate
         # pair in JS
         self.assertEqual(len('Love \U0001f355!'), 7)
+
+        self.assertEqual(list('Love \U0001f355!'), ['L', 'o', 'v', 'e', ' ', '\U0001f355', '!'])
+
         self.assertEqual('Love \U0001f355!'[6], '!')
         self.assertEqual('Love \U0001f355!'[5], '\U0001f355')
         self.assertEqual('Love \U0001f355!'[4:6], ' \U0001f355')
         self.assertEqual('Love \U0001f355!'[:6], 'Love \U0001f355')
         self.assertEqual('Love \U0001f355!'[4:], ' \U0001f355!')
+
+        self.assertEqual('Love \U0001f355!'[-2:], '\U0001f355!')
+        self.assertEqual('abc\U0001f355def'[-2::-2], 'e\U0001f355b')
+        self.assertEqual('abc\U0001f355def'[-1::-2], 'fdca')
 
         self.assertEqual('Love \U0001f355!'.find('!'), 6)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', 0, 6), 5)

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -115,6 +115,9 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('Build a \u2603!'[:9], 'Build a \u2603')
         self.assertEqual('Build a \u2603!'[6:], 'a \u2603!')
 
+        self.assertEqual('Build a \u2603!'.find('!'), 9)
+        self.assertEqual('Build a \u2603!'.find('\u2603'), 8)
+
         # Piece of pizza: Astral emoji
         self.assertEqual('\U0001f355'.encode(), b'\xf0\x9f\x8d\x95')
         self.assertEqual(b'\xf0\x9f\x8d\x95'.decode(), '\U0001f355')
@@ -127,6 +130,11 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('Love \U0001f355!'[4:6], ' \U0001f355')
         self.assertEqual('Love \U0001f355!'[:6], 'Love \U0001f355')
         self.assertEqual('Love \U0001f355!'[4:], ' \U0001f355!')
+
+        self.assertEqual('Love \U0001f355!'.find('!'), 6)
+        self.assertEqual('Love \U0001f355!'.find('\U0001f355', 0, 6), 5)
+        self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -1), 5)
+        self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -2), -1)
 
 
 if __name__ == '__main__':

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -101,6 +101,34 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual("%g" % (.00012), "0.00012")
         self.assertEqual("%d %i %o %x %X %e %E" % (12,-12,-0O7,0x4a,-0x4a,2.3e10,2.3E-10), "12 -12 -7 4a -4A 2.300000e+10 2.300000E-10")
         self.assertEqual("%g %G %g %G" % (.00000123,.00000123,1.4,-1.4), "1.23e-06 1.23E-06 1.4 -1.4")
+
+    def test_encoding(self):
+        # Unicode snowman: BMP emoji
+        self.assertEqual('\u2603'.encode(), b'\xe2\x98\x83')
+        self.assertEqual(b'\xe2\x98\x83'.decode(), '\u2603')
+
+        # Indexing: It's a single character
+        self.assertEqual(len('Build a \u2603!'), 10)
+        self.assertEqual('Build a \u2603!'[9], '!')
+        self.assertEqual('Build a \u2603!'[8], '\u2603')
+        self.assertEqual('Build a \u2603!'[6:9], 'a \u2603')
+        self.assertEqual('Build a \u2603!'[:9], 'Build a \u2603')
+        self.assertEqual('Build a \u2603!'[6:], 'a \u2603!')
+
+        # Piece of pizza: Astral emoji
+        self.assertEqual('\U0001f355'.encode(), b'\xf0\x9f\x8d\x95')
+        self.assertEqual(b'\xf0\x9f\x8d\x95'.decode(), '\U0001f355')
+
+        # It's *still* a single character, even though it's a surrogate
+        # pair in JS
+        self.assertEqual(len('Love \U0001f355!'), 7)
+        self.assertEqual('Love \U0001f355!'[6], '!')
+        self.assertEqual('Love \U0001f355!'[5], '\U0001f355')
+        self.assertEqual('Love \U0001f355!'[4:6], ' \U0001f355')
+        self.assertEqual('Love \U0001f355!'[:6], 'Love \U0001f355')
+        self.assertEqual('Love \U0001f355!'[4:], ' \U0001f355!')
+
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/test/unit3/test_string_methods.py
+++ b/test/unit3/test_string_methods.py
@@ -136,6 +136,40 @@ class StringMethodsTests(unittest.TestCase):
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -1), 5)
         self.assertEqual('Love \U0001f355!'.find('\U0001f355', None, -2), -1)
 
+    def test_bytes(self):
+        # Bytes are not strings
+        self.assertNotEqual(b'hello', 'hello')
+
+        # Construct from string
+        self.assertRaises(TypeError, lambda: bytes('hello'))
+        self.assertEqual(bytes('hello', 'utf-8'), b'hello')
+        self.assertEqual(bytes('Love \U0001f355!', 'utf-8'), b'Love \xf0\x9f\x8d\x95!')
+
+        # Construct from bytestrings
+        self.assertEqual(bytes(b'hello'), b'hello')
+
+        # Construct empty bytestrings
+        self.assertEqual(bytes(4), b'\x00\x00\x00\x00')
+
+        # Construct from object with __bytes__
+        class C:
+            def __bytes__(self):
+                return b'hello'
+
+            def __iter__(self):
+                # Gets pre-empted by __bytes__
+                return iter([1,2,3,4])
+        self.assertEqual(bytes(C()), b'hello')
+
+        # Construct from iterables
+        self.assertEqual(bytes([0xf0, 0x9f, 0x8d, 0x95]).decode(), '\U0001f355')
+        self.assertRaises(ValueError, lambda: bytes([0x100]))
+
+        # or give up
+        class D:
+            pass
+        self.assertRaises(TypeError, lambda: bytes(D()))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_suspensions.py
+++ b/test/unit3/test_suspensions.py
@@ -17,6 +17,10 @@ class sleepingEmptyIter:
       sleep(.01)
       raise StopIteration
 
+class sleepingClass:
+    def __bytes__ (self):
+        sleep(.01)
+        return b'abc'
 
 class Test_Suspensions(unittest.TestCase):
     def test_min_max(self):
@@ -45,6 +49,10 @@ class Test_Suspensions(unittest.TestCase):
     def test_builtin_types(self):
         self.assertEqual(list(sleeping_gen([1, 2, 3])), [1, 2, 3])
         self.assertEqual(tuple(sleeping_gen([1, 2, 3])), (1, 2, 3))
+
+    def test_bytes(self):
+        self.assertEqual(bytes(sleeping_gen([1,2,3])), bytes([1,2,3]))
+        self.assertEqual(bytes(sleepingClass()), b'abc')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pr is the aim to marry the unicode work in #983 and the bytes work in #989 
The diff to #989 can be seen here s-cork#7 (diff fixed to be more readable with latest changes rebased)
The approx diff with #983 can be seen at s-cork#10
_(it's not totally accurate since it was after a merge commit of #983 on top of #989 but it's approx accurate. 
You can see - the minor change to ast.js, 
change in `compile.js`
removal of `builtin.staticfunc` and `misceval.iterator` (additions in #983 branch)
adjustment to `builtin.ord` 
cleanse of bytes from `str.js`)_

**AST** 
changes here are from #983 
I made no change of the #983 algorithm apart from making sure the ascii characters were `< 0x7f` rather than `0xff`
This means that `b'¥'` is now correctly thrown as a `SyntaxError` which was not the case in #983.
#983 removed `decodeUtf8` in favour of `decodeEscape`
I'm happy to adjust this algorithm as per discussion - might need some suggestions here.

The motivation: it seemed the simplest way to marry the branches and allowed for correct encoding of bytes objects like `b"\xf0\x9f\x8d\x95"` which were part of the tests in #983.

Since there are no longer any surprising errors from `decodeUtf8` I remove the `try` `catch` statements in `parsestrplus`. 
`decodeEscape` throws the appropriate `ast_error` where `decodUtf8` might have failed without an `ast_error`

---

**Compile.js**
In `compile.js` I adjusted the approach from #983 and #989. 
Since the byte literal has already been tested for correctness I convert each character to it's `charCode` and use the fast path passing an array to the bytes constructor.


---

**Bytes**
(the changes to constructor may be more easily seen directly in the file compared to reading the diff)
Since there are about 10 ways to call the bytes constructor:
```
undefined, Uint8Array, Array of js integers, String, js integer,
str, iterable of int like objects, int, bytes instance, object with __bytes__
throw TypeError
```
I decoupled the internal JS calls from the python calls
and then further decoupled the encodings into a separate function... and then `ascii` encoding into its own function. 
I implement `__bytes__` (since it's part of the #983 tests and some additional cpython tests added) 
I add suspension awareness for calls to bytes with an iterator or  `__bytes__` method. (a couple of tests added to `test_suspensions` - suspension awareness part of #983 bytes constructor)
a couple of changes to constructor enhance some simple subclassing of bytes. (some addition cpython tests added)

small adjustments as additional cpython tests were added...
small change to `indices` function  allow `start`/`end` to be `None`.
small change to `bytes.decode` text signature since encoding has a default value
```python
>>> bytes.decode.__text_signature__
"($self, /, encoding='utf-8', errors='strict')"
```

edit:
I add a $jsstr method and use this to implement comparisons
```javascript
// akin to
this.$jsstr() < other.$jsstr();
```

---

**Str.js**
merged changes from #983 and cleansed bytes from the file
adjusted `startswith`/`endswith` in light of `"astral awareness"` since pr #1033 added the `start/end` arguments.

---

**builtin.js**
`ascii` function merged from #983 
`ord` adapted to take a single bytes object and cpython tests added

---

**Other tests and beyond the scope of this pr**
`mod`: `%` symbol not yet supported
`index/count`: the algorithm should raise `ValueError` for ints outside of `range(0, 256)`

I've added these tests but commented them out. 

I remove one test in #983 which was incorrect
```python
# self.assertEqual(str(b'\xf0\x9f\x8d\x95'), '\U0001f355')
```

other quick observation - future pr might wish to address `bytes.fromhex` which is a `classmethod_descriptor` 
```python
>>> type(bytes.__dict__['fromhex'])
classmethod_descriptor
```
so could be called like `b'abc'.fromhex('ff')` in the same way that `dict.fromkeys` can be called...  

kwarg support might also be the consideration of a future pr...
```python
>>> str(encoding='utf-8', errors='strict', object=b'foo')
'foo'
>>> bytes('foo', errors='strict', encoding='utf-8')
b'foo'
```