### PR TITLE
Refactor time module and fix its tests

### DIFF
--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -164,6 +164,16 @@ var $builtinmodule = function (name) {
         );
     }
 
+    function from_seconds(secs, asUtc) {
+        var d = new Date();
+        if (secs) {
+            Sk.builtin.pyCheckType("secs", "number", Sk.builtin.checkNumber(secs));
+            var seconds = Sk.builtin.asnum$(secs);
+            d.setTime(seconds * 1000);
+        }
+        return date_to_struct_time(d, asUtc);
+    }
+
     function localtime_f(secs) {
         Sk.builtin.pyCheckArgsLen("localtime", arguments.length, 0, 1);
         var d = new Date();

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -190,7 +190,7 @@ var $builtinmodule = function (name) {
     function asctime_f(time) {
         if (!time || Sk.builtin.checkNone(time))
         {
-            time = localtime_f();
+            time = from_seconds();
         } else if (!(time instanceof struct_time_f)) {
             time = new struct_time_f(time);
         }
@@ -215,7 +215,7 @@ var $builtinmodule = function (name) {
     mod.asctime = new Sk.builtin.func(asctime_f);
 
     mod.ctime = new Sk.builtin.func(function(secs) {
-        return asctime_f(localtime_f(secs));
+        return asctime_f(from_seconds(secs));
     });
 
     function mktime_f(time) {

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -174,28 +174,14 @@ var $builtinmodule = function (name) {
         return date_to_struct_time(d, asUtc);
     }
 
-    function localtime_f(secs) {
+    mod.localtime = new Sk.builtin.func(function(secs) {
         Sk.builtin.pyCheckArgsLen("localtime", arguments.length, 0, 1);
-        var d = new Date();
-        if (secs) {
-            Sk.builtin.pyCheckType("secs", "number", Sk.builtin.checkNumber(secs));
-            var seconds = Sk.builtin.asnum$(secs);
-            d.setTime(seconds * 1000);
-        }
-        return date_to_struct_time(d);
-    }
-
-    mod.localtime = new Sk.builtin.func(localtime_f);
+        return from_seconds(secs, false);
+    });
 
     mod.gmtime = new Sk.builtin.func(function(secs) {
-        Sk.builtin.pyCheckArgsLen("localtime", arguments.length, 0, 1);
-        var d = new Date();
-        if (secs) {
-            Sk.builtin.pyCheckType("secs", "number", Sk.builtin.checkNumber(secs));
-            var seconds = Sk.builtin.asnum$(secs);
-            d.setTime(seconds * 1000);
-        }
-        return date_to_struct_time(d, true);
+        Sk.builtin.pyCheckArgsLen("gmtime", arguments.length, 0, 1);
+        return from_seconds(secs, true);
     });
 
     var monthnames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -188,6 +188,8 @@ var $builtinmodule = function (name) {
     var daynames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
     function asctime_f(time) {
+        Sk.builtin.pyCheckArgsLen("asctime", arguments.length, 0, 1);
+
         if (!time || Sk.builtin.checkNone(time))
         {
             time = from_seconds();
@@ -215,10 +217,13 @@ var $builtinmodule = function (name) {
     mod.asctime = new Sk.builtin.func(asctime_f);
 
     mod.ctime = new Sk.builtin.func(function(secs) {
+        Sk.builtin.pyCheckArgsLen("ctime", arguments.length, 0, 1);
         return asctime_f(from_seconds(secs));
     });
 
     function mktime_f(time) {
+        Sk.builtin.pyCheckArgsLen("mktime", arguments.length, 1, 1);
+
         if (time instanceof Sk.builtin.tuple && time.v.length == 9)
         {
             var d = new Date(Sk.builtin.asnum$(time.v[0]),

--- a/test/unit3/test_time.py
+++ b/test/unit3/test_time.py
@@ -99,7 +99,25 @@ class TimeTestCase(unittest.TestCase):
         self.assertEqual([x*2 for x in gen.sleeping_generator()], [0, 2, 4, 6, 8, 10, 12, 14, 16, 18])
 
     def test_strftime(self):
-        self.assertEqual(time.strftime("%b %d %Y %H:%M:%S", time.localtime(3661 + time.timezone)), "Jan 01 1970 01:01:01");
+        # Skulpt computes the timezone offset in 2002, so use a date
+        # in that year.  The following number was computed by running
+        #
+        #     import datetime
+        #     print((datetime.date(2002, 2, 3) - datetime.date(1970, 1, 1)).days)
+        #
+        # in CPython.
+        #
+        days_to_20020203 = 11721
+        seconds_within_day = 3661  # One hour + one minute + one second
+        timestamp_to_test = (
+            days_to_20020203 * 24 * 60 * 60  # Unix timestamps ignore leap seconds
+            + seconds_within_day
+            + time.timezone
+        )
+        self.assertEqual(
+            time.strftime("%b %d %Y %H:%M:%S", time.localtime(timestamp_to_test)),
+            "Feb 03 2002 01:01:01"
+        );
 
     def _test_dir(self):
         # this test fails because the compare 

--- a/test/unit3/test_time.py
+++ b/test/unit3/test_time.py
@@ -160,6 +160,57 @@ class BadTimeFunctionArgsLength(unittest.TestCase):
                 self.fail(f"exception matching '{regex}' not raised:"
                           f" '{exception_msg}'")
 
+    def test_asctime(self):
+        # asctime([t])
+        self.assertFailsArgsLengthCheck(
+            "at most 1 argument",
+            time.asctime, self.t_struct, "arg 2")
+
+    def test_ctime(self):
+        # ctime([secs])
+        self.assertFailsArgsLengthCheck(
+            "at most 1 argument",
+            time.ctime, self.t, "arg 2")
+
+    def test_gmtime(self):
+        # gmtime([secs])
+        self.assertFailsArgsLengthCheck(
+            "at most 1 argument",
+            time.gmtime, self.t, "arg 2")
+
+    def test_localtime(self):
+        # localtime([secs])
+        self.assertFailsArgsLengthCheck(
+            "at most 1 argument",
+            time.localtime, self.t, "arg 2")
+
+    def test_mktime(self):
+        # mktime(t)
+        self.assertFailsArgsLengthCheck(
+            "exactly 1 argument",
+            time.mktime)  # no args
+        self.assertFailsArgsLengthCheck(
+            "exactly 1 argument",
+            time.mktime, self.t_struct, "arg 2")
+
+    def test_strftime(self):
+        # strftime(format[, t])
+        self.assertFailsArgsLengthCheck(
+            "at least 1 argument",
+            time.strftime)  # no args
+        self.assertFailsArgsLengthCheck(
+            "at most 2 arguments",
+            time.strftime, "%Y%m%d", self.t_struct, "arg 3")
+
+    def test_strptime(self):
+        # strptime(string[, format])
+        self.assertFailsArgsLengthCheck(
+            "at least 1 argument",
+            time.strptime)  # no args
+        self.assertFailsArgsLengthCheck(
+            "at most 2 arguments",
+            time.strptime, "2020-11-26", "%Y-%m-%d", "arg 3")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_time.py
+++ b/test/unit3/test_time.py
@@ -1,6 +1,7 @@
 __author__ = 'Jacco Kulman'
 
 import unittest
+import re
 import time
 
 class TimeTestCase(unittest.TestCase):
@@ -142,6 +143,23 @@ class TimeTestCase(unittest.TestCase):
             'timezone', 
             'tzname', 
             'tzset']);
+
+
+class BadTimeFunctionArgsLength(unittest.TestCase):
+    def setUp(self):
+        self.t = 1606419201
+        self.t_struct = time.gmtime(self.t)
+
+    def assertFailsArgsLengthCheck(self, regex, fun, *args):
+        # TODO: assertRaisesRegex() would be useful here.
+        with self.assertRaises(TypeError) as raise_context:
+            fun(*args)
+        if raise_context.exception is not None:
+            exception_msg = str(raise_context.exception)
+            if not re.search(regex, exception_msg):
+                self.fail(f"exception matching '{regex}' not raised:"
+                          f" '{exception_msg}'")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Follow-up to the aside in #1231 regarding the failed `TimeTestCase.test_strftime` test.

If I'm reading it right, Skulpt's implementation of `time.timezone` uses the offset as of 2002.  I'm in Ireland and [the history of its civil timekeeping](https://en.wikipedia.org/wiki/Time_in_the_Republic_of_Ireland#History) means that its timezone offset was different in 1970 compared to 2002.  It's likely that developers in other timezones weren't seeing this failure.  This PR updates the test to use a moment in 2002, for consistency with how `timezone` is computed.  I've checked it under timezones `Europe/Dublin`, `America/Denver`, `Europe/Istanbul`.

This PR also extracts a function from near-duplicated code between Skulpt's `localtime()` and `gmtime()` implementations, and fixes a minor typo.