### PR TITLE
raise error with non Exception should raise an error

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -1359,7 +1359,7 @@ Compiler.prototype.craise = function (s) {
         // for the Python version you're using.
 
         var instantiatedException = this.newBlock("exception now instantiated");
-        var isClass = this._gr("isclass", exc + " instanceof Sk.builtin.type || " + exc + ".prototype instanceof Sk.builtin.BaseException");
+        var isClass = this._gr("isclass", exc + ".prototype instanceof Sk.builtin.BaseException");
         this._jumpfalse(isClass, instantiatedException);
         //this._jumpfalse(instantiatedException, isClass);
 
@@ -1383,7 +1383,7 @@ Compiler.prototype.craise = function (s) {
         // TODO TODO TODO set cause appropriately
         // (and perhaps traceback for py2 if we care before it gets fully deprecated)
 
-        out("throw ",exc,";");
+        out("if (", exc, " instanceof Sk.builtin.BaseException) {throw ",exc,";} else {throw new Sk.builtin.TypeError('exceptions must derive from BaseException');};");
     }
     else {
         // re-raise

--- a/test/unit3/test_errors.py
+++ b/test/unit3/test_errors.py
@@ -97,6 +97,22 @@ class TryExceptFinallyTest(unittest.TestCase):
         c = C()
         self.assertEqual(c.x, "Caught")
 
+    def test_bad_exception(self):
+        # Skulpt Bug
+        class InvalidException:
+            # does not inherit from BaseException
+            pass
+
+        with self.assertRaises(TypeError) as c:
+            raise InvalidException
+        self.assertIn("BaseException", c.exception.args[0])
+        
+        with self.assertRaises(TypeError):
+            raise InvalidException()
+
+        with self.assertRaises(TypeError):
+            raise 1
+
 if __name__ == '__main__':
     unittest.main()
             


### PR DESCRIPTION
```python
>> raise 1
TypeError: exceptions must derive from BaseException
# skulpt undefined undefined
```

This fixes a small issue that the user should only be able to raise `Exceptions` if they are instances of `BaseException` or classes that derive from `BaseException`

