### PR TITLE
remove Sk.exportSymbol from the codebase

### DIFF
--- a/gen/astnodes.js
+++ b/gen/astnodes.js
@@ -1504,4 +1504,4 @@ Sk.astnodes.withitem.prototype._fields = [
     "optional_vars", function(n) { return n.optional_vars; }
 ];
 
-Sk.exportSymbol("Sk.astnodes", Sk.astnodes);
+

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -263,12 +263,12 @@ Sk.abstr.unary_op_ = function (v, opname) {
 Sk.abstr.numberBinOp = function (v, w, op) {
     return Sk.abstr.binary_op_(v, w, op);
 };
-Sk.exportSymbol("Sk.abstr.numberBinOp", Sk.abstr.numberBinOp);
+
 
 Sk.abstr.numberInplaceBinOp = function (v, w, op) {
     return Sk.abstr.binary_iop_(v, w, op);
 };
-Sk.exportSymbol("Sk.abstr.numberInplaceBinOp", Sk.abstr.numberInplaceBinOp);
+
 
 Sk.abstr.numberUnaryOp = function (v, op) {
     if (op === "Not") {
@@ -276,7 +276,7 @@ Sk.abstr.numberUnaryOp = function (v, op) {
     }
     return Sk.abstr.unary_op_(v, op);
 };
-Sk.exportSymbol("Sk.abstr.numberUnaryOp", Sk.abstr.numberUnaryOp);
+
 
 //
 // Sequence
@@ -636,7 +636,7 @@ Sk.abstr.objectDelItem = function (o, key) {
     otypename = Sk.abstr.typeName(o);
     throw new Sk.builtin.TypeError("'" + otypename + "' object does not support item deletion");
 };
-Sk.exportSymbol("Sk.abstr.objectDelItem", Sk.abstr.objectDelItem);
+
 
 Sk.abstr.objectGetItem = function (o, key, canSuspend) {
     var otypename;
@@ -653,7 +653,7 @@ Sk.abstr.objectGetItem = function (o, key, canSuspend) {
     otypename = Sk.abstr.typeName(o);
     throw new Sk.builtin.TypeError("'" + otypename + "' does not support indexing");
 };
-Sk.exportSymbol("Sk.abstr.objectGetItem", Sk.abstr.objectGetItem);
+
 
 Sk.abstr.objectSetItem = function (o, key, v, canSuspend) {
     var otypename;
@@ -670,7 +670,7 @@ Sk.abstr.objectSetItem = function (o, key, v, canSuspend) {
     otypename = Sk.abstr.typeName(o);
     throw new Sk.builtin.TypeError("'" + otypename + "' does not support item assignment");
 };
-Sk.exportSymbol("Sk.abstr.objectSetItem", Sk.abstr.objectSetItem);
+
 
 
 Sk.abstr.gattr = function (obj, pyName, canSuspend) {
@@ -700,7 +700,7 @@ Sk.abstr.gattr = function (obj, pyName, canSuspend) {
         return ret;
     }
 };
-Sk.exportSymbol("Sk.abstr.gattr", Sk.abstr.gattr);
+
 
 
 Sk.abstr.sattr = function (obj, pyName, data, canSuspend) {
@@ -716,13 +716,13 @@ Sk.abstr.sattr = function (obj, pyName, data, canSuspend) {
         throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + pyName.$jsstr() + "'");
     }
 };
-Sk.exportSymbol("Sk.abstr.sattr", Sk.abstr.sattr);
+
 
 
 Sk.abstr.iternext = function (it, canSuspend) {
     return it.tp$iternext(canSuspend);
 };
-Sk.exportSymbol("Sk.abstr.iternext", Sk.abstr.iternext);
+
 
 
 /**
@@ -783,7 +783,7 @@ Sk.abstr.iter = function(obj) {
     }
     throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(obj) + "' object is not iterable");
 };
-Sk.exportSymbol("Sk.abstr.iter", Sk.abstr.iter);
+
 
 /**
  * Special method look up. First try getting the method via
@@ -803,7 +803,7 @@ Sk.abstr.lookupSpecial = function(op, pyName) {
 
     return Sk.builtin.type.typeLookup(obtp, pyName);
 };
-Sk.exportSymbol("Sk.abstr.lookupSpecial", Sk.abstr.lookupSpecial);
+
 
 /**
  * Mark a class as unhashable and prevent its `__hash__` function from being called.

--- a/src/assert-dev.js
+++ b/src/assert-dev.js
@@ -16,7 +16,7 @@ Sk.asserts.assert = function (condition, message) {
     }
     return condition;
 };
-Sk.exportSymbol("Sk.asserts.assert", Sk.asserts.assert);
+
 
 /**
  * Cause assertion failure.
@@ -32,4 +32,4 @@ Sk.asserts.fail = function (message) {
         throw new Error(msg);
     }
 };
-Sk.exportSymbol("Sk.asserts.fail", Sk.asserts.fail);
+

--- a/src/assert-prod.js
+++ b/src/assert-prod.js
@@ -9,7 +9,7 @@ Sk.asserts = {};
 Sk.asserts.assert = function (condition, message) {
     return condition;
 };
-Sk.exportSymbol("Sk.asserts.assert", Sk.asserts.assert);
+
 
 /**
  * Cause assertion failure.
@@ -18,4 +18,4 @@ Sk.exportSymbol("Sk.asserts.assert", Sk.asserts.assert);
  */
 Sk.asserts.fail = function (message) {
 };
-Sk.exportSymbol("Sk.asserts.fail", Sk.asserts.fail);
+

--- a/src/ast.js
+++ b/src/ast.js
@@ -260,7 +260,7 @@ Sk.setupOperators = function (py3) {
         }
     }
 }
-Sk.exportSymbol("Sk.setupOperators", Sk.setupOperators);
+
 
 function getOperator (n) {
     if (operatorMap[n.type] === undefined) {
@@ -3399,5 +3399,5 @@ Sk.astDump = function (node) {
     return _format(node, "");
 };
 
-Sk.exportSymbol("Sk.astFromParse", Sk.astFromParse);
-Sk.exportSymbol("Sk.astDump", Sk.astDump);
+
+

--- a/src/bool.js
+++ b/src/bool.js
@@ -89,7 +89,7 @@ Sk.builtin.bool.prototype.ob$ge = function (other) {
     return Sk.builtin.int_.prototype.ob$ge.call(this, other);
 };
 
-Sk.exportSymbol("Sk.builtin.bool", Sk.builtin.bool);
+
 
 /**
  * Python bool True constant.

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -121,7 +121,7 @@ Sk.builtin.asnum$ = function (a) {
     return a;
 };
 
-Sk.exportSymbol("Sk.builtin.asnum$", Sk.builtin.asnum$);
+
 
 /**
  * Return a Python number (either float or int) from a Javascript number.
@@ -138,7 +138,7 @@ Sk.builtin.assk$ = function (a) {
         return new Sk.builtin.float_(a);
     }
 };
-Sk.exportSymbol("Sk.builtin.assk$", Sk.builtin.assk$);
+
 
 Sk.builtin.asnum$nofloat = function (a) {
     var decimal;
@@ -237,7 +237,7 @@ Sk.builtin.asnum$nofloat = function (a) {
 
     return mantissa;
 };
-Sk.exportSymbol("Sk.builtin.asnum$nofloat", Sk.builtin.asnum$nofloat);
+
 
 Sk.builtin.round = function round (number, ndigits) {
     var special;

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -141,5 +141,5 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["ascii"];
     }
 };
-Sk.exportSymbol("Sk.setupObjects", Sk.setupObjects);
-Sk.exportSymbol("Sk.builtins", Sk.builtins);
+
+

--- a/src/bytes.js
+++ b/src/bytes.js
@@ -1744,4 +1744,4 @@ Sk.builtin.bytes_iter_.prototype.next$ = function (self) {
     return ret;
 };
 
-Sk.exportSymbol("Sk.builtin.bytes", Sk.builtin.bytes);
+

--- a/src/compile.js
+++ b/src/compile.js
@@ -2818,19 +2818,19 @@ Sk.compile = function (source, filename, mode, canSuspend) {
     };
 };
 
-Sk.exportSymbol("Sk.compile", Sk.compile);
+
 
 Sk.resetCompiler = function () {
     Sk.gensymcount = 0;
 };
 
-Sk.exportSymbol("Sk.resetCompiler", Sk.resetCompiler);
+
 
 Sk.fixReserved = fixReserved;
-Sk.exportSymbol("Sk.fixReserved", Sk.fixReserved);
+
 
 Sk.unfixReserved = unfixReserved;
-Sk.exportSymbol("Sk.unfixReserved", Sk.unfixReserved);
+
 
 Sk.mangleName = mangleName;
-Sk.exportSymbol("Sk.mangleName", Sk.mangleName);
+

--- a/src/complex.js
+++ b/src/complex.js
@@ -1121,7 +1121,7 @@ Sk.builtin.complex.prototype.nb$nonzero = function () {
 
 
 // ToDo: think about inplace methods too
-Sk.exportSymbol("Sk.builtin.complex", Sk.builtin.complex);
+
 
 
 /**

--- a/src/dict.js
+++ b/src/dict.js
@@ -845,7 +845,7 @@ Sk.builtin.dict.prototype["viewvalues"] = new Sk.builtin.func(function (self) {
     throw new Sk.builtin.NotImplementedError("dict.viewvalues is not yet implemented in Skulpt");
 });
 
-Sk.exportSymbol("Sk.builtin.dict", Sk.builtin.dict);
+
 
 Sk.builtin.create_dict_iter_ = function (obj) {
     const iterobj = {};

--- a/src/env.js
+++ b/src/env.js
@@ -97,7 +97,7 @@ Sk.configure = function (options) {
 
     Sk.timeoutMsg = options["timeoutMsg"] || Sk.timeoutMsg;
     Sk.asserts.assert(typeof Sk.timeoutMsg === "function");
-    Sk.exportSymbol("Sk.timeoutMsg", Sk.timeoutMsg);
+    
 
     Sk.sysargv = options["sysargv"] || Sk.sysargv;
     Sk.asserts.assert(Sk.isArrayLike(Sk.sysargv));
@@ -215,7 +215,7 @@ Sk.configure = function (options) {
     Sk.setupObjects(Sk.__future__.python3);
 };
 
-Sk.exportSymbol("Sk.configure", Sk.configure);
+
 
 /*
 * Replaceable handler for uncaught exceptions
@@ -230,7 +230,7 @@ Sk.uncaughtException = function(err) {
 Sk.uncaughtException = function(err) {
     throw err;
 };
-Sk.exportSymbol("Sk.uncaughtException", Sk.uncaughtException);
+
 
 /*
  *      Replaceable message for message timeouts
@@ -238,7 +238,7 @@ Sk.exportSymbol("Sk.uncaughtException", Sk.uncaughtException);
 Sk.timeoutMsg = function () {
     return "Program exceeded run time limit.";
 };
-Sk.exportSymbol("Sk.timeoutMsg", Sk.timeoutMsg);
+
 
 /*
  *  Hard execution timeout, throws an error. Set to null to disable
@@ -278,7 +278,7 @@ Sk.sysargv = [];
 Sk.getSysArgv = function () {
     return Sk.sysargv;
 };
-Sk.exportSymbol("Sk.getSysArgv", Sk.getSysArgv);
+
 
 
 /**
@@ -401,8 +401,8 @@ Sk.switch_version = function (method_to_map, python3) {
     }
 };
 
-Sk.exportSymbol("Sk.__future__", Sk.__future__);
-Sk.exportSymbol("Sk.inputfun", Sk.inputfun);
+
+
 
 function setupDictIterators (python3) {
     if (python3) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -79,7 +79,7 @@ Sk.builtin.BaseException.prototype.args = {
     }
 };
 
-Sk.exportSymbol("Sk.builtin.BaseException", Sk.builtin.BaseException);
+
 
 /**
  * @constructor
@@ -96,7 +96,7 @@ Sk.builtin.Exception = function (args) {
     Sk.builtin.BaseException.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("Exception", Sk.builtin.Exception, Sk.builtin.BaseException);
-Sk.exportSymbol("Sk.builtin.Exception", Sk.builtin.Exception);
+
 
 /**
  * @constructor
@@ -113,7 +113,7 @@ Sk.builtin.AssertionError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("AssertionError", Sk.builtin.AssertionError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.AssertionError", Sk.builtin.AssertionError);
+
 
 /**
  * @constructor
@@ -194,7 +194,7 @@ Sk.builtin.LookupError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("LookupError", Sk.builtin.LookupError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.LookupError", Sk.builtin.LookupError);
+
 
 /**
  * @constructor
@@ -292,7 +292,7 @@ Sk.builtin.RuntimeError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("RuntimeError", Sk.builtin.RuntimeError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.RuntimeError", Sk.builtin.RuntimeError);
+
 
 
 /**
@@ -310,7 +310,7 @@ Sk.builtin.SuspensionError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("SuspensionError", Sk.builtin.SuspensionError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.SuspensionError", Sk.builtin.SuspensionError);
+
 
 
 /**
@@ -328,7 +328,7 @@ Sk.builtin.SystemExit = function (args) {
     Sk.builtin.BaseException.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("SystemExit", Sk.builtin.SystemExit, Sk.builtin.BaseException);
-Sk.exportSymbol("Sk.builtin.SystemExit", Sk.builtin.SystemExit);
+
 
 
 /**
@@ -346,7 +346,7 @@ Sk.builtin.TypeError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("TypeError", Sk.builtin.TypeError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.TypeError", Sk.builtin.TypeError);
+
 /**
  * @constructor
  * @extends Sk.builtin.Exception
@@ -362,7 +362,7 @@ Sk.builtin.ValueError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("ValueError", Sk.builtin.ValueError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.ValueError", Sk.builtin.ValueError);
+
 
 /**
  * @constructor
@@ -395,7 +395,7 @@ Sk.builtin.TimeLimitError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("TimeLimitError", Sk.builtin.TimeLimitError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.TimeLimitError", Sk.builtin.TimeLimitError);
+
 
 /**
  * @constructor
@@ -412,7 +412,7 @@ Sk.builtin.IOError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("IOError", Sk.builtin.IOError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.IOError", Sk.builtin.IOError);
+
 
 
 /**
@@ -430,7 +430,7 @@ Sk.builtin.NotImplementedError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("NotImplementedError", Sk.builtin.NotImplementedError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.NotImplementedError", Sk.builtin.NotImplementedError);
+
 
 /**
  * @constructor
@@ -447,7 +447,7 @@ Sk.builtin.NegativePowerError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("NegativePowerError", Sk.builtin.NegativePowerError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.NegativePowerError", Sk.builtin.NegativePowerError);
+
 
 /**
  * @constructor
@@ -472,7 +472,7 @@ Sk.builtin.ExternalError = function (nativeError, args) {
     Sk.builtin.Exception.apply(this, args);
 };
 Sk.abstr.setUpInheritance("ExternalError", Sk.builtin.ExternalError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.ExternalError", Sk.builtin.ExternalError);
+
 
 /**
  * @constructor
@@ -489,7 +489,7 @@ Sk.builtin.OperationError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("OperationError", Sk.builtin.OperationError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.OperationError", Sk.builtin.OperationError);
+
 
 /**
  * @constructor
@@ -506,7 +506,7 @@ Sk.builtin.SystemError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("SystemError", Sk.builtin.SystemError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.SystemError", Sk.builtin.SystemError);
+
 
 /**
  * @constructor
@@ -523,7 +523,7 @@ Sk.builtin.UnicodeDecodeError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("UnicodeDecodeError", Sk.builtin.UnicodeDecodeError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.UnicodeDecodeError", Sk.builtin.UnicodeDecodeError);
+
 
 /**
  * @constructor
@@ -540,7 +540,7 @@ Sk.builtin.UnicodeEncodeError = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("UnicodeEncodeError", Sk.builtin.UnicodeEncodeError, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.UnicodeEncodeError", Sk.builtin.UnicodeEncodeError);
+
 
 
 /**
@@ -558,7 +558,7 @@ Sk.builtin.StopIteration = function (args) {
     Sk.builtin.Exception.apply(this, arguments);
 };
 Sk.abstr.setUpInheritance("StopIteration", Sk.builtin.StopIteration, Sk.builtin.Exception);
-Sk.exportSymbol("Sk.builtin.StopIteration", Sk.builtin.StopIteration);
+
 
 
 // TODO: Extract into sys.exc_info(). Work out how the heck

--- a/src/ffi.js
+++ b/src/ffi.js
@@ -66,7 +66,7 @@ Sk.ffi.remapToPy = function (obj) {
 
     Sk.asserts.fail("unhandled remap type " + typeof(obj));
 };
-Sk.exportSymbol("Sk.ffi.remapToPy", Sk.ffi.remapToPy);
+
 
 /**
  * Maps from Python dict/list/str/number to Javascript Object/Array/string/number.
@@ -118,7 +118,7 @@ Sk.ffi.remapToJs = function (obj) {
         return obj.v;
     }
 };
-Sk.exportSymbol("Sk.ffi.remapToJs", Sk.ffi.remapToJs);
+
 
 Sk.ffi.callback = function (fn) {
     if (fn === undefined) {
@@ -128,14 +128,14 @@ Sk.ffi.callback = function (fn) {
         return Sk.misceval.apply(fn, undefined, undefined, undefined, Array.prototype.slice.call(arguments, 0));
     };
 };
-Sk.exportSymbol("Sk.ffi.callback", Sk.ffi.callback);
+
 
 Sk.ffi.stdwrap = function (type, towrap) {
     var inst = new type();
     inst["v"] = towrap;
     return inst;
 };
-Sk.exportSymbol("Sk.ffi.stdwrap", Sk.ffi.stdwrap);
+
 
 /**
  * for when the return type might be one of a variety of basic types.
@@ -159,7 +159,7 @@ Sk.ffi.basicwrap = function (obj) {
     }
     Sk.asserts.fail("unexpected type for basicwrap");
 };
-Sk.exportSymbol("Sk.ffi.basicwrap", Sk.ffi.basicwrap);
+
 
 Sk.ffi.unwrapo = function (obj) {
     if (obj === undefined) {
@@ -167,7 +167,7 @@ Sk.ffi.unwrapo = function (obj) {
     }
     return obj["v"];
 };
-Sk.exportSymbol("Sk.ffi.unwrapo", Sk.ffi.unwrapo);
+
 
 Sk.ffi.unwrapn = function (obj) {
     if (obj === null) {
@@ -175,4 +175,4 @@ Sk.ffi.unwrapn = function (obj) {
     }
     return obj["v"];
 };
-Sk.exportSymbol("Sk.ffi.unwrapn", Sk.ffi.unwrapn);
+

--- a/src/file.js
+++ b/src/file.js
@@ -258,4 +258,4 @@ Sk.builtin.file.prototype["write"] = new Sk.builtin.func(function write(self, st
 });
 
 
-Sk.exportSymbol("Sk.builtin.file", Sk.builtin.file);
+

--- a/src/filter.js
+++ b/src/filter.js
@@ -64,4 +64,4 @@ Sk.builtin.filter_.prototype["$r"] = function () {
     return new Sk.builtin.str("<filter object>");
 };
 
-Sk.exportSymbol("Sk.builtin.filter_", Sk.builtin.filter_);
+

--- a/src/frozenset.js
+++ b/src/frozenset.js
@@ -387,7 +387,7 @@ Sk.builtin.frozenset.prototype["copy"] = new Sk.builtin.func(function (self) {
     return new Sk.builtin.frozenset(self);
 });
 
-Sk.exportSymbol("Sk.builtin.frozenset", Sk.builtin.frozenset);
+
 
 Sk.builtin.frozenset.prototype.__contains__ = new Sk.builtin.func(function(self, item) {
     Sk.builtin.pyCheckArgsLen("__contains__", arguments.length, 2, 2);

--- a/src/function.js
+++ b/src/function.js
@@ -42,7 +42,7 @@ Sk.builtin.pyCheckArgs = function (name, args, minargs, maxargs, kwargs, free) {
         throw new Sk.builtin.TypeError(msg);
     }
 };
-Sk.exportSymbol("Sk.builtin.pyCheckArgs", Sk.builtin.pyCheckArgs);
+
 
 /**
  * Check arguments to Python functions to ensure the correct number of
@@ -95,12 +95,12 @@ Sk.builtin.pyCheckType = function (name, exptype, check) {
         throw new Sk.builtin.TypeError(name + " must be a " + exptype);
     }
 };
-Sk.exportSymbol("Sk.builtin.pyCheckType", Sk.builtin.pyCheckType);
+
 
 Sk.builtin.checkSequence = function (arg) {
     return (arg !== null && arg.mp$subscript !== undefined);
 };
-Sk.exportSymbol("Sk.builtin.checkSequence", Sk.builtin.checkSequence);
+
 
 /**
  * Use this to test whether or not a Python object is iterable.  You should **not** rely
@@ -130,7 +130,7 @@ Sk.builtin.checkIterable = function (arg) {
     }
     return ret;
 };
-Sk.exportSymbol("Sk.builtin.checkIterable", Sk.builtin.checkIterable);
+
 
 Sk.builtin.checkCallable = function (obj) {
     // takes care of builtin functions and methods, builtins
@@ -158,7 +158,7 @@ Sk.builtin.checkNumber = function (arg) {
         arg instanceof Sk.builtin.float_ ||
         arg instanceof Sk.builtin.lng));
 };
-Sk.exportSymbol("Sk.builtin.checkNumber", Sk.builtin.checkNumber);
+
 
 /**
  * Checks for complex type, delegates to internal method
@@ -167,22 +167,22 @@ Sk.exportSymbol("Sk.builtin.checkNumber", Sk.builtin.checkNumber);
 Sk.builtin.checkComplex = function (arg) {
     return Sk.builtin.complex._complex_check(arg);
 };
-Sk.exportSymbol("Sk.builtin.checkComplex", Sk.builtin.checkComplex);
+
 
 Sk.builtin.checkInt = function (arg) {
     return arg instanceof Sk.builtin.int_ || arg instanceof Sk.builtin.lng || (typeof arg === "number" && Number.isInteger(arg));
 };
-Sk.exportSymbol("Sk.builtin.checkInt", Sk.builtin.checkInt);
+
 
 Sk.builtin.checkFloat = function (arg) {
     return (arg !== null) && (arg instanceof Sk.builtin.float_);
 };
-Sk.exportSymbol("Sk.builtin.checkFloat", Sk.builtin.checkFloat);
+
 
 Sk.builtin.checkString = function (arg) {
     return (arg !== null && arg.__class__ == Sk.builtin.str);
 };
-Sk.exportSymbol("Sk.builtin.checkString", Sk.builtin.checkString);
+
 
 Sk.builtin.checkBytes = function (arg) {
     return arg instanceof Sk.builtin.bytes;
@@ -191,22 +191,22 @@ Sk.builtin.checkBytes = function (arg) {
 Sk.builtin.checkClass = function (arg) {
     return (arg !== null && arg.sk$type);
 };
-Sk.exportSymbol("Sk.builtin.checkClass", Sk.builtin.checkClass);
+
 
 Sk.builtin.checkBool = function (arg) {
     return (arg instanceof Sk.builtin.bool);
 };
-Sk.exportSymbol("Sk.builtin.checkBool", Sk.builtin.checkBool);
+
 
 Sk.builtin.checkNone = function (arg) {
     return (arg === Sk.builtin.none.none$);
 };
-Sk.exportSymbol("Sk.builtin.checkNone", Sk.builtin.checkNone);
+
 
 Sk.builtin.checkFunction = function (arg) {
     return (arg !== null && arg.tp$call !== undefined);
 };
-Sk.exportSymbol("Sk.builtin.checkFunction", Sk.builtin.checkFunction);
+
 
 /**
  * @constructor
@@ -275,7 +275,7 @@ Sk.builtin.func = function (code, globals, closure, closure2) {
 
 Sk.abstr.setUpInheritance("function", Sk.builtin.func, Sk.builtin.object);
 
-Sk.exportSymbol("Sk.builtin.func", Sk.builtin.func);
+
 
 Sk.builtin.func.prototype.tp$name = "function";
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -47,7 +47,7 @@ Sk.builtin.generator = function (code, globals, args, closure, closure2) {
     this.func_closure = closure;
     return this;
 };
-Sk.exportSymbol("Sk.builtin.generator", Sk.builtin.generator);
+
 
 Sk.abstr.setUpInheritance("generator", Sk.builtin.generator, Sk.builtin.object);
 
@@ -127,4 +127,4 @@ Sk.builtin.makeGenerator = function (next, data) {
 
     return gen;
 };
-Sk.exportSymbol("Sk.builtin.makeGenerator", Sk.builtin.makeGenerator);
+

--- a/src/import.js
+++ b/src/import.js
@@ -587,8 +587,8 @@ Sk.importStar = function (module, loc, global) {
     }
 };
 
-Sk.exportSymbol("Sk.importMain", Sk.importMain);
-Sk.exportSymbol("Sk.importMainWithBody", Sk.importMainWithBody);
-Sk.exportSymbol("Sk.importBuiltinWithBody", Sk.importBuiltinWithBody);
-Sk.exportSymbol("Sk.builtin.__import__", Sk.builtin.__import__);
-Sk.exportSymbol("Sk.importStar", Sk.importStar);
+
+
+
+
+

--- a/src/int.js
+++ b/src/int.js
@@ -1191,4 +1191,4 @@ Sk.str2number = function (s, base, parser, negater, fname) {
     return val;
 };
 
-Sk.exportSymbol("Sk.builtin.int_", Sk.builtin.int_);
+

--- a/src/iterator.js
+++ b/src/iterator.js
@@ -99,4 +99,4 @@ Sk.builtin.iterator.prototype.next$ = function (self) {
     return ret;
 };
 
-Sk.exportSymbol("Sk.builtin.iterator", Sk.builtin.iterator);
+

--- a/src/list.js
+++ b/src/list.js
@@ -619,7 +619,7 @@ Sk.builtin.list.prototype["count"] = new Sk.builtin.func(function (self, item) {
 Sk.builtin.list.prototype["reverse"] = new Sk.builtin.func(Sk.builtin.list.prototype.list_reverse_);
 Sk.builtin.list.prototype["sort"] = new Sk.builtin.func(Sk.builtin.list.prototype.list_sort_);
 
-Sk.exportSymbol("Sk.builtin.list", Sk.builtin.list);
+
 
 /**
  * @constructor

--- a/src/long.js
+++ b/src/long.js
@@ -158,7 +158,7 @@ Sk.longFromStr = function (s, base) {
 
     return new Sk.builtin.lng(biginteger);
 };
-Sk.exportSymbol("Sk.longFromStr", Sk.longFromStr);
+
 
 Sk.builtin.lng.prototype.toInt$ = function () {
     return parseInt(this.biginteger.toString(), 10);

--- a/src/map.js
+++ b/src/map.js
@@ -82,4 +82,3 @@ Sk.builtin.map_.prototype["$r"] = function () {
     return new Sk.builtin.str("<map object>");
 };
 
-Sk.exportSymbol("Sk.builtin.map_", Sk.builtin.map_);

--- a/src/method.js
+++ b/src/method.js
@@ -31,7 +31,7 @@ Sk.builtin.method = function (func, self, klass, builtin) {
     };
 };
 
-Sk.exportSymbol("Sk.builtin.method", Sk.builtin.method);
+
 Sk.abstr.setUpInheritance("instancemethod", Sk.builtin.method, Sk.builtin.object);
 
 Sk.builtin.method.prototype.tp$name = "method";

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -35,7 +35,7 @@ Sk.misceval.Suspension = function Suspension(resume, child, data) {
         this.data = data;
     }
 };
-Sk.exportSymbol("Sk.misceval.Suspension", Sk.misceval.Suspension);
+
 
 /**
  *
@@ -53,7 +53,7 @@ Sk.misceval.retryOptionalSuspensionOrThrow = function (susp, message) {
     }
     return susp;
 };
-Sk.exportSymbol("Sk.misceval.retryOptionalSuspensionOrThrow", Sk.misceval.retryOptionalSuspensionOrThrow);
+
 
 /**
  * Check if the given object is valid to use as an index. Only ints, or if the object has an `__index__` method.
@@ -69,7 +69,7 @@ Sk.misceval.isIndex = function (o) {
     }
     return false;
 };
-Sk.exportSymbol("Sk.misceval.isIndex", Sk.misceval.isIndex);
+
 
 Sk.misceval.asIndex = function (o) {
     var idxfn, ret;
@@ -132,7 +132,7 @@ Sk.misceval.applySlice = function (u, v, w, canSuspend) {
     }
     return Sk.abstr.objectGetItem(u, new Sk.builtin.slice(v, w, null), canSuspend);
 };
-Sk.exportSymbol("Sk.misceval.applySlice", Sk.misceval.applySlice);
+
 
 /**
  * u[v:w] = x
@@ -158,7 +158,7 @@ Sk.misceval.assignSlice = function (u, v, w, x, canSuspend) {
         }
     }
 };
-Sk.exportSymbol("Sk.misceval.assignSlice", Sk.misceval.assignSlice);
+
 
 /**
  * Used by min() and max() to get an array from arbitrary input.
@@ -196,7 +196,7 @@ Sk.misceval.arrayFromArguments = function (args) {
 
     throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(arg) + "' object is not iterable");
 };
-Sk.exportSymbol("Sk.misceval.arrayFromArguments", Sk.misceval.arrayFromArguments);
+
 
 /**
  * for reversed comparison: Gt -> Lt, etc.
@@ -533,7 +533,7 @@ Sk.misceval.richCompareBool = function (v, w, op, canSuspend) {
     throw new Sk.builtin.TypeError("'" + Sk.misceval.opSymbols[op] + "' not supported between instances of '" + vname + "' and '" + wname + "'");
     //throw new Sk.builtin.ValueError("don't know how to compare '" + vname + "' and '" + wname + "'");
 };
-Sk.exportSymbol("Sk.misceval.richCompareBool", Sk.misceval.richCompareBool);
+
 
 Sk.misceval.objectRepr = function (v) {
     Sk.asserts.assert(v !== undefined, "trying to repr undefined");
@@ -568,7 +568,7 @@ Sk.misceval.objectRepr = function (v) {
         return v["$r"]();
     }
 };
-Sk.exportSymbol("Sk.misceval.objectRepr", Sk.misceval.objectRepr);
+
 
 Sk.misceval.opAllowsEquality = function (op) {
     switch (op) {
@@ -579,7 +579,7 @@ Sk.misceval.opAllowsEquality = function (op) {
     }
     return false;
 };
-Sk.exportSymbol("Sk.misceval.opAllowsEquality", Sk.misceval.opAllowsEquality);
+
 
 Sk.misceval.isTrue = function (x) {
     var ret;
@@ -647,7 +647,7 @@ Sk.misceval.isTrue = function (x) {
     }
     return true;
 };
-Sk.exportSymbol("Sk.misceval.isTrue", Sk.misceval.isTrue);
+
 
 Sk.misceval.softspace_ = false;
 Sk.misceval.print_ = function (x) {
@@ -674,7 +674,7 @@ Sk.misceval.print_ = function (x) {
         }
     });
 };
-Sk.exportSymbol("Sk.misceval.print_", Sk.misceval.print_);
+
 
 /**
  * @param {string} name
@@ -697,7 +697,7 @@ Sk.misceval.loadname = function (name, other) {
 
     throw new Sk.builtin.NameError("name '" + Sk.unfixReserved(name) + "' is not defined");
 };
-Sk.exportSymbol("Sk.misceval.loadname", Sk.misceval.loadname);
+
 
 /**
  *
@@ -778,7 +778,7 @@ Sk.misceval.call = function (func, kwdict, varargseq, kws, args) {
     // todo; possibly inline apply to avoid extra stack frame creation
     return Sk.misceval.apply(func, kwdict, varargseq, kws, args);
 };
-Sk.exportSymbol("Sk.misceval.call", Sk.misceval.call);
+
 
 /**
  * @param {?Object} suspensionHandlers
@@ -797,7 +797,7 @@ Sk.misceval.callAsync = function (suspensionHandlers, func, kwdict, varargseq, k
     // todo; possibly inline apply to avoid extra stack frame creation
     return Sk.misceval.applyAsync(suspensionHandlers, func, kwdict, varargseq, kws, args);
 };
-Sk.exportSymbol("Sk.misceval.callAsync", Sk.misceval.callAsync);
+
 
 
 Sk.misceval.callOrSuspend = function (func, kwdict, varargseq, kws, args) {
@@ -805,7 +805,7 @@ Sk.misceval.callOrSuspend = function (func, kwdict, varargseq, kws, args) {
     // todo; possibly inline apply to avoid extra stack frame creation
     return Sk.misceval.applyOrSuspend(func, kwdict, varargseq, kws, args);
 };
-Sk.exportSymbol("Sk.misceval.callOrSuspend", Sk.misceval.callOrSuspend);
+
 
 /**
  * @param {Object} func the thing to call
@@ -815,7 +815,7 @@ Sk.misceval.callsim = function (func, args) {
     args = Array.prototype.slice.call(arguments, 1);
     return Sk.misceval.apply(func, undefined, undefined, undefined, args);
 };
-Sk.exportSymbol("Sk.misceval.callsim", Sk.misceval.callsim);
+
 
 /**
  * @param {Object} func the thing to call
@@ -828,7 +828,7 @@ Sk.misceval.callsimArray = function(func, args, kws) {
     var argarray = args ? args : [];
     return Sk.misceval.apply(func, undefined, undefined, kws, argarray);
 };
-Sk.exportSymbol("Sk.misceval.callsimArray", Sk.misceval.callsimArray);
+
 
 /**
  * @param {?Object} suspensionHandlers any custom suspension handlers
@@ -839,7 +839,7 @@ Sk.misceval.callsimAsync = function (suspensionHandlers, func, args) {
     args = Array.prototype.slice.call(arguments, 2);
     return Sk.misceval.applyAsync(suspensionHandlers, func, undefined, undefined, undefined, args);
 };
-Sk.exportSymbol("Sk.misceval.callsimAsync", Sk.misceval.callsimAsync);
+
 
 
 /**
@@ -850,7 +850,7 @@ Sk.misceval.callsimOrSuspend = function (func, args) {
     args = Array.prototype.slice.call(arguments, 1);
     return Sk.misceval.applyOrSuspend(func, undefined, undefined, undefined, args);
 };
-Sk.exportSymbol("Sk.misceval.callsimOrSuspend", Sk.misceval.callsimOrSuspend);
+
 
 /**
  * @param {Object} func the thing to call
@@ -873,7 +873,7 @@ Sk.misceval.callsimOrSuspendArray = function (func, args, kws) {
         return Sk.misceval.applyOrSuspend(func, undefined, undefined, kws, args);
     }
 };
-Sk.exportSymbol("Sk.misceval.callsimOrSuspendArray", Sk.misceval.callsimOrSuspendArray);
+
 
 /**
  * Wrap Sk.misceval.applyOrSuspend, but throw an error if we suspend
@@ -886,7 +886,7 @@ Sk.misceval.apply = function (func, kwdict, varargseq, kws, args) {
         return r;
     }
 };
-Sk.exportSymbol("Sk.misceval.apply", Sk.misceval.apply);
+
 
 /**
  * Wraps anything that can return an Sk.misceval.Suspension, and returns a
@@ -1004,14 +1004,14 @@ Sk.misceval.asyncToPromise = function(suspendablefn, suspHandlers) {
         }
     });
 };
-Sk.exportSymbol("Sk.misceval.asyncToPromise", Sk.misceval.asyncToPromise);
+
 
 Sk.misceval.applyAsync = function (suspHandlers, func, kwdict, varargseq, kws, args) {
     return Sk.misceval.asyncToPromise(function() {
         return Sk.misceval.applyOrSuspend(func, kwdict, varargseq, kws, args);
     }, suspHandlers);
 };
-Sk.exportSymbol("Sk.misceval.applyAsync", Sk.misceval.applyAsync);
+
 
 /**
  * Chain together a set of functions, each of which might return a value or
@@ -1073,7 +1073,7 @@ Sk.misceval.chain = function (initialValue, chainedFns) {
         return r;
     })(value);
 };
-Sk.exportSymbol("Sk.misceval.chain", Sk.misceval.chain);
+
 
 
 /**
@@ -1104,7 +1104,7 @@ Sk.misceval.tryCatch = function (tryFn, catchFn) {
         return r;
     }
 };
-Sk.exportSymbol("Sk.misceval.tryCatch", Sk.misceval.tryCatch);
+
 
 /**
  * Perform a suspension-aware for-each on an iterator, without
@@ -1154,7 +1154,7 @@ Sk.misceval.iterFor = function (iter, forFn, initialValue) {
         return prevValue;
     })(iter.tp$iternext(true));
 };
-Sk.exportSymbol("Sk.misceval.iterFor", Sk.misceval.iterFor);
+
 
 /**
  * @function
@@ -1200,7 +1200,7 @@ Sk.misceval.Break = function(brValue) {
 
     this.brValue = brValue;
 };
-Sk.exportSymbol("Sk.misceval.Break", Sk.misceval.Break);
+
 
 /**
  * same as Sk.misceval.call except args is an actual array, rather than
@@ -1250,7 +1250,7 @@ Sk.misceval.applyOrSuspend = function (func, kwdict, varargseq, kws, args) {
 
     throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(func) + "' object is not callable");
 };
-Sk.exportSymbol("Sk.misceval.applyOrSuspend", Sk.misceval.applyOrSuspend);
+
 
 /**
  * Do the boilerplate suspension stuff.
@@ -1273,7 +1273,7 @@ Sk.misceval.promiseToSuspension = function(promise) {
 
     return suspension;
 };
-Sk.exportSymbol("Sk.misceval.promiseToSuspension", Sk.misceval.promiseToSuspension);
+
 
 /**
  * Constructs a class object given a code object representing the body
@@ -1329,4 +1329,4 @@ Sk.misceval.buildClass = function (globals, func, name, bases, cell) {
 
     return klass;
 };
-Sk.exportSymbol("Sk.misceval.buildClass", Sk.misceval.buildClass);
+

--- a/src/module.js
+++ b/src/module.js
@@ -3,7 +3,7 @@
  */
 Sk.builtin.module = function module () {
 };
-Sk.exportSymbol("Sk.builtin.module", Sk.builtin.module);
+
 
 Sk.builtin.module.prototype.ob$type = Sk.builtin.type.makeIntoTypeObj("module", Sk.builtin.module);
 Sk.builtin.module.prototype.tp$getattr = Sk.builtin.object.prototype.GenericGetAttr;

--- a/src/number.js
+++ b/src/number.js
@@ -307,4 +307,4 @@ Sk.builtin.nmber.prototype.str$ = function (base, sign) {
     throw deprecatedError;
 };
 
-Sk.exportSymbol("Sk.builtin.nmber", Sk.builtin.nmber);
+

--- a/src/object.js
+++ b/src/object.js
@@ -72,7 +72,7 @@ Sk.builtin._tryGetSubscript = function(dict, pyName) {
         return undefined;
     }
 };
-Sk.exportSymbol("Sk.builtin._tryGetSubscript", Sk.builtin._tryGetSubscript);
+
 
 
 /**
@@ -155,7 +155,7 @@ Sk.builtin.object.prototype.GenericGetAttr = function (pyName, canSuspend) {
 
     return undefined;
 };
-Sk.exportSymbol("Sk.builtin.object.prototype.GenericGetAttr", Sk.builtin.object.prototype.GenericGetAttr);
+
 
 Sk.builtin.object.prototype.GenericPythonGetAttr = function(self, pyName) {
     var r = Sk.builtin.object.prototype.GenericGetAttr.call(self, pyName, true);
@@ -164,7 +164,7 @@ Sk.builtin.object.prototype.GenericPythonGetAttr = function(self, pyName) {
     }
     return r;
 };
-Sk.exportSymbol("Sk.builtin.object.prototype.GenericPythonGetAttr", Sk.builtin.object.prototype.GenericPythonGetAttr);
+
 
 /**
  * @param {Object} pyName
@@ -216,12 +216,12 @@ Sk.builtin.object.prototype.GenericSetAttr = function (pyName, value, canSuspend
         dict[mangled] = value;
     }
 };
-Sk.exportSymbol("Sk.builtin.object.prototype.GenericSetAttr", Sk.builtin.object.prototype.GenericSetAttr);
+
 
 Sk.builtin.object.prototype.GenericPythonSetAttr = function(self, pyName, value) {
     return Sk.builtin.object.prototype.GenericSetAttr.call(self, pyName, value, true);
 };
-Sk.exportSymbol("Sk.builtin.object.prototype.GenericPythonSetAttr", Sk.builtin.object.prototype.GenericPythonSetAttr);
+
 
 Sk.builtin.object.prototype.HashNotImplemented = function () {
     throw new Sk.builtin.TypeError("unhashable type: '" + Sk.abstr.typeName(this) + "'");
@@ -576,5 +576,5 @@ Sk.builtin.NotImplemented.prototype["$r"] = function () { return new Sk.builtin.
 Sk.builtin.NotImplemented.NotImplemented$ =  /** @type {Sk.builtin.NotImplemented} */ (Object.create(Sk.builtin.NotImplemented.prototype, {
     v: { value: null, enumerable: true },
 }));
-Sk.exportSymbol("Sk.builtin.none", Sk.builtin.none);
-Sk.exportSymbol("Sk.builtin.NotImplemented", Sk.builtin.NotImplemented);
+
+

--- a/src/parser.js
+++ b/src/parser.js
@@ -374,6 +374,6 @@ Sk.parseTreeDump = function parseTreeDump (n, indent) {
 };
 
 
-Sk.exportSymbol("Sk.Parser", Parser);
-Sk.exportSymbol("Sk.parse", Sk.parse);
-Sk.exportSymbol("Sk.parseTreeDump", Sk.parseTreeDump);
+Sk.Parser = Parser;
+
+

--- a/src/pgen/ast/asdl_js.py
+++ b/src/pgen/ast/asdl_js.py
@@ -383,7 +383,7 @@ def main(asdlfile, outputfile):
         )
     v.visit(mod)
 
-    f.write('Sk.exportSymbol("Sk.astnodes", Sk.astnodes);\n');
+    f.write('\n');
     
     f.close()
 

--- a/src/set.js
+++ b/src/set.js
@@ -442,7 +442,7 @@ Sk.builtin.set.prototype.__contains__ = new Sk.builtin.func(function(self, item)
     return new Sk.builtin.bool(self.sq$contains(item));
 });
 
