### PR TITLE
Implement the 'webbrowser' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Building Skulpt is straightforward:
 2. Install node.js
 3. Install the required dependencies using `npm install`
 4. Navigate to the repository and run `npm run dist`
-5. The tests should run and you will find `skulpt.min.js` and `skulpt-stdlib.js` in the `dist`folder
+5. The tests should run and you will find `skulpt.min.js` and `skulpt-stdlib.js` in the `dist` folder
 
 
 ### Contributing

--- a/src/lib/antigravity.js
+++ b/src/lib/antigravity.js
@@ -1,1 +1,0 @@
-window.open("https://xkcd.com/353/", "_blank");

--- a/src/lib/antigravity.py
+++ b/src/lib/antigravity.py
@@ -1,0 +1,3 @@
+import webbrowser
+
+webbrowser.open("https://xkcd.com/353/")

--- a/src/lib/webbrowser.js
+++ b/src/lib/webbrowser.js
@@ -20,19 +20,42 @@ var $builtinmodule = function(name){
     });
 
     mod.open_new = new Sk.builtin.func(function open_new(url) {
-        Sk.builtin.pyCheckArgsLen("open_new", arguments.length + 1, 1, 1);
+        Sk.builtin.pyCheckArgsLen("open_new", arguments.length, 1, 1);
         return open_tab(url);
     });
 
     mod.open_new_tab = new Sk.builtin.func(function open_new_tab(url) {
-        Sk.builtin.pyCheckArgsLen("open_new_tab", arguments.length + 1, 1, 1);
+        Sk.builtin.pyCheckArgsLen("open_new_tab", arguments.length, 1, 1);
         return open_tab(url);
     });
 
+    function dflbrowser($gbl, $loc) {
+        $loc.__init__ = new Sk.builtin.func(function __init__(self) {
+            return Sk.builtin.none.none$;
+        });
+
+        $loc.open = new Sk.builtin.func(function open(self, url) {
+            Sk.builtin.pyCheckArgsLen("open", arguments.length, 2, 4);
+            return open_tab(url);
+        });
+
+        $loc.open_new = new Sk.builtin.func(function open_new(self, url) {
+            Sk.builtin.pyCheckArgsLen("open_new", arguments.length, 2, 2);
+            return open_tab(url);
+        });
+
+        $loc.open_new_tab = new Sk.builtin.func(function open_new_tab(self, url) {
+            Sk.builtin.pyCheckArgsLen("open_new_tab", arguments.length, 2, 2);
+            return open_tab(url);
+        });
+    }
+
+    mod.DefaultBrowser = Sk.misceval.buildClass(mod, dflbrowser, "DefaultBrowser", []);
+
     mod.get = new Sk.builtin.func(function get() {
         Sk.builtin.pyCheckArgsLen("get", arguments.length, 0, 1);
-        return $builtinmodule;
-    }
+        return Sk.misceval.callsimArray(mod.DefaultBrowser, []);
+    });
 
     return mod;
 };

--- a/src/lib/webbrowser.js
+++ b/src/lib/webbrowser.js
@@ -14,6 +14,8 @@ var $builtinmodule = function(name){
         return Sk.builtin.bool.true$;
     }
 
+    mod.__name__ = new Sk.builtin.str("webbrowser");
+
     mod.open = new Sk.builtin.func(function open(url) {
         Sk.builtin.pyCheckArgsLen("open", arguments.length + 1, 1, 3);
         return open_tab(url);

--- a/src/lib/webbrowser.js
+++ b/src/lib/webbrowser.js
@@ -1,0 +1,19 @@
+var $builtinmodule = function(name){
+    var mod = {};
+    var inBrowser = (typeof window != "undefined") && (typeof window.navigator != "undefined");
+
+    mod.open = new Sk.builtin.func(function() {
+        Sk.builtin.pyCheckArgsLen("open", arguments.length, 1, 3);
+        var url = arguments[0];
+        if (!(url instanceof Sk.builtin.str))
+            throw new Sk.builtin.TypeError("webbrowser.open expects 'str' for 'url'");
+
+        if (!inBrowser)
+            return false;
+
+        url = url.$jsstr();
+        window.open(url, "_blank");
+        return true;
+    });
+    return mod;
+};

--- a/src/lib/webbrowser.js
+++ b/src/lib/webbrowser.js
@@ -29,5 +29,10 @@ var $builtinmodule = function(name){
         return open_tab(url);
     });
 
+    mod.get = new Sk.builtin.func(function get() {
+        Sk.builtin.pyCheckArgsLen("get", arguments.length, 0, 1);
+        return $builtinmodule;
+    }
+
     return mod;
 };

--- a/src/lib/webbrowser.js
+++ b/src/lib/webbrowser.js
@@ -20,12 +20,12 @@ var $builtinmodule = function(name){
     });
 
     mod.open_new = new Sk.builtin.func(function open_new(url) {
-        Sk.builtin.pyCheckArgsLen("open_new", arguments.length + 1, 1, 3);
+        Sk.builtin.pyCheckArgsLen("open_new", arguments.length + 1, 1, 1);
         return open_tab(url);
     });
 
     mod.open_new_tab = new Sk.builtin.func(function open_new_tab(url) {
-        Sk.builtin.pyCheckArgsLen("open_new_tab", arguments.length + 1, 1, 3);
+        Sk.builtin.pyCheckArgsLen("open_new_tab", arguments.length + 1, 1, 1);
         return open_tab(url);
     });
 

