### PR TITLE
bytes mod hash

### DIFF
--- a/test/unit3/test_bytes.py
+++ b/test/unit3/test_bytes.py
@@ -334,39 +334,47 @@ class BytesTests(unittest.TestCase):
 
         self.assertRaises(TypeError, lambda x: x * x, a)
 
-    # def test_mod(self):
-    #     b = bytes(b'hello, %b!')
-    #     orig = b
-    #     b = b % b'world'
-    #     self.assertEqual(b, b'hello, world!')
-    #     self.assertEqual(orig, b'hello, %b!')
-    #     self.assertFalse(b is orig)
-    #     b = bytes(b'%s / 100 = %d%%')
-    #     a = b % (b'seventy-nine', 79)
-    #     self.assertEqual(a, b'seventy-nine / 100 = 79%')
-    #     self.assertIs(type(a), bytes)
-    #     # issue 29714
-    #     b = bytes(b'hello,\x00%b!')
-    #     b = b % b'world'
-    #     self.assertEqual(b, b'hello,\x00world!')
-    #     self.assertIs(type(b), bytes)
+    def test_mod(self):
+        b = bytes(b'hello, %b!')
+        orig = b
+        b = b % b'world'
+        self.assertEqual(b, b'hello, world!')
+        self.assertEqual(orig, b'hello, %b!')
+        self.assertFalse(b is orig)
+        b = bytes(b'%s / 100 = %d%%')
+        a = b % (b'seventy-nine', 79)
+        self.assertEqual(a, b'seventy-nine / 100 = 79%')
+        self.assertIs(type(a), bytes)
+        # issue 29714
+        b = bytes(b'hello,\x00%b!')
+        b = b % b'world'
+        self.assertEqual(b, b'hello,\x00world!')
+        self.assertIs(type(b), bytes)
 
-    # def test_imod(self):
-    #     b = bytes(b'hello, %b!')
-    #     orig = b
-    #     b %= b'world'
-    #     self.assertEqual(b, b'hello, world!')
-    #     self.assertEqual(orig, b'hello, %b!')
-    #     self.assertFalse(b is orig)
-    #     b = bytes(b'%s / 100 = %d%%')
-    #     b %= (b'seventy-nine', 79)
-    #     self.assertEqual(b, b'seventy-nine / 100 = 79%')
-    #     self.assertIs(type(b), bytes)
-    #     # issue 29714
-    #     b = bytes(b'hello,\x00%b!')
-    #     b %= b'world'
-    #     self.assertEqual(b, b'hello,\x00world!')
-    #     self.assertIs(type(b), bytes)
+        # test mapping
+        self.assertEqual(b'%(foo)s' % {b'foo': b'bar'}, b'bar')
+        x = b'\xf0\x9f\x8d\x95 %b'
+        self.assertEqual(x % b'foo', b'\xf0\x9f\x8d\x95 foo')
+        self.assertEqual(x % b'\xf0\x9f\x8d\x95', b'\xf0\x9f\x8d\x95 \xf0\x9f\x8d\x95')
+        # self.assertEqual(b'abc%(\xc2\xa2)s' % {b'\xc2\xa2': b'd'}, b'abcd') #skulpt fails with \ in the brackets
+
+
+    def test_imod(self):
+        b = bytes(b'hello, %b!')
+        orig = b
+        b %= b'world'
+        self.assertEqual(b, b'hello, world!')
+        self.assertEqual(orig, b'hello, %b!')
+        self.assertFalse(b is orig)
+        b = bytes(b'%s / 100 = %d%%')
+        b %= (b'seventy-nine', 79)
+        self.assertEqual(b, b'seventy-nine / 100 = 79%')
+        self.assertIs(type(b), bytes)
+        # issue 29714
+        b = bytes(b'hello,\x00%b!')
+        b %= b'world'
+        self.assertEqual(b, b'hello,\x00world!')
+        self.assertIs(type(b), bytes)
 
     def test_fromhex(self):
         a = "0f34"


### PR DESCRIPTION
extension of the bytes pr

this pr adds support for bytes `nb$remainder`
Rather than rewrite `nb$remainder` it piggybacks off `str.prototype.nb$remainder`

To fully support `nb$remainder` bytes objects must have the ability to be keys of dictionaries. 
The current `hash` function is not suitable since two `bytes objects` that are the same in python have different in `hash` values in skulpt.
```python
>>> hash(b'x') == hash(b'x')
False # should be True
```
Skulpt/Python `hash` function for `str` is consistent because of `interned`
in Python, the `hash` function for `bytes` is the same as for its `str` counterpart
```python
>>> hash('x')
-3753845217207833703
>>> hash(b'x')
-3753845217207833703
```
so for the `bytes` `hash` function it make sense to take the same value that is returned by the `hash` function when applied to its `str` counterpart.

```javascript
Sk.builtin.bytes.prototype.tp$hash = function () {
    return Sk.builtin.hash(new Sk.builtin.str(this.$jsstr()))
}
```

---

In order to piggy back off `str` I add `$baseType` onto the prototype of `bytes` and `str` - i'm not wedded to this notation. 

I think it's preferable to using `__class__` or `ob$type` because the `nb$remainder` should still work for instances of `str` and `bytes` and `__class__` and `ob$type` are overridden by subclasses where `this.$baseType` will not be overriden.

Other suggestions: `this.sk$base_type`, `this.sk$base`, `this.sk$builtin_base`, `this.sk$bltn_base`, `this.base$type`, `this.sk$bltn_subclass`.

---

I adjust the fast path for the constructor of `bytes` when given a `javascript string`.
This now must take a [javascript binary string](https://developer.mozilla.org/en-US/docs/Web/API/DOMString/Binary)
which means that each `charCode` must be between (0, 255) i.e. equivalent to each value for the resulting `Uint8Array`.

I think this is a sensible restriction for the fast path. 
It means that `new Sk.builtin.bytes(this.$jsstr())` has the same `Uint8Array` values as `this` 
I also think this is sensible change now since this `string` fast path is currently not used in the code base and so does not affect existing code. 


