### PR TITLE
fix scientific notation string formatting (remade)

### DIFF
--- a/src/formatting.js
+++ b/src/formatting.js
@@ -189,6 +189,9 @@ let formatNumber = function(num, formatSpec, isFractional) {
                     result += ".0";
                 }
             }
+            if (conversionType.toLowerCase()==="e") {
+                result = result.replace(/^([-+]?[0-9]*\.?[0-9]+[eE][-+]?)([0-9])?$/, "$10$2");
+            }
             if (m[FMT.COMMA]){
                 var parts = result.toString().split(".");
                 parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");

--- a/test/unit/test_strformat.py
+++ b/test/unit/test_strformat.py
@@ -77,5 +77,11 @@ class string_format(unittest.TestCase):
         d = datetime.datetime(2010, 7, 4, 12, 15, 58)
         self.assertEqual('2010-07-04 12:15:58', '{:%Y-%m-%d %H:%M:%S}'.format(d))
 
+    def test_scientific_notation(self):
+        self.assertEqual('1.234568e+08', "{:e}".format(123456789))
+        self.assertEqual('1.234568E+08', "{:E}".format(123456789))
+        self.assertEqual('1.234568e+16', "{:e}".format(12345678987654321))
+        self.assertEqual('1e+08', "{:.0e}".format(123456789))
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_strformat.py
+++ b/test/unit3/test_strformat.py
@@ -108,5 +108,11 @@ class string_format(unittest.TestCase):
         self.assertEqual('hello world!', f'hello {x:world}!')
         self.assertEqual('hello world!!', f'{x:hello {x:world}!}!')
 
+    def test_scientific_notation(self):
+        self.assertEqual('1.234568e+08', "{:e}".format(123456789))
+        self.assertEqual('1.234568E+08', "{:E}".format(123456789))
+        self.assertEqual('1.234568e+16', "{:e}".format(12345678987654321))
+        self.assertEqual('1e+08', "{:.0e}".format(123456789))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The code is taken from pull request: https://github.com/skulpt/skulpt/pull/1016
The author of that 1016 pull request seems hasn't responded on that thread for several months, and it could be an easy merge, so I am just remaking the pull request based on the discussion in that thread.

**All credits** should go to @darkaardvark2  and @meredydd 
(If this pull request violated some credits rule, please feel free to close/delete it)