--- a/src/lib/webbrowser.js
+++ b/src/lib/webbrowser.js
@@ -2,18 +2,18 @@ var $builtinmodule = function(name){
     var mod = {};
     var inBrowser = (typeof window != "undefined") && (typeof window.navigator != "undefined");
 
-    mod.open = new Sk.builtin.func(function() {
-        Sk.builtin.pyCheckArgsLen("open", arguments.length, 1, 3);
-        var url = arguments[0];
-        if (!(url instanceof Sk.builtin.str))
+    mod.open = new Sk.builtin.func(function open(url) {
+        if (!(url instanceof Sk.builtin.str)) {
             throw new Sk.builtin.TypeError("webbrowser.open expects 'str' for 'url'");
-
-        if (!inBrowser)
-            return false;
+        }
+        if (!inBrowser) {
+            return Sk.builtin.bool.false$;
+        }
 
         url = url.$jsstr();
         window.open(url, "_blank");
-        return true;
+
+        return Sk.builtin.bool.true$;
     });
     return mod;
 };

--- a/src/lib/webbrowser.js
+++ b/src/lib/webbrowser.js
@@ -2,7 +2,7 @@ var $builtinmodule = function(name){
     var mod = {};
     var inBrowser = (typeof window != "undefined") && (typeof window.navigator != "undefined");
 
-    mod.open = new Sk.builtin.func(function open(url) {
+    function open_tab(url) {
         Sk.builtin.pyCheckType("url", "string", Sk.builtin.checkString(url));
         if (!inBrowser) {
             return Sk.builtin.bool.false$;
@@ -12,6 +12,22 @@ var $builtinmodule = function(name){
         window.open(url, "_blank");
 
         return Sk.builtin.bool.true$;
+    }
+
+    mod.open = new Sk.builtin.func(function open(url) {
+        Sk.builtin.pyCheckArgsLen("open", arguments.length + 1, 1, 3);
+        return open_tab(url);
     });
+
+    mod.open_new = new Sk.builtin.func(function open_new(url) {
+        Sk.builtin.pyCheckArgsLen("open_new", arguments.length + 1, 1, 3);
+        return open_tab(url);
+    });
+
+    mod.open_new_tab = new Sk.builtin.func(function open_new_tab(url) {
+        Sk.builtin.pyCheckArgsLen("open_new_tab", arguments.length + 1, 1, 3);
+        return open_tab(url);
+    });
+
     return mod;
 };

--- a/src/lib/webbrowser.js
+++ b/src/lib/webbrowser.js
@@ -3,9 +3,7 @@ var $builtinmodule = function(name){
     var inBrowser = (typeof window != "undefined") && (typeof window.navigator != "undefined");
 
     mod.open = new Sk.builtin.func(function open(url) {
-        if (!(url instanceof Sk.builtin.str)) {
-            throw new Sk.builtin.TypeError("webbrowser.open expects 'str' for 'url'");
-        }
+        Sk.builtin.pyCheckType("url", "string", Sk.builtin.checkString(url));
         if (!inBrowser) {
             return Sk.builtin.bool.false$;
         }


### PR DESCRIPTION
Hi! This is my first PR for this cool project, looking forward for more chances!

## How to implement:

- Like `antigravity.js` does, using `window.open(url, "_blank")` for `webbrowser.open(url)`.
- A `TypeError` will be raised if `url` is not `str`.

## Questions / TODOs:

- [ ] How can I write a test for this? Currently this module only works in browser and our tests seems to be running on `node`?
- [ ] Will we implement `webbrowser.get`, `webbrowser.open_new`, `webbrowser.open_new_tab` too? And how?
- [ ] Is that possible to open a browser in Node.js?
- [x] Import and use `webbrowser` for `antigravity.py`.

Please let me know if I'm making things correct, thanks in advance!