### PR TITLE
feat(builtin functions): remove raw_input function in python3

### DIFF
--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -137,6 +137,7 @@ Sk.setupObjects = function (py3) {
         Sk.builtins["StandardError"] = Sk.builtin.Exception;
         Sk.builtins["unicode"] = Sk.builtin.str;
         Sk.builtins["basestring"] = Sk.builtin.str;
+        Sk.builtins["raw_input"] = new Sk.builtin.func(Sk.builtin.raw_input);
         Sk.builtin.str.prototype.decode = Sk.builtin.str.$py2decode;
         delete Sk.builtins["bytes"];
         delete Sk.builtins["ascii"];

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -124,6 +124,7 @@ Sk.setupObjects = function (py3) {
         delete Sk.builtins["StandardError"];
         delete Sk.builtins["unicode"];
         delete Sk.builtins["basestring"];
+        delete Sk.builtins["raw_input"];
         delete Sk.builtin.str.prototype.decode;
         Sk.builtins["bytes"] = Sk.builtin.bytes;
         Sk.builtins["ascii"] = new Sk.builtin.func(Sk.builtin.ascii);


### PR DESCRIPTION
If Python3 mode is preferred in Skulpt, then the raw_input function shouldn't be available.

Credits: [comment](https://github.com/skulpt/skulpt/pull/1221#issuecomment-716921934) from @s-cork 