### PR TITLE
import use mp_lookup and avoid try catch

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -203,13 +203,12 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, rela
         topLevelModuleToReturn = topLevelModuleToReturn_;
 
         // if leaf is already in sys.modules, early out
-        try {
-            prev = Sk.sysmodules.mp$subscript(modname);
+        prev = Sk.sysmodules.mp$lookup(modname);
+        if (prev !== undefined) {
             // if we're a dotted module, return the top level, otherwise ourselves
             return topLevelModuleToReturn || prev;
-        } catch (x) {
-            // not in sys.modules, continue
         }
+        // not in sys.modules, continue
 
         return Sk.misceval.chain(undefined, function() {
             var codeAndPath, co, googClosure;
@@ -490,11 +489,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
             relativeToPackageNames.length -= level-1;
             relativeToPackageName = relativeToPackageNames.join(".");
         }
-        try {
-            relativeToPackage = Sk.sysmodules.mp$subscript(relativeToPackageName);
-        } catch(e) {
-            relativeToPackageName = undefined;
-        }
+        relativeToPackage = Sk.sysmodules.mp$lookup(relativeToPackageName);
     }
 
     if (level > 0 && relativeToPackage === undefined) {


### PR DESCRIPTION
a couple of places where import statements could avoid a try catch by using `dict.mp$lookup` over `dict.mp$subscript`
the former returns `undefined` whereas the latter throws an error.