### PR TITLE
Fix xyz typo in processing.js

### DIFF
--- a/src/lib/processing.js
+++ b/src/lib/processing.js
@@ -1815,7 +1815,7 @@ var $builtinmodule = function (name) {
 	    return new_vec;
 	});
 	
-	$loc.set = new Sk.builtin.func(function (self, x, y, x) {
+	$loc.set = new Sk.builtin.func(function (self, x, y, z) {
 	    // set() Sets the x, y, z component of the vector
 	    if (typeof(z) === "undefined") {
 		self.v.set(x.v, y.v);


### PR DESCRIPTION
The parameters were named x, y, and x, but it looks like they wanted to be x, y, and z.

This probably causes very unexpected behavior for anyone trying to set 3D coordinates in processing.js

First-time contributor, so I'm still getting up-to-speed on reading the docs on contributing, so please feel free to let me know if there's anything else you'd like me to do before submitting this.