-Sk.exportSymbol("Sk.builtin.set", Sk.builtin.set);
+
 
 /**
  * @constructor

--- a/src/str.js
+++ b/src/str.js
@@ -84,7 +84,7 @@ Sk.builtin.str = function (x, encoding, errors) {
     return this;
 
 };
-Sk.exportSymbol("Sk.builtin.str", Sk.builtin.str);
+
 
 Sk.abstr.setUpInheritance("str", Sk.builtin.str, Sk.builtin.seqtype);
 

--- a/src/structseq.js
+++ b/src/structseq.js
@@ -95,4 +95,4 @@ Sk.builtin.make_structseq = function (module, name, fields, doc) {
 
     return cons;
 };
-Sk.exportSymbol("Sk.builtin.make_structseq", Sk.builtin.make_structseq);
+

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -87,7 +87,7 @@ var SYMTAB_CONSTS = {
     ClassBlock: ClassBlock
 };
 
-Sk.exportSymbol("Sk.SYMTAB_CONSTS", SYMTAB_CONSTS);
+Sk.SYMTAB_CONSTS = SYMTAB_CONSTS;
 
 /**
  * @constructor
@@ -1121,5 +1121,5 @@ Sk.dumpSymtab = function (st) {
     return getIdents(st.top, "");
 };
 
-Sk.exportSymbol("Sk.symboltable", Sk.symboltable);
-Sk.exportSymbol("Sk.dumpSymtab", Sk.dumpSymtab);
+
+

--- a/src/timsort.js
+++ b/src/timsort.js
@@ -729,5 +729,5 @@ Sk.builtin.listSlice.prototype.reverse = function () {
     }
 };
 
-Sk.exportSymbol("Sk.builtin.listSlice", Sk.builtin.listSlice);
-Sk.exportSymbol("Sk.builtin.timSort", Sk.builtin.timSort);
+
+

--- a/src/token.js
+++ b/src/token.js
@@ -159,10 +159,10 @@ Sk.token.ISTERMINAL = ISTERMINAL;
 Sk.token.ISNONTERMINAL = ISNONTERMINAL;
 Sk.token.ISEOF = ISEOF;
 
-Sk.exportSymbol("Sk.token", Sk.token);
-Sk.exportSymbol("Sk.token.tokens", Sk.token.tokens);
-Sk.exportSymbol("Sk.token.tok_name", Sk.token.tok_name);
-Sk.exportSymbol("Sk.token.EXACT_TOKEN_TYPES");
-Sk.exportSymbol("Sk.token.ISTERMINAL", Sk.token.ISTERMINAL);
-Sk.exportSymbol("Sk.token.ISNONTERMINAL", Sk.token.ISNONTERMINAL);
-Sk.exportSymbol("Sk.token.ISEOF", Sk.token.ISEOF);
+
+
+
+
+
+
+

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -471,4 +471,4 @@ function _tokenize(filename, readline, encoding, yield_) {
 
 Sk._tokenize = _tokenize;
 
-Sk.exportSymbol("Sk._tokenize", Sk._tokenize);
+

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -259,7 +259,7 @@ Sk.builtin.tuple.prototype["count"] = new Sk.builtin.func(function (self, item) 
     return  new Sk.builtin.int_(count);
 });
 
-Sk.exportSymbol("Sk.builtin.tuple", Sk.builtin.tuple);
+
 
 /**
  * @constructor

--- a/src/type.js
+++ b/src/type.js
@@ -75,7 +75,7 @@ Sk.setupDunderMethods = function (py3) {
     }
 };
 
-Sk.exportSymbol("Sk.setupDunderMethods", Sk.setupDunderMethods);
+
 /**
  *
  * @constructor

--- a/src/util.js
+++ b/src/util.js
@@ -15,32 +15,8 @@ Sk.global =
     typeof window !== "undefined" ? window : // jshint ignore:line
     {};
 
-/**
- * Export "object" to global namespace as "name".
- *
- * @param {string} name name to export the object to
- * @param {*} object object to export
- */
-Sk.exportSymbol = function (name, object) {
-    var parts = name.split(".");
-    var curobj = Sk.global;
-    var part, idx;
+Sk.global["Sk"] = Sk;
 
-    for (idx = 0; idx < (parts.length - 1); idx++) {
-        part = parts[idx];
-
-        if (curobj.hasOwnProperty(part)) {
-            curobj = curobj[part];
-        } else {
-            curobj = curobj[part] = {};
-        }
-    }
-
-    if (typeof object !== "undefined") {
-        part = parts[idx];
-        curobj[part] = object;
-    }
-};
 
 Sk.isArrayLike = function (object) {
     if ((object instanceof Array) || (object && object.length && (typeof object.length == "number"))) {
@@ -53,9 +29,9 @@ Sk.js_beautify = function (x) {
     return x;
 };
 
-Sk.exportSymbol("Sk", Sk);
-Sk.exportSymbol("Sk.global", Sk.global);
-Sk.exportSymbol("Sk.build", Sk.build);
-Sk.exportSymbol("Sk.exportSymbol", Sk.exportSymbol);
-Sk.exportSymbol("Sk.isArrayLike", Sk.isArrayLike);
-Sk.exportSymbol("Sk.js_beautify", Sk.js_beautify);
+
+
+
+
+
+

--- a/src/zip.js
+++ b/src/zip.js
@@ -60,4 +60,3 @@ Sk.builtin.zip_.prototype["$r"] = function () {
     return new Sk.builtin.str("<zip object>");
 };
 
-Sk.exportSymbol("Sk.builtin.zip_", Sk.builtin.zip_);


### PR DESCRIPTION
I might be wrong but I don't think this does anything anymore. 

The webpack/closurecompiler build preserves `Sk` since it's defined as an `extern` and so I don't see that we need to also export the symbols using this function.

By removing this from the codebase we save 10kb 🏆 