### PR TITLE
Support keyword arguments in @classmethod

### DIFF
--- a/src/classmethod.py
+++ b/src/classmethod.py
@@ -7,6 +7,6 @@ class classmethod(object):
     def __get__(self, obj, klass=None):
         if klass is None:
             klass = type(obj)
-        def newfunc(*args):
-            return self.f(klass, *args)
+        def newfunc(*args, **kwargs):
+            return self.f(klass, *args, **kwargs)
         return newfunc

--- a/test/unit3/test_builtin.py
+++ b/test/unit3/test_builtin.py
@@ -1650,5 +1650,22 @@ class TestType(unittest.TestCase):
     #     self.assertRaises(TypeError, lambda: type('A', (B,), {'__slots__': '__dict__'}))
     #     self.assertRaises(TypeError, lambda: type('A', (B,), {'__slots__': '__weakref__'}))
 
+
+class HasClassMethod(object):
+    @classmethod
+    def foo(cls, *args, **kwargs):
+        return (cls, args, kwargs)
+
+
+class AlsoHasClassMethod(HasClassMethod):
+    pass
+
+
+class TestMisc(unittest.TestCase):
+    def test_classmethod(self):
+        self.assertEqual(HasClassMethod().foo(1, x=2), (HasClassMethod, (1,), {'x': 2}))
+        self.assertEqual(AlsoHasClassMethod().foo(1, x=2), (AlsoHasClassMethod, (1,), {'x': 2}))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Our implementation of `@classmethod` doesn't support keyword arguments. Fix it.