### PR TITLE
LookupError

### DIFF
--- a/src/dict.js
+++ b/src/dict.js
@@ -190,7 +190,6 @@ Sk.builtin.dict.prototype.mp$lookup = function (key) {
 
 Sk.builtin.dict.prototype.mp$subscript = function (key) {
     Sk.builtin.pyCheckArgsLen("[]", arguments.length, 1, 2, false, false);
-    var s;
     var res = this.mp$lookup(key);
 
     if (res !== undefined) {
@@ -198,8 +197,7 @@ Sk.builtin.dict.prototype.mp$subscript = function (key) {
         return res;
     } else {
         // Not found in dictionary
-        s = new Sk.builtin.str(key);
-        throw new Sk.builtin.KeyError(s.v);
+        throw new Sk.builtin.KeyError(key);
     }
 };
 
@@ -286,7 +284,7 @@ Sk.builtin.dict.prototype.pop$bucket_item = function (key, hash_value) {
 Sk.builtin.dict.prototype.mp$del_subscript = function (key) {
     Sk.builtin.pyCheckArgsLen("del", arguments.length, 1, 1, false, false);
     const hash = kf(key);
-    let item, s;
+    let item;
     if (typeof hash === "string") {
         // key is a string so remove from entries directly
         item = this.entries[hash];
@@ -300,8 +298,7 @@ Sk.builtin.dict.prototype.mp$del_subscript = function (key) {
         return;
     }
     // Not found in dictionary
-    s = new Sk.builtin.str(key);
-    throw new Sk.builtin.KeyError(s.v);
+    throw new Sk.builtin.KeyError(key);
 };
 
 Sk.builtin.dict.prototype["$r"] = function () {
@@ -351,7 +348,7 @@ Sk.builtin.dict.prototype["get"] = new Sk.builtin.func(function (self, k, d) {
 Sk.builtin.dict.prototype["pop"] = new Sk.builtin.func(function (self, key, d) {
     Sk.builtin.pyCheckArgsLen("pop()", arguments.length, 1, 2, false, true);
     const hash = kf(key);
-    let item, value, s;
+    let item, value;
     if (typeof hash === "string") {
         item = self.entries[hash];
         if (item !== undefined) {
@@ -374,8 +371,7 @@ Sk.builtin.dict.prototype["pop"] = new Sk.builtin.func(function (self, key, d) {
         return d;
     }
 
-    s = new Sk.builtin.str(key);
-    throw new Sk.builtin.KeyError(s.v);
+    throw new Sk.builtin.KeyError(key);
 });
 
 Sk.builtin.dict.prototype.haskey$ = function (self, k) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -184,6 +184,23 @@ Sk.abstr.setUpInheritance("IndexError", Sk.builtin.IndexError, Sk.builtin.Except
  * @extends Sk.builtin.Exception
  * @param {...*} args
  */
+Sk.builtin.LookupError = function (args) {
+    var o;
+    if (!(this instanceof Sk.builtin.LookupError)) {
+        o = Object.create(Sk.builtin.LookupError.prototype);
+        o.constructor.apply(o, arguments);
+        return o;
+    }
+    Sk.builtin.Exception.apply(this, arguments);
+};
+Sk.abstr.setUpInheritance("LookupError", Sk.builtin.LookupError, Sk.builtin.Exception);
+Sk.exportSymbol("Sk.builtin.LookupError", Sk.builtin.LookupError);
+
+/**
+ * @constructor
+ * @extends Sk.builtin.Exception
+ * @param {...*} args
+ */
 Sk.builtin.KeyError = function (args) {
     var o;
     if (!(this instanceof Sk.builtin.KeyError)) {
@@ -191,9 +208,9 @@ Sk.builtin.KeyError = function (args) {
         o.constructor.apply(o, arguments);
         return o;
     }
-    Sk.builtin.Exception.apply(this, arguments);
+    Sk.builtin.LookupError.apply(this, arguments);
 };
-Sk.abstr.setUpInheritance("KeyError", Sk.builtin.KeyError, Sk.builtin.Exception);
+Sk.abstr.setUpInheritance("KeyError", Sk.builtin.KeyError, Sk.builtin.LookupError);
 
 /**
  * @constructor
@@ -525,22 +542,6 @@ Sk.builtin.UnicodeEncodeError = function (args) {
 Sk.abstr.setUpInheritance("UnicodeEncodeError", Sk.builtin.UnicodeEncodeError, Sk.builtin.Exception);
 Sk.exportSymbol("Sk.builtin.UnicodeEncodeError", Sk.builtin.UnicodeEncodeError);
 
-/**
- * @constructor
- * @extends Sk.builtin.Exception
- * @param {...*} args
- */
-Sk.builtin.LookupError = function (args) {
-    var o;
-    if (!(this instanceof Sk.builtin.LookupError)) {
-        o = Object.create(Sk.builtin.LookupError.prototype);
-        o.constructor.apply(o, arguments);
-        return o;
-    }
-    Sk.builtin.Exception.apply(this, arguments);
-};
-Sk.abstr.setUpInheritance("LookupError", Sk.builtin.LookupError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.LookupError", Sk.builtin.LookupError);
 
 /**
  * @constructor

--- a/test/unit3/test_sets2.py
+++ b/test/unit3/test_sets2.py
@@ -218,6 +218,28 @@ class SetTests(unittest.TestCase):
         a = set(range(6))
         a.remove(5)
         self.assertEqual(a, set([0, 1, 2, 3, 4]))
+        self.assertRaises(KeyError, set('abc').remove, 'Q')
+
+    def test_remove_keyerror_unpacking(self):
+        # bug:  www.python.org/sf/1576657
+        s = set('simsalabim')
+        for v1 in ['Q', (1,)]:
+            try:
+                s.remove(v1)
+            except KeyError as e:
+                v2 = e.args[0]
+                self.assertEqual(v1, v2)
+            else:
+                self.fail()
+
+    def test_remove_absent(self):
+        s = set('simsalabim')
+        try:
+            s.remove("d")
+            self.fail("Removing missing element should have raised LookupError")
+        except LookupError:
+            pass
+
 
     def test_discard(self):
         empty = set([])


### PR DESCRIPTION
`LookupError` was recently introduced with `bytes`
this pr tidies a couple of related loose ends

```python
>>> KeyError.__bases__ 
(LookupError,) 
```

When a `KeyError` is thrown from a dict lookup we should throw the `KeyError` with the actual `key` and not the `repr`

```python
d = {}
x = 1
try: 
  d[x]
except KeyError as e:
  print(e.args[0] is x) # currently in skulpt the dict key lookups return the `repr` and so this would fail
```
