### PR TITLE
metaclass proof of concept

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -317,6 +317,38 @@ Compiler.prototype.cunpackstarstoarray = function(elts, permitEndOnly) {
     }
 };
 
+Compiler.prototype.cunpackkwstoarray = function (keywords, codeobj) {
+        
+    let keywordArgs = "undefined";
+
+    if (keywords && keywords.length > 0) {
+        let hasStars = false;
+        const kwarray = [];
+        for (let kw of keywords) {
+            if (hasStars && !Sk.__future__.python3) {
+                throw new SyntaxError("Advanced unpacking of function arguments is not supported in Python 2");
+            }
+            if (kw.arg) {
+                kwarray.push("'" + kw.arg.v + "'");
+                kwarray.push(this.vexpr(kw.value));
+            } else {
+                hasStars = true;
+            }
+        }
+        keywordArgs = "[" + kwarray.join(",") + "]";
+        if (hasStars) {
+            keywordArgs = this._gr("keywordArgs", keywordArgs);
+            for (let kw of keywords) {
+                if (!kw.arg) {
+                    out("$ret = Sk.abstr.mappingUnpackIntoKeywordArray(",keywordArgs,",",this.vexpr(kw.value),",",codeobj,");");
+                    this._checkSuspension();
+                }
+            }
+        }
+    }
+    return keywordArgs;
+};
+
 Compiler.prototype.ctuplelistorset = function(e, data, tuporlist) {
     var i;
     var items;
@@ -543,7 +575,6 @@ Compiler.prototype.ccompare = function (e) {
 
 Compiler.prototype.ccall = function (e) {
     var func = this.vexpr(e.func);
-    var kwarray = null;
     // Okay, here's the deal. We have some set of positional args
     // and we need to unpack them. We have some set of keyword args
     // and we need to unpack those too. Then we make a call.
@@ -551,33 +582,8 @@ Compiler.prototype.ccall = function (e) {
     // help us here; we do it by hand.
 
     let positionalArgs = this.cunpackstarstoarray(e.args, !Sk.__future__.python3);
-    let keywordArgs = "undefined";
+    let keywordArgs = this.cunpackkwstoarray(e.keywords, func);
 
-    if (e.keywords && e.keywords.length > 0) {
-        let hasStars = false;
-        kwarray = [];
-        for (let kw of e.keywords) {
-            if (hasStars && !Sk.__future__.python3) {
-                throw new SyntaxError("Advanced unpacking of function arguments is not supported in Python 2");
-            }
-            if (kw.arg) {
-                kwarray.push("'" + kw.arg.v + "'");
-                kwarray.push(this.vexpr(kw.value));
-            } else {
-                hasStars = true;
-            }
-        }
-        keywordArgs = "[" + kwarray.join(",") + "]";
-        if (hasStars) {
-            keywordArgs = this._gr("keywordArgs", keywordArgs);
-            for (let kw of e.keywords) {
-                if (!kw.arg) {
-                    out("$ret = Sk.abstr.mappingUnpackIntoKeywordArray(",keywordArgs,",",this.vexpr(kw.value),",",func,");");
-                    this._checkSuspension();
-                }
-            }
-        }
-    }
 
     if (Sk.__future__.super_args && e.func.id && e.func.id.v === "super" && positionalArgs === "[]") {
         // make sure there is a self variable
@@ -2283,6 +2289,7 @@ Compiler.prototype.cclass = function (s) {
 
     bases = this.vseqexpr(s.bases);
 
+    let keywordArgs = this.cunpackkwstoarray(s.keywords);
     scopename = this.enterScope(s.name, s, s.lineno);
     entryBlock = this.newBlock("class entry");
 
@@ -2313,7 +2320,8 @@ Compiler.prototype.cclass = function (s) {
     this.exitScope();
 
     // todo; metaclass
-    out("$ret = Sk.misceval.buildClass($gbl,", scopename, ",", s.name["$r"]().v, ",[", bases, "], $cell);")
+    out("$ret = Sk.misceval.buildClass($gbl,", scopename, ",", s.name["$r"]().v, ",[", bases, "], $cell, ", keywordArgs, ");");
+    this._checkSuspension();
 
     // apply decorators
 

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1290,10 +1290,18 @@ Sk.exportSymbol("Sk.misceval.promiseToSuspension", Sk.misceval.promiseToSuspensi
  * should return a newly constructed class object.
  *
  */
-Sk.misceval.buildClass = function (globals, func, name, bases, cell) {
+Sk.misceval.buildClass = function (globals, func, name, bases, cell, kws) {
     // todo; metaclass
     var klass;
-    var meta = Sk.builtin.type;
+    kws = kws || [];
+    let meta_idx = kws.indexOf("metaclass");
+    let meta;
+    if (meta_idx > -1) {
+        meta = kws[meta_idx + 1];
+        kws.splice(meta_idx, 2);
+    } else {
+        meta = Sk.builtin.type;
+    }
 
     var l_cell = cell === undefined ? {} : cell;
     var locals = {};
@@ -1325,7 +1333,7 @@ Sk.misceval.buildClass = function (globals, func, name, bases, cell) {
     }
     _locals = new Sk.builtin.dict(_locals);
 
-    klass = Sk.misceval.callsimArray(meta, [_name, _bases, _locals]);
+    klass = Sk.misceval.callsimOrSuspendArray(meta, [_name, _bases, _locals], kws);
 
     return klass;
 };


### PR DESCRIPTION
This branch is a proof of concept for metaclasses

More needs to happen for metaclasses to by inline with python but you can do simple things like:

```python3
>>> class A(type): pass
>>> class B(metaclass=A): pass
>>> type(B)
__main__.A
```

And more complicated things like

```python3
>>> class A(type):
...   def __new__(cls, name, bases, _dict, **kwargs):
...     _dict.update(kwargs)
...     return super(A, cls).__new__(cls, name, bases, _dict)
...
>>> class B(metaclass=A, foo='bar'): pass
>>> B.__dict__
mappingproxy({'__module__': '__main__',
              'foo': 'bar',
              '__dict__': <getset_descriptor '__dict__' of 'B' objects>
            })
```

The first example does work on master 😄 

The second example works on #1092 but does not work on master because `type` has no `__new__` implementation and `super` is a little quirky on master branch.
