### PR TITLE
make locals and globals work(ish)

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -1373,15 +1373,8 @@ Sk.builtin.issubclass = function issubclass (c1, c2) {
 };
 
 Sk.builtin.globals = function globals () {
-    var i, unmangled;
-    var ret = new Sk.builtin.dict([]);
-    for (i in Sk["globals"]) {
-        unmangled = Sk.unfixReserved(i);
-        ret.mp$ass_subscript(new Sk.builtin.str(unmangled), Sk["globals"][i]);
-    }
-
-    return ret;
-
+    const globals = (Sk._state && Sk._state.globals) || {};
+    return new Sk.builtin.mappingproxy(globals);
 };
 
 Sk.builtin.divmod = function divmod (a, b) {
@@ -1534,8 +1527,9 @@ Sk.builtin.iter = function iter (obj, sentinel) {
     }
 };
 
-Sk.builtin.locals = function locals () {
-    throw new Sk.builtin.NotImplementedError("locals is not yet implemented");
+Sk.builtin.locals = function locals() {
+    const locals = (Sk._state && Sk._state.locals) || {};
+    return new Sk.builtin.mappingproxy(locals);
 };
 Sk.builtin.memoryview = function memoryview () {
     throw new Sk.builtin.NotImplementedError("memoryview is not yet implemented");

--- a/src/compile.js
+++ b/src/compile.js
@@ -1184,6 +1184,7 @@ Compiler.prototype.outputAllUnits = function () {
                 generatedBlocks[block] = true;
 
                 ret += "case " + block + ": /* --- " + blocks[block]._name + " --- */";
+                ret += "\nSk._state = {globals: $gbl, locals: $loc};";
                 ret += blocks[block].join("");
 
                 if (blocks[block]._next !== null) {
@@ -2564,10 +2565,11 @@ Compiler.prototype.nameop = function (name, ctx, dataToStore) {
                     out("if (", mangled, " === undefined) { throw new Sk.builtin.UnboundLocalError('local variable \\\'", mangled, "\\\' referenced before assignment'); }\n");
                     return mangled;
                 case Sk.astnodes.Store:
-                    out(mangled, "=", dataToStore, ";");
+                    out("$loc.",mangled, "=", mangled, "=", dataToStore, ";");
                     break;
                 case Sk.astnodes.Del:
-                    out("delete ", mangled, ";");
+                    out("delete $loc.", mangled, ";");
+                    out("delete", mangled, ";");
                     break;
                 default:
                     Sk.asserts.fail("unhandled");


### PR DESCRIPTION
This pr aims to fix globals and locals (ish)

---

**The current problem with globals:**

Modules can't use `globals` in skulpt 
from python docs `globals`:
> Return a dictionary representing the current global symbol table. This is always the dictionary of the current module (inside a function or method, this is the module where it is defined, not the module from which it is called).

but in skulpt we use whatever the current reference is to `Sk.globals`
this will depend on the module that is `__main__` and so `globals()` will only work if you're calling it from `__main__`

---

**How this pr fixes it:**
At each block I add a state object `Sk._state = {globals: $gbl, locals.$loc}`
and thus will be correct for any call to globals/locals

---

**Use of `mappingproxy`**
This is why I have (ish) in the title.
`globals()` in skulpt is really a readonly property since changing it has no effect.
but in python you can change the `globals()` object as you like. 

currently we return a dictionary which is a copy of `Sk.globals` 
but given the above - I think it would be more sensible to return a `mappingproxy` since it is readonly and will raise the appropriate error if someone tries to do something like

```python
globals()['foo'] = 'bar'
```
It's probably better that this raises an error in `skulpt` until changing `globals()` has an effect.

---

This pr depends on `mappingproxy` being implemented and so won't work on master. 

I don't know if this is the best way... if anyone else (@albertjan 😉 ) has tried to implement `locals` and has a more elegant solution then yes please!

I don't particularly like that I've ended up updating the `_state` object at every block. But I couldn't see a way around it...
since you need to be sure that the block hasn't done a call to a module who has then update the `_state` object.