### PR TITLE
make exec work

### DIFF
--- a/repl/repl.js
+++ b/repl/repl.js
@@ -32,16 +32,16 @@ if (program.args[0] == "py2") {
     process.exit(1);
 }
 
+const gbl = {__file__: "<repl>", __name__: "__main__"};
+
 Sk.configure({
     output: (args) => { process.stdout.write(args); },
     read: (fname) => { return fs.readFileSync(fname, "utf8"); },
     systemexit: true,
-    retainGlobals: true,
     inputfun: readline,
     __future__: py3 ? Sk.python3 : Sk.python2,
 });
 
-Sk.globals = { __name__: new Sk.builtin.str("__main__")};
 
 var //finds lines starting with "print"
     re = new RegExp("\\s*print"),
@@ -128,7 +128,7 @@ while (true) {
         if (!lines || /^\s*$/.test(lines)) {
             continue;
         } else {
-            Sk.importMainWithBody("repl", false, lines.join("\n"));
+            Sk.misceval.retryOptionalSuspensionOrThrow(Sk.builtin.exec(lines.join("\n"), gbl), "repl does not support suspensions");
         }
     } catch (err) {
         if (err instanceof Sk.builtin.SystemExit) {

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -791,7 +791,10 @@ Sk.builtin.exec = function (code, globals, locals) {
     );
     /**@todo shouldn't have to do this - Sk.globals loses scope*/
     const tmp = Sk.globals;
-    /** @todo this is not correct outside of __main__ i.e. exec doesn't work inside modules using the module scope*/
+    /** 
+     * @todo this is not correct outside of __main__ i.e. exec doesn't work inside modules using the module scope
+     * This is because globals don't work outside of __main__
+    */
     globals = globals || tmp;
     return Sk.misceval.chain(
         code,

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -739,8 +739,94 @@ Sk.builtin.jsmillis = function jsmillis() {
     return now.valueOf();
 };
 
-Sk.builtin.eval_ = function eval_() {
-    throw new Sk.builtin.NotImplementedError("eval is not yet implemented");
+const pyCode = Sk.abstr.buildNativeClass("code", {
+    constructor: function code(filename, compiled) {
+        this.compiled = compiled;
+        this.code = compiled.code;
+        this.filename = filename;
+    },
+    slots: {
+        tp$new(args, kwargs) {
+            throw new Sk.builtin.NotImplementedError("cannot construct a code object in skulpt");
+        },
+        $r() {
+            return new Sk.builtin.str("<code object <module>, file " + this.filename + ">");
+        },
+    },
+});
+
+Sk.builtin.compile = function (source, filename, mode, flags, dont_inherit, optimize) {
+    Sk.builtin.pyCheckType("source", "str", Sk.builtin.checkString(source));
+    Sk.builtin.pyCheckType("filename", "str", Sk.builtin.checkString(filename));
+    Sk.builtin.pyCheckType("mode", "str", Sk.builtin.checkString(mode));
+    source = source.$jsstr();
+    filename = filename.$jsstr();
+    mode = mode.$jsstr();
+    return Sk.misceval.chain(Sk.compile(source, filename, mode, true), (co) => new pyCode(filename, co));
+};
+
+/**
+ *
+ * @param {*} code
+ * @param {Object|undefined} globals
+ * @param {Object|undefined} locals
+ *
+ * Internally call with javascript objects for globals and locals
+ */
+Sk.builtin.exec = function (code, globals, locals) {
+    if (Sk.builtin.checkString(code)) {
+        code = Sk.compile(code.$jsstr(), "?", "exec", true);
+    } else if (typeof code === "string") {
+        code = Sk.compile(code, "?", "exec", true);
+    } else if (!(code instanceof pyCode)) {
+        throw new Sk.builtin.TypeError("exec() arg 1 must be a string, bytes or code object");
+    }
+    Sk.asserts.assert(
+        globals === undefined || globals.constructor === Object,
+        "internal calls to exec should be called with a javascript object for globals"
+    );
+    Sk.asserts.assert(
+        locals === undefined || locals.constructor === Object,
+        "internal calls to exec should be called with a javascript object for locals"
+    );
+    /**@todo shouldn't have to do this - Sk.globals loses scope*/
+    const tmp = Sk.globals;
+    /** @todo this is not correct outside of __main__ i.e. exec doesn't work inside modules using the module scope*/
+    globals = globals || tmp;
+    return Sk.misceval.chain(
+        code,
+        (co) => eval(co.code)(globals, locals),
+        (new_locals) => {
+            Sk.globals = tmp;
+            // we return new_locals internally for eval
+            return new_locals;
+        }
+    );
+};
+
+
+Sk.builtin.eval = function (source, globals, locals) {
+    if (Sk.builtin.checkString(source)) {
+        source = source.$jsstr();
+    } else if (Sk.builtin.checkBytes(source)) {
+        throw new Sk.builtin.NotImplementedError("bytes for eval is not yet implemented in skulpt");
+    }
+    if (typeof source === "string") {
+        source = source.trim();
+        const parse = Sk.parse("?", source);
+        const ast = Sk.astFromParse(parse.cst, "?", parse.flags);
+        if (ast.body.length > 1 || !(ast.body[0] instanceof Sk.astnodes.Expr)) {
+            throw new Sk.builtin.SyntaxError("invalid syntax");
+        }
+        source = "__final_res__ = " + source;
+    } else if (!(source instanceof pyCode)) {
+        throw new Sk.builtin.TypeError("eval() arg 1 must be a string, bytes or code object");
+    }
+    return Sk.misceval.chain(Sk.builtin.exec(source, globals, locals), (new_locals) => {
+        const res = new_locals.__final_res__ || Sk.builtin.none.none$;
+        delete new_locals.__final_res__;
+        return res;
+    });
 };
 
 Sk.builtin.map = function map(fun, seq) {

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -231,9 +231,9 @@ Sk.abstr.setUpModuleMethods("builtins", Sk.builtins, {
         $name: "eval",
         $meth: function (source, globals, locals) {
             // check globals
-            const tmp_globals = checkGlobLoc(globals, "globals");
+            const tmp_globals = globLocToJs(globals, "globals");
             // check locals
-            const tmp_locals = checkGlobLoc(locals, "locals");
+            const tmp_locals = globLocToJs(locals, "locals");
             return Sk.misceval.chain(Sk.builtin.eval(source, tmp_globals, tmp_locals), (res) => {
                 reassignGlobLoc(globals, tmp_globals);
                 reassignGlobLoc(locals, tmp_locals);
@@ -249,9 +249,9 @@ Sk.abstr.setUpModuleMethods("builtins", Sk.builtins, {
     exec: {
         $meth: function (source, globals, locals) {
             // check globals
-            const tmp_globals = checkGlobLoc(globals, "globals");
+            const tmp_globals = globLocToJs(globals, "globals");
             // check locals
-            const tmp_locals = checkGlobLoc(locals, "locals");
+            const tmp_locals = globLocToJs(locals, "locals");
             return Sk.misceval.chain(Sk.builtin.exec(source, tmp_globals, tmp_locals), (new_locals) => {
                 reassignGlobLoc(globals, tmp_globals);
                 reassignGlobLoc(locals, tmp_locals);
@@ -491,7 +491,7 @@ Sk.abstr.setUpModuleMethods("builtins", Sk.builtins, {
 });
 
 // function used for exec and eval
-function checkGlobLoc(glob_loc, name) {
+function globLocToJs(glob_loc, name) {
     let tmp = undefined;
     if (glob_loc === undefined || Sk.builtin.checkNone(glob_loc)) {
         glob_loc = undefined;

--- a/src/compile.js
+++ b/src/compile.js
@@ -2763,12 +2763,11 @@ Compiler.prototype.cmod = function (mod) {
     var modf = this.enterScope(new Sk.builtin.str("<module>"), mod, 0, this.canSuspend);
 
     var entryBlock = this.newBlock("module entry");
-    this.u.prefixCode = "var " + modf + "=(function($forcegbl){";
+    this.u.prefixCode = "var " + modf + "=(function($forcegbl, $forceloc){";
     this.u.varDeclsCode =
         "var $gbl = $forcegbl || {}, $blk=" + entryBlock +
-        ",$exc=[],$loc=$gbl,$cell={},$err=undefined;" +
-        "$loc.__file__=new Sk.builtins.str('" + this.filename +
-        "');var $ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;";
+        ",$exc=[],$loc=$forceloc || $gbl,$cell={},$err=undefined;" +
+        "var $ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;";
 
     if (Sk.execLimit !== null) {
         this.u.varDeclsCode += "if (typeof Sk.execStart === 'undefined') {Sk.execStart = Date.now()}";
@@ -2781,7 +2780,6 @@ Compiler.prototype.cmod = function (mod) {
     this.u.varDeclsCode += "var $waking=false; if ("+modf+".$wakingSuspension!==undefined) { $wakeFromSuspension(); $waking=true; }" +
         "if (Sk.retainGlobals) {" +
         "    if (Sk.globals) { $gbl = Sk.globals; Sk.globals = $gbl; $loc = $gbl; }" +
-        "    if (Sk.globals) { $gbl = Sk.globals; Sk.globals = $gbl; $loc = $gbl; $loc.__file__=new Sk.builtins.str('" + this.filename + "');}" +
         "    else { Sk.globals = $gbl; }" +
         "} else { Sk.globals = $gbl; }";
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -2857,7 +2857,8 @@ Sk.compile = function (source, filename, mode, canSuspend) {
     var ret = "$compiledmod = function() {" + c.result.join("") + "\nreturn " + funcname + ";}();";
     return {
         funcname: "$compiledmod",
-        code    : ret
+        code    : ret,
+        filename: filename,
     };
 };
 

--- a/src/import.js
+++ b/src/import.js
@@ -266,6 +266,9 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, rela
             if (co.packagePath) {
                 module["$d"]["__path__"] = new Sk.builtin.tuple([new Sk.builtin.str(co.packagePath)]);
             }
+            if (co.filename && co.funcname !== "$builtinmodule") {
+                module["$d"]["__file__"] = new Sk.builtin.str(co.filename);
+            }
 
             return modscope(module["$d"]);
 


### PR DESCRIPTION
This is a cherry picked commit on top of #1092

A suggestion for exec. 

I have suggested two implementations:
internal implementations are called via `Sk.builtin.exec`
and python are called via `Sk.builtins.exec`

The reason for separate implementations is that...it could be quite nice to pass a javascript object for globals and locals.

```javascript
globals = {foo: new Sk.builtin.str('bar')}
Sk.builtin.exec("print(foo)", globals)
```

But i'm not wedded to an approach. 
I've been working on implementing dataclasses - as a first step to get the module to work using the version in python - exec was necessary. So here it is...

UPDATE:
- I've limited to globals, locals only being dictionaries when called from python, whereas, Cpython supports dicts for globals and any mapping for locals. This can be updated in the future.
- I adjusted how repl.js worked since this implementation of exec means that you can keep track of the globals without having to use `forceGlobal`.


