### PR TITLE
support generic alias

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -765,6 +765,17 @@ Sk.abstr.objectGetItem = function (o, key, canSuspend) {
     if (o.mp$subscript) {
         return o.mp$subscript(key, canSuspend);
     }
+    if (Sk.builtin.checkClass(o)) {
+        if (o === Sk.builtin.type) {
+            return new Sk.builtin.GenericAlias(o, key);
+        }
+        const meth = Sk.abstr.typeLookup(o, Sk.builtin.str.$class_getitem);
+        if (meth !== undefined) {
+            const res = Sk.misceval.callsimOrSuspendArray(meth, [key]);
+            return canSuspend ? res : Sk.misceval.retryOptionalSuspensionOrThrow(res);
+        }
+    }
+
     throw new Sk.builtin.TypeError("'" + Sk.abstr.typeName(o) + "' does not support indexing");
 };
 Sk.exportSymbol("Sk.abstr.objectGetItem", Sk.abstr.objectGetItem);

--- a/src/abstract.js
+++ b/src/abstract.js
@@ -23,9 +23,9 @@ Sk.abstr = {};
  */
 Sk.abstr.typeName = function (obj) {
     if (obj != null && obj.tp$name !== undefined) {
-        let name = obj.hp$name;
+        let name = obj.ht$name;
         if (name !== undefined) {
-            return name;
+            return name.toString();
         }
         name = obj.tp$name;
         if (name.includes(".")) {

--- a/src/compile.js
+++ b/src/compile.js
@@ -992,6 +992,8 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
             return this.cjoinedstr(e);
         case Sk.astnodes.FormattedValue:
             return this.cformattedvalue(e);
+        case Sk.astnodes.Ellipsis:
+            return this.makeConstant("Sk.builtin.ellipsis");
         default:
             Sk.asserts.fail("unhandled case " + e.constructor.name + " vexpr");
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,6 +16,7 @@ Sk.builtin.str.$abs = new Sk.builtin.str("__abs__");
 Sk.builtin.str.$bytes = new Sk.builtin.str("__bytes__");
 Sk.builtin.str.$call = new Sk.builtin.str("__call__");
 Sk.builtin.str.$class = new Sk.builtin.str("__class__");
+Sk.builtin.str.$class_getitem = new Sk.builtin.str("__class_getitem__");
 Sk.builtin.str.$cmp = new Sk.builtin.str("__cmp__");
 Sk.builtin.str.$complex = new Sk.builtin.str("__complex__");
 Sk.builtin.str.$contains = new Sk.builtin.str("__contains__");

--- a/src/dict.js
+++ b/src/dict.js
@@ -251,7 +251,7 @@ Sk.builtin.dict = Sk.abstr.buildNativeClass("dict", {
             $doc: "D.copy() -> a shallow copy of D",
         },
     },
-    classmethods: /**@lends {Sk.builtin.dict.prototype}*/ {
+    classmethods: /**@lends {Sk.builtin.dict.prototype}*/ Object.assign({
         fromkeys: {
             $meth: function fromkeys(seq, value) {
                 value = value || Sk.builtin.none.none$;
@@ -271,7 +271,7 @@ Sk.builtin.dict = Sk.abstr.buildNativeClass("dict", {
             $textsig: "($type, iterable, value=None, /)",
             $doc: "Create a new dictionary with keys from iterable and values set to value.",
         },
-    },
+    }, Sk.generic.classGetItem),
     proto: /**@lends {Sk.builtin.dict.prototype}*/ {
         quick$lookup,
         mp$lookup,

--- a/src/enumerate.js
+++ b/src/enumerate.js
@@ -38,5 +38,6 @@ Sk.builtin.enumerate = Sk.abstr.buildIteratorClass("enumerate", {
             }
         },
     },
+    classmethods: Sk.generic.classGetItem,
 });
 Sk.exportSymbol("Sk.builtin.enumerate", Sk.builtin.enumerate);

--- a/src/errors.js
+++ b/src/errors.js
@@ -40,7 +40,7 @@ Sk.builtin.BaseException = Sk.abstr.buildNativeClass("BaseException", {
         tp$doc: "Common base class for all exceptions",
         tp$new(args, kwargs) {
             let instance;
-            if (!this.hp$type) {
+            if (!this.ht$type) {
                 // then we have a builtin constructor so just return it as new this
                 instance = new this.constructor();
             } else {

--- a/src/function.js
+++ b/src/function.js
@@ -257,7 +257,14 @@ function $resolveArgs(posargs, kw) {
             }
         }
         if (missing.length != 0 && (this.co_argcount || this.co_varnames)) {
-            throw new Sk.builtin.TypeError(this.$name + "() missing " + missing.length + " required argument" + (missing.length==1?"":"s") + (missingUnnamed ? "" : (": " + missing.join(", "))));
+            throw new Sk.builtin.TypeError(
+                this.$name +
+                    "() missing " +
+                    missing.length +
+                    " required argument" +
+                    (missing.length == 1 ? "" : "s") +
+                    (missingUnnamed ? "" : ": " + missing.map((x) => "'" + x + "'").join(", "))
+            );
         }
         for (; i < co_argcount; i++) {
             if (args[i] === undefined) {

--- a/src/generic.js
+++ b/src/generic.js
@@ -342,3 +342,13 @@ Sk.generic.seqCompare = function (other, op) {
     // or, compare the differing element using the proper operator
     return Sk.misceval.richCompareBool(v[i], w[i], op);
 };
+
+
+Sk.generic.classGetItem = {
+    __class_getitem__: {
+        $meth(args) {
+            return new Sk.builtin.GenericAlias(this, args);
+        },
+        $flags: { OneArg: true },
+    },
+};

--- a/src/generic_alias.js
+++ b/src/generic_alias.js
@@ -1,0 +1,208 @@
+Sk.builtin.GenericAlias = Sk.abstr.buildNativeClass("types.GenericAlias", {
+    constructor: function GenericAlias(origin, args) {
+        this.$origin = origin;
+        if (!(args instanceof Sk.builtin.tuple)) {
+            args = new Sk.builtin.tuple([args]);
+        }
+        this.$args = args;
+        this.$params = null;
+    },
+    slots: {
+        tp$new(args, kwargs) {
+            Sk.abstr.checkNoKwargs("GenericAlias", kwargs);
+            Sk.abstr.checkArgsLen("GenericAlias", args, 2, 2);
+            return new Sk.builtin.GenericAlias(args[0], args[1]);
+        },
+        tp$getattr(pyName, canSuspend) {
+            if (Sk.builtin.checkString(pyName)) {
+                if (!this.attr$exc.includes(pyName)) {
+                    return this.$origin.tp$getattr(pyName, canSuspend);
+                }
+            }
+            return Sk.generic.getAttr.call(this, pyName, canSuspend);
+        },
+        $r() {
+            const origin_repr = this.ga$repr(this.$origin);
+            let arg_repr = "";
+            this.$args.forEach((arg, i) => {
+                arg_repr += i > 0 ? ", " : "";
+                arg_repr += this.ga$repr(arg);
+            });
+            if (!arg_repr) {
+                arg_repr = "()";
+            }
+            return new Sk.builtin.str(origin_repr + "[" + arg_repr + "]");
+        },
+        tp$doc: "Represent a PEP 585 generic type\n\nE.g. for t = list[int], t.origin is list and t.args is (int,).",
+        tp$hash() {
+            const h0 = Sk.abstr.objectHash(this.$origin);
+            if (h0 == -1) {
+                return -1;
+            }
+            const h1 = Sk.abstr.objectHash(this.$args);
+            if (h1 == -1) {
+                return -1;
+            }
+            return h0 ^ h1;
+        },
+        tp$call(args, kwargs) {
+            const obj = Sk.misceval.callsimArray(this.$origin, args, kwargs);
+            try {
+                obj.tp$setattr(new Sk.builtin.str("__orig_class__"), this);
+            } catch (e) {
+                if (!(e instanceof Sk.builtin.AttributeError) && !(e instanceof Sk.builtin.TypeError)) {
+                    throw e;
+                }
+            }
+            return obj;
+        },
+        tp$richcompare(other, op) {
+            if (!(other instanceof Sk.builtin.GenericAlias) || (op !== "Eq" && op !== "NotEq")) {
+                return Sk.builtin.NotImplemented.NotImplemented$;
+            }
+            const eq = Sk.misceval.richCompareBool(this.$origin, other.$origin, "Eq");
+            if (!eq) {
+                return op === "Eq" ? eq : !eq;
+            }
+            const res = Sk.misceval.richCompareBool(this.$args, other.$args, "Eq");
+            return op === "Eq" ? res : !res;
+        },
+        tp$as_sequence_or_mapping: true,
+        mp$subscript(item) {
+            if (this.$params === null) {
+                this.mk$params();
+            }
+            const nparams = this.$params.sq$length();
+            if (nparams === 0) {
+                throw new Sk.builtin.TypeError("There are no type variables left in " + Sk.misceval.objectRepr(this));
+            }
+
+            /**@todo the following only makes sense when we do typing*/
+
+            // const is_tuple = item instanceof Sk.builtin.tuple;
+            // if (is_tuple) {
+            //     const nitems = item.sq$length();
+            //     if (nitems !== nparams) {
+            //         throw new Sk.builtin.TypeError("Too " + (nitems > nparams ? "many" : "few") + " arguments for " + Sk.misceval.objectRepr(this));
+            //     }
+            // }
+            // const args = this.$args.v;
+            // const new_args = [];
+            // args.forEach((arg) => {
+            //     if (this.is$typevar(arg)) {
+            //         const iparam = this.tuple$index(this.$params.v, arg);
+            //         if (is_tuple) {
+            //             arg = item.v[iparam];
+            //         } else {
+            //             arg = item;
+            //         }
+            //     }
+            //     new_args.push(arg);
+            // });
+            // const res = new Sk.builtin.GenericAlias(this.$origin, new Sk.builtin.tuple(new_args));
+            // return res;
+        },
+    },
+    methods: {
+        __mro_entries__: {
+            $meth() {
+                return new Sk.builtin.tuple([this.$origin]);
+            },
+        },
+        __instancecheck__: {
+            $meth(_) {
+                throw new Sk.builtin.TypeError("isinstance() argument 2 cannot be a parameterized generic");
+            },
+            $flags: {OneArg: true},
+        },
+        __subclasscheck__: {
+            $meth(_) {
+                throw new Sk.builtin.TypeError("issubclass() argument 2 cannot be a parameterized generic");
+            },
+            $flags: {OneArg: true},
+        }
+    },
+    getsets: {
+        __parameters__: {
+            $get() {
+                if (this.$params === null) {
+                    this.mk$params();
+                }
+                return this.$params;
+            },
+            $doc: "Type variables in the GenericAlias.",
+        },
+        __origin__: {
+            $get() {
+                return this.$origin;
+            },
+        },
+        __args__: {
+            $get() {
+                return this.$args;
+            },
+        },
+    },
+    proto: {
+        mk$params() {
+            const arg_arr = this.$args.v;
+            const params = [];
+            arg_arr.forEach((t) => {
+                if (this.is$typevar(t)) {
+                    if (this.tuple$index(params, t) < 0) {
+                        params.push(t);
+                    }
+                }
+            });
+            this.$params = new Sk.builtin.tuple(params);
+        },
+        tuple$index(tup_arr, item) {
+            return tup_arr.indexOf(item);
+        },
+        is$typevar(type) {
+            if (type.tp$name !== "TypeVar") {
+                return false;
+            }
+            const module = Sk.abstr.lookupSpecial(type, Sk.builtin.str.$module);
+            if (module === undefined) {
+                // throw some sort of error
+                throw "err?";
+            }
+            if (module.toString() === "typing") {
+                return true;
+            }
+            return false;
+        },
+        ga$repr(item) {
+            if (item === Sk.builtin.ellipsis) {
+                return "...";
+            }
+            if (Sk.abstr.lookupSpecial(item, this.str$orig)) {
+                if (Sk.abstr.lookupSpecial(item, this.str$args)) {
+                    return Sk.misceval.objectRepr(item);
+                }
+            }
+            const qualname = Sk.abstr.lookupSpecial(item, Sk.builtin.str.$qualname);
+            if (qualname === undefined) {
+                return Sk.misceval.objectRepr(item);
+            }
+            const mod = Sk.abstr.lookupSpecial(item, Sk.builtin.str.$module);
+            if (mod === undefined || Sk.builtin.checkNone(mod)) {
+                return Sk.misceval.objectRepr(item);
+            } else if (mod.toString() === "builtins") {
+                return qualname.toString();
+            }
+            return mod.toString() + "." + qualname.toString();
+        },
+        str$orig: new Sk.builtin.str("__origin__"),
+        str$args: new Sk.builtin.str("__args__"),
+        attr$exc: [
+            "__origin__",
+            "__args__",
+            "__parameters__",
+            "__mro_entries__",
+            "__reduce_ex__", // needed so we don't look up object.__reduce_ex__
+            "__reduce__",
+        ].map((x) => new Sk.builtin.str(x)),
+    },
+});

--- a/src/generic_alias.js
+++ b/src/generic_alias.js
@@ -108,19 +108,20 @@ Sk.builtin.GenericAlias = Sk.abstr.buildNativeClass("types.GenericAlias", {
             $meth() {
                 return new Sk.builtin.tuple([this.$origin]);
             },
+            $flags: { NoArgs: true },
         },
         __instancecheck__: {
             $meth(_) {
                 throw new Sk.builtin.TypeError("isinstance() argument 2 cannot be a parameterized generic");
             },
-            $flags: {OneArg: true},
+            $flags: { OneArg: true },
         },
         __subclasscheck__: {
             $meth(_) {
                 throw new Sk.builtin.TypeError("issubclass() argument 2 cannot be a parameterized generic");
             },
-            $flags: {OneArg: true},
-        }
+            $flags: { OneArg: true },
+        },
     },
     getsets: {
         __parameters__: {

--- a/src/generic_alias.js
+++ b/src/generic_alias.js
@@ -145,6 +145,7 @@ Sk.builtin.GenericAlias = Sk.abstr.buildNativeClass("types.GenericAlias", {
         },
     },
     proto: {
+        // functions here match similar functions in Objects/genericaliasobject.c
         mk$params() {
             const arg_arr = this.$args.v;
             const params = [];
@@ -166,13 +167,10 @@ Sk.builtin.GenericAlias = Sk.abstr.buildNativeClass("types.GenericAlias", {
             }
             const module = Sk.abstr.lookupSpecial(type, Sk.builtin.str.$module);
             if (module === undefined) {
-                // throw some sort of error
-                throw "err?";
+                // throw some sort of error but all objects have __module_ so we shouldn't be here.
+                throw Sk.builtin.RuntimeError("found object withought a __module__");
             }
-            if (module.toString() === "typing") {
-                return true;
-            }
-            return false;
+            return module.toString() === "typing";
         },
         ga$repr(item) {
             if (item === Sk.builtin.ellipsis) {

--- a/src/lib/collections.js
+++ b/src/lib/collections.js
@@ -991,6 +991,7 @@ function collections_mod(collections) {
                 $doc: "Rotate the deque n steps to the right (default n=1).  If n is negative, rotates left.",
             },
         },
+        classmethods: Sk.generic.classGetItem,
         getsets: {
             maxlen: {
                 $get() {

--- a/src/lib/functools.js
+++ b/src/lib/functools.js
@@ -502,6 +502,7 @@ cache_info_type:    namedtuple class with the fields:\n\
             // __reduce__: {},
             // __setstate__: {}
         },
+        classmethods: Sk.generic.classGetItem,
         proto: {
             adj$args_kws: partial_adjust_args_kwargs,
             check$func(func) {
@@ -555,6 +556,7 @@ cache_info_type:    namedtuple class with the fields:\n\
                 $flags: { NoArgs: true },
             },
         },
+        classmethods: Sk.generic.classGetItem,
         getsets: {
             func: {
                 $get() {

--- a/src/lib/itertools.js
+++ b/src/lib/itertools.js
@@ -96,7 +96,7 @@ var $builtinmodule = function (name) {
                 }
             },
         },
-        classmethods: {
+        classmethods: Object.assign({
             from_iterable: {
                 $meth(iterable) {
                     const iterables = Sk.abstr.iter(iterable);
@@ -107,7 +107,7 @@ var $builtinmodule = function (name) {
                     "chain.from_iterable(iterable) --> chain object\n\nAlternate chain() constructor taking a single iterable argument\nthat evaluates lazily.",
                 $textsig: null,
             },
-        },
+        }, Sk.generic.classGetItem),
     });
 
     /**

--- a/src/lib/types.py
+++ b/src/lib/types.py
@@ -94,3 +94,5 @@ NotImplementedType = type(NotImplemented)
 
 del sys, _f, _g, _C, _x                           # Not for export
 __all__ = list(n for n in globals() if n[:1] != '_')
+
+GenericAlias = type(type[int])

--- a/src/list.js
+++ b/src/list.js
@@ -10,7 +10,7 @@ Sk.builtin.list = Sk.abstr.buildNativeClass("list", {
         if (L === undefined) {
             L = [];
         } else if (!Array.isArray(L)) {
-            L = Sk.misceval.arrayFromIterable(L); 
+            L = Sk.misceval.arrayFromIterable(L);
             // internal calls to constructor can't suspend - avoid using this;
         }
         Sk.asserts.assert(this instanceof Sk.builtin.list, "bad call to list, use 'new' with an Array of python objects");
@@ -125,7 +125,7 @@ Sk.builtin.list = Sk.abstr.buildNativeClass("list", {
             } else if (n * len > Number.MAX_SAFE_INTEGER) {
                 throw new Sk.builtin.OverflowError();
             }
-            
+
             for (let i = 1; i < n; i++) {
                 for (let j = 0; j < len; j++) {
                     this.v.push(this.v[j]);
@@ -283,6 +283,7 @@ Sk.builtin.list = Sk.abstr.buildNativeClass("list", {
             $doc: "Reverse *IN PLACE*.",
         },
     },
+    classmethods: Sk.generic.classGetItem,
     proto: /** @lends {Sk.builtin.list.prototype}*/ {
         sk$asarray() {
             return this.v.slice(0);

--- a/src/main.js
+++ b/src/main.js
@@ -81,6 +81,7 @@ require("./compile.js");
 require("./import.js");
 require("./timsort.js");
 require("./super.js");
+require("./generic_alias.js");
 require("./builtindict.js");
 require("./constants.js");
 

--- a/src/mappingproxy.js
+++ b/src/mappingproxy.js
@@ -134,6 +134,7 @@ Sk.builtin.mappingproxy = Sk.abstr.buildNativeClass("mappingproxy", {
             $doc: "D.copy() -> a shallow copy of D",
         },
     },
+    classmethods: Sk.generic.classGetItem,
     proto: {
         str$get: new Sk.builtin.str("get"),
         str$copy: new Sk.builtin.str("copy"),

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1187,7 +1187,7 @@ Sk.misceval.arrayFromIterable = function (iterable, canSuspend) {
     if (iterable === undefined) {
         return [];
     }
-    if (iterable.hp$type === undefined && iterable.sk$asarray !== undefined) {
+    if (iterable.ht$type === undefined && iterable.sk$asarray !== undefined) {
         // use sk$asarray only if we're a builtin
         return iterable.sk$asarray();
     }

--- a/src/nonetype.js
+++ b/src/nonetype.js
@@ -69,3 +69,24 @@ Sk.builtin.NotImplemented = Sk.abstr.buildNativeClass("NotImplementedType", {
 Sk.builtin.NotImplemented.NotImplemented$ = /** @type {Sk.builtin.NotImplemented} */ (Object.create(Sk.builtin.NotImplemented.prototype, {
     v: { value: null, enumerable: true },
 }));
+
+
+const ellipsisType = Sk.abstr.buildNativeClass("ellipsis", {
+    constructor: function ellipsis() {
+        return Sk.builtin.ellipsis;
+    }, 
+    slots : {
+        tp$new(args, kwargs) {
+            Sk.abstr.checkNoArgs("ellipsis", args, kwargs);
+            return Sk.builtin.ellipsis;
+        },
+        $r() {
+            return new Sk.builtin.str("Ellipsis");
+        }
+    },
+    flags: {
+        sk$acceptable_as_base_class: false,
+    }
+});
+
+Sk.builtin.ellipsis = Object.create(ellipsisType.prototype, {v: { value: "..." }});

--- a/src/object.js
+++ b/src/object.js
@@ -160,7 +160,7 @@ Sk.builtin.object = Sk.abstr.buildNativeClass("object", {
             return this.tp$str().v;
         },
         hasOwnProperty: Object.prototype.hasOwnProperty,
-        hp$type: undefined,
+        ht$type: undefined,
         // private method used for error messages
         sk$attrError() {
             return "'" + this.tp$name + "' object";

--- a/src/set.js
+++ b/src/set.js
@@ -334,6 +334,7 @@ Sk.builtin.set = Sk.abstr.buildNativeClass("set", {
             $doc: "Update a set with the union of itself and others.",
         },
     },
+    classmethods: Sk.generic.classGetItem,
     proto: /**@lends {Sk.builtin.set.prototype}*/ Object.assign(set_private_, {
         sk$asarray() {
             return this.v.sk$asarray();
@@ -516,6 +517,7 @@ Sk.builtin.frozenset = Sk.abstr.buildNativeClass("frozenset", {
         symmetric_difference: set_proto.symmetric_difference.d$def,
         union: set_proto.union.d$def,
     },
+    classmethods: Sk.generic.classGetItem,
     proto: /**@lends {Sk.builtin.frozenset.prototype}*/ Object.assign(
         {
             $subtype_new(args, kwargs) {

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -777,6 +777,8 @@ SymbolTable.prototype.visitExpr = function (e) {
         case Sk.astnodes.Starred:
             this.visitExpr(e.value);
             break;
+        case Sk.astnodes.Ellipsis:
+            break;
         default:
             Sk.asserts.fail("Unhandled type " + e.constructor.name + " in visitExpr");
     }

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -141,6 +141,9 @@ Sk.builtin.tuple = Sk.abstr.buildNativeClass("tuple", {
         sk$asarray() {
             return this.v.slice(0);
         },
+        forEach(...args) {
+            return this.v.forEach(...args);
+        }
     },
     methods: /**@lends {Sk.builtin.tuple.prototype}*/ {
         __getnewargs__: {
@@ -187,6 +190,7 @@ Sk.builtin.tuple = Sk.abstr.buildNativeClass("tuple", {
             $doc: "Return number of occurrences of value.",
         },
     },
+    classmethods: Sk.generic.classGetItem,
 });
 
 Sk.exportSymbol("Sk.builtin.tuple", Sk.builtin.tuple);

--- a/test/unit3/test_generic_alias.py
+++ b/test/unit3/test_generic_alias.py
@@ -1,0 +1,267 @@
+"""Tests for C-implemented GenericAlias."""
+
+import unittest
+# import pickle
+from collections import (
+    defaultdict, deque, OrderedDict, Counter#, UserDict, UserList
+)
+# from collections.abc import *
+# from concurrent.futures import Future
+# from concurrent.futures.thread import _WorkItem
+# from contextlib import AbstractContextManager, AbstractAsyncContextManager
+# from contextvars import ContextVar, Token
+# from dataclasses import Field
+from functools import partial, partialmethod#, cached_property
+# from mailbox import Mailbox, _PartialFile
+# from ctypes import Array, LibraryLoader
+# from difflib import SequenceMatcher
+# from filecmp import dircmp
+# from fileinput import FileInput
+# from mmap import mmap
+# from ipaddress import IPv4Network, IPv4Interface, IPv6Network, IPv6Interface
+from itertools import chain
+# from http.cookies import Morsel
+# from multiprocessing.managers import ValueProxy
+# from multiprocessing.pool import ApplyResult
+# try:
+    # from multiprocessing.shared_memory import ShareableList
+# except ImportError:
+    # multiprocessing.shared_memory is not available on e.g. Android
+    # ShareableList = None
+# from multiprocessing.queues import SimpleQueue
+# from os import DirEntry
+# from re import Pattern, Match
+from types import GenericAlias, MappingProxyType#, AsyncGeneratorType
+# from tempfile import TemporaryDirectory, SpooledTemporaryFile
+# from urllib.parse import SplitResult, ParseResult
+# from unittest.case import _AssertRaisesContext
+# from queue import Queue, SimpleQueue
+# from weakref import WeakSet, ReferenceType, ref
+# import typing
+
+# from typing import TypeVar
+# T = TypeVar('T')
+
+class BaseTest(unittest.TestCase):
+    """Test basics."""
+
+    def test_subscriptable(self):
+        for t in (type, tuple, list, dict, set, frozenset, enumerate,
+                #   mmap,
+                  defaultdict, deque,
+                #   SequenceMatcher,
+                #   dircmp,
+                #   FileInput,
+                  OrderedDict, Counter, #UserDict, UserList,
+                #   Pattern, Match,
+                  partial, partialmethod,# cached_property,
+                #   AbstractContextManager, AbstractAsyncContextManager,
+                #   Awaitable, Coroutine,
+                #   AsyncIterable, AsyncIterator,
+                #   AsyncGenerator, Generator,
+                #   Iterable, Iterator,
+                #   Reversible,
+                #   Container, Collection,
+                #   Callable,
+                #   Mailbox, _PartialFile,
+                #   ContextVar, Token,
+                #   Field,
+                #   Set, MutableSet,
+                #   Mapping, MutableMapping, MappingView,
+                #   KeysView, ItemsView, ValuesView,
+                #   Sequence, MutableSequence,
+                  MappingProxyType, #AsyncGeneratorType,
+                #   DirEntry,
+                #   IPv4Network, IPv4Interface, IPv6Network, IPv6Interface,
+                  chain,
+                #   TemporaryDirectory, SpooledTemporaryFile,
+                #   Queue, SimpleQueue,
+                #   _AssertRaisesContext,
+                #   Array, LibraryLoader,
+                #   SplitResult, ParseResult,
+                #   ValueProxy, ApplyResult,
+                #   WeakSet, ReferenceType, ref,
+                #   ShareableList, SimpleQueue,
+                #   Future, _WorkItem,
+                #   Morsel,
+                  ):
+            if t is None:
+                continue
+            tname = t.__name__
+            # with self.subTest(f"Testing {tname}"):
+            alias = t[int]
+            self.assertIs(alias.__origin__, t)
+            self.assertEqual(alias.__args__, (int,))
+            self.assertEqual(alias.__parameters__, ())
+
+    def test_unsubscriptable(self):
+        for t in int, str, float: #, Sized, Hashable:
+            tname = t.__name__
+            # with self.subTest(f"Testing {tname}"):
+            with self.assertRaises(TypeError):
+                t[int]
+
+    def test_instantiate(self):
+        for t in tuple, list, dict, set, frozenset, defaultdict, deque:
+            tname = t.__name__
+            # with self.subTest(f"Testing {tname}"):
+            alias = t[int]
+            self.assertEqual(alias(), t())
+            if t is dict:
+                self.assertEqual(alias(iter([('a', 1), ('b', 2)])), dict(a=1, b=2))
+                self.assertEqual(alias(a=1, b=2), dict(a=1, b=2))
+            elif t is defaultdict:
+                def default():
+                    return 'value'
+                a = alias(default)
+                d = defaultdict(default)
+                self.assertEqual(a['test'], d['test'])
+            else:
+                self.assertEqual(alias(iter((1, 2, 3))), t((1, 2, 3)))
+
+    def test_unbound_methods(self):
+        t = list[int]
+        a = t()
+        t.append(a, 'foo')
+        self.assertEqual(a, ['foo'])
+        x = t.__getitem__(a, 0)
+        self.assertEqual(x, 'foo')
+        self.assertEqual(t.__len__(a), 1)
+
+    # def test_subclassing(self):
+    #     class C(list[int]):
+    #         pass
+    #     self.assertEqual(C.__bases__, (list,))
+    #     self.assertEqual(C.__class__, type)
+
+    def test_class_methods(self):
+        t = dict[int, None]
+        self.assertEqual(dict.fromkeys(range(2)), {0: None, 1: None})  # This works
+        self.assertEqual(t.fromkeys(range(2)), {0: None, 1: None})  # Should be equivalent
+
+    def test_no_chaining(self):
+        t = list[int]
+        with self.assertRaises(TypeError):
+            t[int]
+
+    def test_generic_subclass(self):
+        class MyList(list):
+            pass
+        t = MyList[int]
+        self.assertIs(t.__origin__, MyList)
+        self.assertEqual(t.__args__, (int,))
+        self.assertEqual(t.__parameters__, ())
+
+    def test_repr(self):
+        class MyList(list):
+            pass
+        self.assertEqual(repr(list[str]), 'list[str]')
+        self.assertEqual(repr(list[()]), 'list[()]')
+        self.assertEqual(repr(tuple[int, ...]), 'tuple[int, ...]')
+        #@TODO qualname
+        # self.assertTrue(repr(MyList[int]).endswith('.BaseTest.test_repr.<locals>.MyList[int]'))
+        self.assertTrue(repr(MyList[int]).endswith('MyList[int]'))
+        self.assertEqual(repr(list[str]()), '[]')  # instances should keep their normal repr
+
+    def test_exposed_type(self):
+        import types
+        a = types.GenericAlias(list, int)
+        self.assertEqual(str(a), 'list[int]')
+        self.assertIs(a.__origin__, list)
+        self.assertEqual(a.__args__, (int,))
+        self.assertEqual(a.__parameters__, ())
+
+    # def test_parameters(self):
+    #     from typing import TypeVar
+    #     T = TypeVar('T')
+    #     K = TypeVar('K')
+    #     V = TypeVar('V')
+    #     D0 = dict[str, int]
+    #     self.assertEqual(D0.__args__, (str, int))
+    #     self.assertEqual(D0.__parameters__, ())
+    #     D1a = dict[str, V]
+    #     self.assertEqual(D1a.__args__, (str, V))
+    #     self.assertEqual(D1a.__parameters__, (V,))
+    #     D1b = dict[K, int]
+    #     self.assertEqual(D1b.__args__, (K, int))
+    #     self.assertEqual(D1b.__parameters__, (K,))
+    #     D2a = dict[K, V]
+    #     self.assertEqual(D2a.__args__, (K, V))
+    #     self.assertEqual(D2a.__parameters__, (K, V))
+    #     D2b = dict[T, T]
+    #     self.assertEqual(D2b.__args__, (T, T))
+    #     self.assertEqual(D2b.__parameters__, (T,))
+    #     L0 = list[str]
+    #     self.assertEqual(L0.__args__, (str,))
+    #     self.assertEqual(L0.__parameters__, ())
+    #     L1 = list[T]
+    #     self.assertEqual(L1.__args__, (T,))
+    #     self.assertEqual(L1.__parameters__, (T,))
+
+    # def test_parameter_chaining(self):
+    #     from typing import TypeVar
+    #     T = TypeVar('T')
+    #     self.assertEqual(list[T][int], list[int])
+    #     self.assertEqual(dict[str, T][int], dict[str, int])
+    #     self.assertEqual(dict[T, int][str], dict[str, int])
+    #     self.assertEqual(dict[T, T][int], dict[int, int])
+    #     with self.assertRaises(TypeError):
+    #         list[int][int]
+    #         dict[T, int][str, int]
+    #         dict[str, T][str, int]
+    #         dict[T, T][str, int]
+
+    def test_equality(self):
+        self.assertEqual(list[int], list[int])
+        self.assertEqual(dict[str, int], dict[str, int])
+        self.assertNotEqual(dict[str, int], dict[str, str])
+        self.assertNotEqual(list, list[int])
+        self.assertNotEqual(list[int], list)
+
+    def test_isinstance(self):
+        self.assertTrue(isinstance([], list))
+        with self.assertRaises(TypeError):
+            isinstance([], list[str])
+
+    def test_issubclass(self):
+        class L(list): ...
+        self.assertTrue(issubclass(L, list))
+        with self.assertRaises(TypeError):
+            issubclass(L, list[str])
+
+    def test_type_generic(self):
+        t = type[int]
+        Test = t('Test', (), {})
+        self.assertTrue(isinstance(Test, type))
+        test = Test()
+        self.assertEqual(t(test), Test)
+        self.assertEqual(t(0), int)
+
+    def test_type_subclass_generic(self):
+        class MyType(type):
+            pass
+        with self.assertRaises(TypeError):
+            MyType[int]
+
+    # def test_pickle(self):
+    #     alias = GenericAlias(list, T)
+    #     s = pickle.dumps(alias)
+    #     loaded = pickle.loads(s)
+    #     self.assertEqual(alias.__origin__, loaded.__origin__)
+    #     self.assertEqual(alias.__args__, loaded.__args__)
+    #     self.assertEqual(alias.__parameters__, loaded.__parameters__)
+
+    # def test_union(self):
+    #     a = typing.Union[list[int], list[str]]
+    #     self.assertEqual(a.__args__, (list[int], list[str]))
+    #     self.assertEqual(a.__parameters__, ())
+
+    # def test_union_generic(self):
+    #     T = typing.TypeVar('T')
+    #     a = typing.Union[list[T], tuple[T, ...]]
+    #     self.assertEqual(a.__args__, (list[T], tuple[T, ...]))
+    #     self.assertEqual(a.__parameters__, (T,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_types.py
+++ b/test/unit3/test_types.py
@@ -623,7 +623,7 @@ class MappingProxyTests(unittest.TestCase):
         self.assertEqual(attrs, {
              '__contains__',
              '__getitem__',
-            #  '__class_getitem__',
+             '__class_getitem__',
              '__ior__',
              '__iter__',
              '__len__',


### PR DESCRIPTION
this pr adds support for `__class_getitem__` (closes #1146 )

it implements partial support for pep 585: https://www.python.org/dev/peps/pep-0585/

```python3
list[int, ...]
dict[str, int]
type[int]

from itertools import chain
chain[list]
```

it provides code for `__mro_entries__` but since this is not checked in skulpt `class A(list[int]): pass` does not work
similarly `__instancecheck__` and `__subclasscheck__` are not yet called.

some of the cpython code accounts for `typing.TypeVar` but since that is not yet a thing much of the implementation doesn't yet make sense in skulpt. 

This won't work on master and builds on top #1092

All the tests in this pr are working on another branch. 
Tests taken from Cpython. 