### PR TITLE
starred assignment unpacking

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -482,6 +482,7 @@ Sk.abstr.sequenceSetSlice = function (seq, i1, i2, x) {
  * // Sk.abstr.sequenceUncpack(seq, 3, 3, false)
  * // return [int_(1), int_(2), int_(3)]
  * 
+ * 
  * a, *b, c = 1,2,3,4 
  * // Sk.abstr.sequenceUncpack(seq, 1, 2, true)
  * // return [int_(1), list(int_(2), int_(3)), int_(4)]
@@ -508,7 +509,7 @@ Sk.abstr.sequenceUnpack = function (seq, breakIdx, numvals, hasStar) {
     }
     const starred = [];
     for (let i = it.tp$iternext(); i !== undefined; i = it.tp$iternext()) {
-        starred.push[i];
+        starred.push(i);
     }
     const end = starred.length + breakIdx - numvals;
     if (end < 0) {

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -489,6 +489,9 @@ Sk.abstr.sequenceSetSlice = function (seq, i1, i2, x) {
  * 
  */
 Sk.abstr.sequenceUnpack = function (seq, breakIdx, numvals, hasStar) {
+    if (!Sk.builtin.checkIterable(seq)) {
+        throw new Sk.builtin.TypeError("cannot unpack non-iterable " + Sk.abstr.typeName(seq) + " object");
+    }
     const it = Sk.abstr.iter(seq);
     const res = [];
     for (let i = 0; i < breakIdx; i++) {

--- a/src/ast.js
+++ b/src/ast.js
@@ -160,6 +160,10 @@ function setContext (c, e, ctx, n) {
             }
             e.ctx = ctx;
             break;
+        case Sk.astnodes.Starred:
+            e.ctx = ctx;
+            setContext(c, e.value, ctx, n);
+            break;
         case Sk.astnodes.Subscript:
             e.ctx = ctx;
             break;

--- a/src/compile.js
+++ b/src/compile.js
@@ -341,7 +341,7 @@ Compiler.prototype.ctuplelistorset = function(e, data, tuporlist) {
             }
             for (i = starIdx + 1; i < e.elts.length; i++) {
                 if (e.elts[i].constructor === Sk.astnodes.Starred) {
-                    throw new Sk.builtin.SyntaxError("too many starred expressions in assignment", this.filename, e.lineno);
+                    throw new Sk.builtin.SyntaxError("multiple starred expressions in assignment", this.filename, e.lineno);
                 }
             }
         }

--- a/src/compile.js
+++ b/src/compile.js
@@ -337,11 +337,11 @@ Compiler.prototype.ctuplelistorset = function(e, data, tuporlist) {
     if (e.ctx === Sk.astnodes.Store) {
         if (hasStars) {
             if (!Sk.__future__.python3) {
-                throw new Sk.builtin.SyntaxError("assignment unpacking with stars is not supported in Python 2");
+                throw new Sk.builtin.SyntaxError("assignment unpacking with stars is not supported in Python 2", this.filename, e.lineno);
             }
             for (i = starIdx + 1; i < e.elts.length; i++) {
                 if (e.elts[i].constructor === Sk.astnodes.Starred) {
-                    throw new Sk.builtin.SyntaxError("too many starred expressions in assignment");
+                    throw new Sk.builtin.SyntaxError("too many starred expressions in assignment", this.filename, e.lineno);
                 }
             }
         }

--- a/src/compile.js
+++ b/src/compile.js
@@ -325,21 +325,38 @@ Compiler.prototype.ctuplelistorset = function(e, data, tuporlist) {
     Sk.asserts.assert(tuporlist === "tuple" || tuporlist === "list" || tuporlist === "set");
 
     let hasStars = false;
-    for (let elt of e.elts) {
-        if (elt.constructor === Sk.astnodes.Starred) { hasStars = true; break; }
+    let starIdx;
+    for (i = 0; i < e.elts.length; i++) {
+        if (e.elts[i].constructor === Sk.astnodes.Starred) {
+            hasStars = true;
+            starIdx = i;
+            break;
+        }
     }
 
     if (e.ctx === Sk.astnodes.Store) {
         if (hasStars) {
-            // TODO support this in Python 3 mode
-            throw new Sk.builtin.SyntaxError("Tuple unpacking with stars is not supported");
+            if (!Sk.__future__.python3) {
+                throw new Sk.builtin.SyntaxError("assignment unpacking with stars is not supported in Python 2");
+            }
+            for (i = starIdx + 1; i < e.elts.length; i++) {
+                if (e.elts[i].constructor === Sk.astnodes.Starred) {
+                    throw new Sk.builtin.SyntaxError("too many starred expressions in assignment");
+                }
+            }
         }
-        items = this._gr("items", "Sk.abstr.sequenceUnpack(" + data + "," + e.elts.length + ")");
+        const breakIdx = hasStars ? starIdx : e.elts.length;
+        const numvals = hasStars ? e.elts.length - 1 : breakIdx;
+        items = this._gr("items", "Sk.abstr.sequenceUnpack(" + data + "," + breakIdx + "," + numvals + ", " + hasStars + ")");
         for (i = 0; i < e.elts.length; ++i) {
-            this.vexpr(e.elts[i], items + "[" + i + "]");
+            if (i === starIdx) {
+                this.vexpr(e.elts[i].value, items + "[" + i + "]");
+            } else {
+                this.vexpr(e.elts[i], items + "[" + i + "]");
+            }
         }
-    }
-    else if (e.ctx === Sk.astnodes.Load || tuporlist === "set") { //because set's can't be assigned to.
+    } else if (e.ctx === Sk.astnodes.Load || tuporlist === "set") {
+        //because set's can't be assigned to.
 
         if (hasStars) {
             if (!Sk.__future__.python3) {
@@ -917,7 +934,14 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
         case Sk.astnodes.Set:
             return this.ctuplelistorset(e, data, 'set');
         case Sk.astnodes.Starred:
-            break;
+            switch (e.ctx) {
+                case Sk.astnodes.Store:
+                    /* In all legitimate cases, the Starred node was already replaced
+                     * by compiler_list/compiler_tuple. XXX: is that okay? */
+                    throw new Sk.builtin.SyntaxError("starred assignment target must be in a list or tuple", this.filename, e.lineno);
+                default:
+                    throw new Sk.builtin.SyntaxError("can't use starred expression here", this.filename, e.lineno);
+            }
         case Sk.astnodes.JoinedStr:
             return this.cjoinedstr(e);
         case Sk.astnodes.FormattedValue:

--- a/src/compile.js
+++ b/src/compile.js
@@ -347,7 +347,10 @@ Compiler.prototype.ctuplelistorset = function(e, data, tuporlist) {
         }
         const breakIdx = hasStars ? starIdx : e.elts.length;
         const numvals = hasStars ? e.elts.length - 1 : breakIdx;
-        items = this._gr("items", "Sk.abstr.sequenceUnpack(" + data + "," + breakIdx + "," + numvals + ", " + hasStars + ")");
+        out("$ret = Sk.abstr.sequenceUnpack(" + data + "," + breakIdx + "," + numvals + ", " + hasStars + ");");
+        this._checkSuspension();
+        items = this._gr("items", "$ret");
+        
         for (i = 0; i < e.elts.length; ++i) {
             if (i === starIdx) {
                 this.vexpr(e.elts[i].value, items + "[" + i + "]");

--- a/test/unit3/test_suspensions.py
+++ b/test/unit3/test_suspensions.py
@@ -54,5 +54,14 @@ class Test_Suspensions(unittest.TestCase):
         self.assertEqual(bytes(sleeping_gen([1,2,3])), bytes([1,2,3]))
         self.assertEqual(bytes(sleepingClass()), b'abc')
 
+    def test_starred_assignment(self):
+        x = [1,2,3]
+        a, b, c = sleeping_gen(x)
+        self.assertEqual([a, b, c], x)
+        a, b, *c = sleeping_gen(x)
+        self.assertEqual((a, b, c), (1, 2, [3]))
+        *a, = sleeping_gen(x)
+        self.assertEqual(a, x)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_unpack.py
+++ b/test/unit3/test_unpack.py
@@ -200,8 +200,9 @@ class UnpackTest(unittest.TestCase):
             'x = *a': (SyntaxError, 'can\'t use starred expression here'),
 
         }
-
-        eval_alt = "Sk.retainGlobals = true; Sk.importMainWithBody('test_unpack', false, '{0}', true)"
+        jseval("Sk.retainGlobals = true") # use globals from this module
+        # use this to test syntax errors and their respective mssages
+        eval_alt = "Sk.importMainWithBody('test_unpack', false, '{0}', true)"
         for expr, (error, msg) in expressions.items():
             try:
                 jseval(eval_alt.format(expr))

--- a/test/unit3/test_unpack.py
+++ b/test/unit3/test_unpack.py
@@ -183,35 +183,32 @@ class UnpackTest(unittest.TestCase):
         # @TODO support eval here
         expressions = {
             # Unpacking non-sequence
-            'a, *b = 7': 'TypeError: cannot unpack non-iterable int object',
+            'a, *b = 7': (TypeError, 'cannot unpack non-iterable int object'),
             # Unpacking sequence too short
-            'a, *b, c, d, e = range(3)': 'ValueError: not enough values to unpack (expected at least 4, got 3)',
+            'a, *b, c, d, e = range(3)': (ValueError, 'not enough values to unpack (expected at least 4, got 3)'),
             # Unpacking sequence too short and target appears last
-            'a, b, c, d, *e = range(3)' : 'ValueError: not enough values to unpack (expected at least 4, got 3)',
+            'a, b, c, d, *e = range(3)' : (ValueError, 'not enough values to unpack (expected at least 4, got 3)'),
             # Unpacking a sequence where the test for too long raises a different kind of error
-            'a, *b, c, d, e = BadSeq()' : 'BozoError: ',
+            'a, *b, c, d, e = BadSeq()' : (BozoError, ''),
             # general tests all fail
-            'a, *b, c, *d, e = range(10)' : 'SyntaxError: multiple starred expressions in assignment',
-            '[*b, *c] = range(10)': 'SyntaxError: multiple starred expressions in assignment',
-            'a,*b,*c,*d = range(4)': 'SyntaxError: multiple starred expressions in assignment',
-            '*a = range(10)': 'SyntaxError: starred assignment target must be in a list or tuple',
-            '*a' : 'SyntaxError: can\'t use starred expression here',
-            '*1': 'SyntaxError: can\'t use starred expression here',
-            'x = *a': 'SyntaxError: can\'t use starred expression here',
+            'a, *b, c, *d, e = range(10)' : (SyntaxError, 'multiple starred expressions in assignment'),
+            '[*b, *c] = range(10)': (SyntaxError, 'multiple starred expressions in assignment'),
+            'a,*b,*c,*d = range(4)': (SyntaxError, 'multiple starred expressions in assignment'),
+            '*a = range(10)': (SyntaxError, 'starred assignment target must be in a list or tuple'),
+            '*a' : (SyntaxError, 'can\'t use starred expression here'),
+            '*1': (SyntaxError, 'can\'t use starred expression here'),
+            'x = *a': (SyntaxError, 'can\'t use starred expression here'),
 
         }
 
         eval_alt = "Sk.retainGlobals = true; Sk.importMainWithBody('test_unpack', false, '{0}', true)"
-        for expr, error in expressions.items():
+        for expr, (error, msg) in expressions.items():
             try:
                 jseval(eval_alt.format(expr))
-            except Exception as e:
-                msg = repr(e)
-                exp_type, exp_msg = error.split(": ")
-                self.assertIn(exp_type, msg)
-                self.assertIn(exp_msg, msg)
+            except error as e:
+                self.assertIn(msg, str(e))
             else:
-                self.fail(f'error not raised for {expr}')
+                self.fail(f'{error} not raised for {expr}')
         jseval("Sk.retainGlobals = false")
 
 

--- a/test/unit3/test_unpack.py
+++ b/test/unit3/test_unpack.py
@@ -2,6 +2,24 @@
 
 import unittest
 
+class BozoError(Exception):
+    pass
+
+class BadSeq:
+    def __getitem__(self, i):
+        if i >= 0 and i < 3:
+            return i
+        elif i == 3:
+            raise BozoError
+        else:
+            raise IndexError
+
+class Seq:
+    def __getitem__(self, i):
+        if i >= 0 and i < 3: 
+            return i
+        raise IndexError
+
 class UnpackTest(unittest.TestCase):
 
     def test_basic(self):
@@ -64,11 +82,6 @@ class UnpackTest(unittest.TestCase):
         self.assertRaises(ValueError, list_too_small)
 
     def test_class(self):
-        class Seq:
-            def __getitem__(self, i):
-                if i >= 0 and i < 3: return i
-                raise IndexError
-
         a, b, c = Seq()
         self.assertEqual(a, 0)
         self.assertEqual(b, 1)
@@ -106,6 +119,102 @@ class UnpackTest(unittest.TestCase):
 
         self.assertRaises(NameError, raise_bad_error1)
         self.assertRaises(NameError, raise_bad_error2)
+    
+    def test_basic_star(self):
+        # tuple
+        t = (1, 2, 3)
+        a, *b, c = t
+        self.assertEqual((a, b, c), (1, [2], 3))
+
+        # list
+        l = [4, 5, 6]
+        a, *b = l
+        self.assertTrue(a == 4 and b == [5, 6])
+
+        # implied tuple
+        *a, = 7, 8, 9
+        self.assertTrue(a == [7, 8, 9])
+
+        #Unpack string... fun!
+        a, *b = 'one'
+        self.assertTrue(a == 'o' and b == ['n', 'e'])
+
+        # long sequence
+        a, b, c, *d, e, f, g = range(10)
+        self.assertTrue((a, b, c, d, e, f, g) == (
+            0, 1, 2, [3, 4, 5, 6], 7, 8, 9))
+
+        #Unpack short sequence
+        a, *b, c = (1, 2)
+        self.assertTrue(a == 1 and c == 2 and b == [])
+
+        # Unpack generic sequence
+        a, *b = Seq()
+        self.assertTrue(a == 0 and b == [1, 2])
+
+        #Unpack in for statement
+        for a, *b, c in [(1, 2, 3)]:
+            self.assertTrue(a == 1 and b == [2] and c == 3)
+        for a, *b, c in [(4, 5, 6, 7)]:
+            self.assertTrue(a == 4 and b == [5, 6] and c == 7)
+
+        #Unpack in list
+        [a, *b, c] = range(5)
+        self.assertTrue(a == 0 and b == [1, 2, 3] and c == 4)
+
+        #Multiple targets
+        a, *b, c = *d, e = range(5)
+        self.assertTrue(a == 0 and b == [1, 2, 3] and c == 4 and d == [
+                        0, 1, 2, 3] and e == 4)
+
+        # Assignment unpacking
+        a, b, *c = range(5)
+        self.assertEqual((a, b, c), (0, 1, [2, 3, 4]))
+
+        *a, b, c = a, b, *c
+        self.assertEqual((a, b, c), ([0, 1, 2], 3, 4))
+
+        # weird nested case
+        a, *[b, *c], d = range(6)
+        self.assertEqual((a,b,c,d), (0, 1, [2, 3, 4], 5))
+
+
+    def test_unpack_fails(self):
+        # @TODO support eval here
+        expressions = {
+            # Unpacking non-sequence
+            'a, *b = 7': 'TypeError: cannot unpack non-iterable int object',
+            # Unpacking sequence too short
+            'a, *b, c, d, e = range(3)': 'ValueError: not enough values to unpack (expected at least 4, got 3)',
+            # Unpacking sequence too short and target appears last
+            'a, b, c, d, *e = range(3)' : 'ValueError: not enough values to unpack (expected at least 4, got 3)',
+            # Unpacking a sequence where the test for too long raises a different kind of error
+            'a, *b, c, d, e = BadSeq()' : 'BozoError: ',
+            # general tests all fail
+            'a, *b, c, *d, e = range(10)' : 'SyntaxError: multiple starred expressions in assignment',
+            '[*b, *c] = range(10)': 'SyntaxError: multiple starred expressions in assignment',
+            'a,*b,*c,*d = range(4)': 'SyntaxError: multiple starred expressions in assignment',
+            '*a = range(10)': 'SyntaxError: starred assignment target must be in a list or tuple',
+            '*a' : 'SyntaxError: can\'t use starred expression here',
+            '*1': 'SyntaxError: can\'t use starred expression here',
+            'x = *a': 'SyntaxError: can\'t use starred expression here',
+
+        }
+
+        eval_alt = "Sk.retainGlobals = true; Sk.importMainWithBody('test_unpack', false, '{0}', true)"
+        for expr, error in expressions.items():
+            try:
+                jseval(eval_alt.format(expr))
+            except Exception as e:
+                msg = repr(e)
+                exp_type, exp_msg = error.split(": ")
+                self.assertIn(exp_type, msg)
+                self.assertIn(exp_msg, msg)
+            else:
+                self.fail(f'error not raised for {expr}')
+        jseval("Sk.retainGlobals = false")
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pr aims to add support for starred assignment - close #1063 

```python
>>> a, *b, c = 1, 2, 3, 4, 5
>>> a
1
>>> b
[2, 3, 4]
>>> c
5
```

general approaches were taken from Cpython's ast and compile files

It even works on weird nested assignment! who knew that was a thing...
```python
>>> a, *[b, *[c, *d]], e = range(6)
>>> a, b, c, d, e
(0, 1, 2, [3, 4] 5)
```

---

**TODO**
- [x] add tests