### PR TITLE
fix(math.sqrt): sqrt should raise ValueError when passed a negative number

### DIFF
--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -591,8 +591,11 @@ var $builtinmodule = function (name) {
     mod.sqrt = new Sk.builtin.func(function sqrt(x) {
         Sk.builtin.pyCheckArgsLen("sqrt", arguments.length, 1, 1);
         Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
-
-        return new Sk.builtin.float_(Math.sqrt(Sk.builtin.asnum$(x)));
+        const _x = Sk.builtin.asnum$(x);
+        if (_x < 0) {
+            throw new Sk.builtin.ValueError("math domain error");
+        }
+        return new Sk.builtin.float_(Math.sqrt(_x));
     });
 
     // Trigonometric functions and Hyperbolic

--- a/test/unit3/test_math.py
+++ b/test/unit3/test_math.py
@@ -1389,8 +1389,8 @@ class MathTests(unittest.TestCase):
         self.ftest('sqrt(1)', math.sqrt(1), 1)
         self.ftest('sqrt(4)', math.sqrt(4), 2)
         self.assertEqual(math.sqrt(INF), INF)
-        # self.assertRaises(ValueError, math.sqrt, -1)
-        # self.assertRaises(ValueError, math.sqrt, NINF)
+        self.assertRaises(ValueError, math.sqrt, -1)
+        self.assertRaises(ValueError, math.sqrt, NINF)
         self.assertTrue(math.isnan(math.sqrt(NAN)))
 
     def testTan(self):


### PR DESCRIPTION
With the previous version, the code:
* `print(math.sqrt(-1))` and 
* `print(math.sqrt(float("-inf")))` 

will both print out "nan", while it should raise a `ValueError: math domain error`. 

ref: https://github.com/python/cpython/blob/dd2804790dfa116d20e37bc6b4463c07586da76c/Lib/test/test_math.py#L1154
