### PR TITLE
Add ability to delete attributes

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -879,7 +879,8 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
                     this._checkSuspension(e);
                     break;
                 case Sk.astnodes.Del:
-                    Sk.asserts.fail("todo Del;");
+                    out("$ret = Sk.abstr.sattr(", val, ",", mname, ", null, true);");
+                    this._checkSuspension(e);
                     break;
                 case Sk.astnodes.Param:
                 default:

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,7 @@ Sk.builtin.str.$cmp = new Sk.builtin.str("__cmp__");
 Sk.builtin.str.$complex = new Sk.builtin.str("__complex__");
 Sk.builtin.str.$contains = new Sk.builtin.str("__contains__");
 Sk.builtin.str.$copy = new Sk.builtin.str("__copy__");
+Sk.builtin.str.$delattr = new Sk.builtin.str("__delattr__");
 Sk.builtin.str.$dict = new Sk.builtin.str("__dict__");
 Sk.builtin.str.$dir = new Sk.builtin.str("__dir__");
 Sk.builtin.str.$enter = new Sk.builtin.str("__enter__");

--- a/src/object.js
+++ b/src/object.js
@@ -218,6 +218,30 @@ Sk.builtin.object.prototype.GenericSetAttr = function (pyName, value, canSuspend
             const mangled = pyName.$mangled;
             dict[mangled] = value;
         }
+    } else {
+        // value === null: delete attribute
+
+        if (dict.mp$del_subscript) {
+            if (this instanceof Sk.builtin.object && !(this.ob$type.sk$klass)) {
+                // Cannot delete attributes from a builtin object
+                throw new Sk.builtin.AttributeError("cannot delete attributes of builtin type '" + objname + "'");
+            }
+            try {
+                dict.mp$del_subscript(pyName);
+            } catch (e) {
+                if (e instanceof Sk.builtin.KeyError) {
+                    throw new Sk.builtin.AttributeError(pyName);
+                } else {
+                    throw e;
+                }
+            }
+        } else if (typeof dict === "object") {
+            const mangled = pyName.$mangled;
+            if (!dict.hasOwnProperty(mangled)) {
+                throw new Sk.builtin.AttributeError(pyName);
+            }
+            delete dict[mangled];
+        }
     }
 };
 Sk.exportSymbol("Sk.builtin.object.prototype.GenericSetAttr", Sk.builtin.object.prototype.GenericSetAttr);

--- a/src/object.js
+++ b/src/object.js
@@ -203,6 +203,12 @@ Sk.builtin.object.prototype.GenericSetAttr = function (pyName, value, canSuspend
             if (f) {
                 return f.call(descr, this, value, canSuspend);
             }
+        } else {
+            // value === null: delete attribute
+            f = descr.tp$descr_del;
+            if (f) {
+                return f.call(descr, this, canSuspend);
+            }
         }
     }
 

--- a/src/object.js
+++ b/src/object.js
@@ -185,6 +185,10 @@ Sk.builtin.object.prototype.GenericSetAttr = function (pyName, value, canSuspend
     dict = this["$d"] || this.constructor["$d"];
 
     if (jsName == "__class__") {
+        if (value === null) {
+            throw new Sk.builtin.TypeError(
+                "attempted to delete __class__ attribute");
+        }
         if (value.tp$mro === undefined || value.sk$klass === undefined) {
             throw new Sk.builtin.TypeError(
                 "attempted to assign non-class to __class__");

--- a/src/object.js
+++ b/src/object.js
@@ -197,10 +197,12 @@ Sk.builtin.object.prototype.GenericSetAttr = function (pyName, value, canSuspend
 
     // otherwise, look in the type for a descr
     if (descr !== undefined && descr !== null) {
-        f = descr.tp$descr_set;
-        // todo; is this the right lookup priority for data descriptors?
-        if (f) {
-            return f.call(descr, this, value, canSuspend);
+        if (value !== null) {
+            f = descr.tp$descr_set;
+            // todo; is this the right lookup priority for data descriptors?
+            if (f) {
+                return f.call(descr, this, value, canSuspend);
+            }
         }
     }
 

--- a/src/object.js
+++ b/src/object.js
@@ -204,16 +204,18 @@ Sk.builtin.object.prototype.GenericSetAttr = function (pyName, value, canSuspend
         }
     }
 
-    if (dict.mp$ass_subscript) {
-        if (this instanceof Sk.builtin.object && !(this.ob$type.sk$klass) &&
-            dict.mp$lookup(pyName) === undefined) {
-            // Cannot add new attributes to a builtin object
-            throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + pyName.$jsstr() + "'");
+    if (value !== null) {
+        if (dict.mp$ass_subscript) {
+            if (this instanceof Sk.builtin.object && !(this.ob$type.sk$klass) &&
+                dict.mp$lookup(pyName) === undefined) {
+                // Cannot add new attributes to a builtin object
+                throw new Sk.builtin.AttributeError("'" + objname + "' object has no attribute '" + pyName.$jsstr() + "'");
+            }
+            dict.mp$ass_subscript(pyName, value);
+        } else if (typeof dict === "object") {
+            const mangled = pyName.$mangled;
+            dict[mangled] = value;
         }
-        dict.mp$ass_subscript(pyName, value);
-    } else if (typeof dict === "object") {
-        const mangled = pyName.$mangled;
-        dict[mangled] = value;
     }
 };
 Sk.exportSymbol("Sk.builtin.object.prototype.GenericSetAttr", Sk.builtin.object.prototype.GenericSetAttr);

--- a/src/type.js
+++ b/src/type.js
@@ -281,6 +281,14 @@ Sk.builtin.type = function (name, bases, dict) {
                     r = Sk.misceval.callsimOrSuspendArray(f, [pyName, data]);
                     return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
                 }
+            } else {
+                // data === null: delete attribute
+                var r, delf = Sk.builtin.object.prototype.GenericGetAttr.call(this, Sk.builtin.str.$delattr);
+                if (delf !== undefined) {
+                    var f = /** @type {?} */ (delf);
+                    r = Sk.misceval.callsimOrSuspendArray(f, [pyName]);
+                    return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
+                }
             }
 
             return Sk.builtin.object.prototype.GenericSetAttr.call(this, pyName, data, canSuspend);

--- a/src/type.js
+++ b/src/type.js
@@ -721,3 +721,8 @@ Sk.builtin.type.$allocateSlot = function (klass, dunder) {
         };
     }
 };
+
+Sk.builtin.type.$deallocateSlot = function (klass, dunder) {
+    let skulpt_name = Sk.dunderToSkulpt[dunder];
+    delete klass.prototype[skulpt_name];
+};

--- a/src/type.js
+++ b/src/type.js
@@ -514,6 +514,17 @@ Sk.builtin.type.prototype.tp$setattr = function (pyName, value) {
         if (jsName in Sk.dunderToSkulpt) {
             Sk.builtin.type.$allocateSlot(this, jsName);
         }
+    } else {
+        // value === null: delete attribute
+        if (!this.hasOwnProperty(jsName)) {
+            throw new Sk.builtin.AttributeError(pyName);
+        }
+
+        delete this[jsName];
+        delete this.prototype[jsName];
+        if (jsName in Sk.dunderToSkulpt) {
+            Sk.builtin.type.$deallocateSlot(this, jsName);
+        }
     }
 };
 

--- a/src/type.js
+++ b/src/type.js
@@ -498,10 +498,13 @@ Sk.builtin.type.prototype.tp$setattr = function (pyName, value) {
         throw new Sk.builtin.TypeError("can't set attributes of built-in/extension type '" + this.prototype.tp$name + "'");
     }
     var jsName = Sk.fixReserved(pyName.$jsstr());
-    this[jsName] = value;
-    this.prototype[jsName] = value;
-    if (jsName in Sk.dunderToSkulpt) {
-        Sk.builtin.type.$allocateSlot(this, jsName);
+
+    if (value !== null) {
+        this[jsName] = value;
+        this.prototype[jsName] = value;
+        if (jsName in Sk.dunderToSkulpt) {
+            Sk.builtin.type.$allocateSlot(this, jsName);
+        }
     }
 };
 

--- a/src/type.js
+++ b/src/type.js
@@ -58,7 +58,8 @@ Sk.dunderToSkulpt = {
     "__nonzero__": ["nb$nonzero", 1],
     "__len__": ["sq$length", 1],
     "__get__": ["tp$descr_get", 3],
-    "__set__": ["tp$descr_set", 3]
+    "__set__": ["tp$descr_set", 3],
+    "__delete__": ["tp$descr_del", 2]
 };
 
 Sk.setupDunderMethods = function (py3) {

--- a/src/type.js
+++ b/src/type.js
@@ -273,11 +273,13 @@ Sk.builtin.type = function (name, bases, dict) {
         };
 
         klass.prototype.tp$setattr = function(pyName, data, canSuspend) {
-            var r, setf = Sk.builtin.object.prototype.GenericGetAttr.call(this, Sk.builtin.str.$setattr);
-            if (setf !== undefined) {
-                var f = /** @type {?} */ (setf);
-                r = Sk.misceval.callsimOrSuspendArray(f, [pyName, data]);
-                return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
+            if (data !== null) {
+                var r, setf = Sk.builtin.object.prototype.GenericGetAttr.call(this, Sk.builtin.str.$setattr);
+                if (setf !== undefined) {
+                    var f = /** @type {?} */ (setf);
+                    r = Sk.misceval.callsimOrSuspendArray(f, [pyName, data]);
+                    return canSuspend ? r : Sk.misceval.retryOptionalSuspensionOrThrow(r);
+                }
             }
 
             return Sk.builtin.object.prototype.GenericSetAttr.call(this, pyName, data, canSuspend);

--- a/test/unit3/test_del_attr.py
+++ b/test/unit3/test_del_attr.py
@@ -1,0 +1,142 @@
+import unittest
+
+
+class CustomDelAttr:
+    def __init__(self):
+        self.a = 42
+        self.attr_deleted = "nothing-yet"
+
+    def __delattr__(self, attr_name):
+        self.attr_deleted = attr_name
+
+
+def cls_DerivedCustomDelAttr():
+    class DerivedCustomDelAttr(CustomDelAttr):
+        def __init__(self):
+            CustomDelAttr.__init__(self)
+            self.a = 99
+            self.derived_attr_deleted = "nothing-yet"
+
+        def __delattr__(self, attr_name):
+            self.derived_attr_deleted = attr_name
+
+    return DerivedCustomDelAttr
+
+
+class CustomDeleteDescriptor:
+    def __get__(self, obj, objtype=None):
+        return 10
+
+    def __set__(self, obj, value):
+        pass
+
+    def __delete__(self, obj):
+        obj.custom_delete_called = True
+
+
+class RaisingCustomDeleteDescriptor:
+    def __get__(self, obj, objtype=None):
+        return 10
+
+    def __set__(self, obj, value):
+        pass
+
+    def __delete__(self, obj):
+        obj.cause_an_error = 1 / 0
+
+
+class WithCustomDeleteDescriptor:
+    a = CustomDeleteDescriptor()
+
+    def __init__(self):
+        self.custom_delete_called = False
+
+
+class WithRaisingCustomDeleteDescriptor:
+    a = RaisingCustomDeleteDescriptor()
+
+
+class DelAttrTests(unittest.TestCase):
+    def cls_DelInstanceOrClassAttr(self):
+        class DelInstanceOrClassAttr:
+            a = 42
+        return DelInstanceOrClassAttr
+
+    def test_del_instance_attr(self):
+        DelInstanceOrClassAttr = self.cls_DelInstanceOrClassAttr()
+        x = DelInstanceOrClassAttr()
+        x.b = 99
+        self.assertEqual(x.b, 99)
+        del x.b
+        self.assertRaises(AttributeError, lambda: x.b)
+
+    def test_override_then_del_instance_attr(self):
+        DelInstanceOrClassAttr = self.cls_DelInstanceOrClassAttr()
+        x = DelInstanceOrClassAttr()
+        x.a = 99
+        self.assertEqual(x.a, 99)
+        del x.a
+        self.assertEqual(x.a, 42)
+
+    def test_del_class_attr(self):
+        cls = self.cls_DelInstanceOrClassAttr()
+        del cls.a
+        self.assertRaises(AttributeError, lambda: cls.a)
+
+    def test_custom_delattr(self):
+        x = CustomDelAttr()
+        self.assertEqual(x.a, 42)
+        del x.a
+        self.assertEqual(x.a, 42)
+        self.assertEqual(x.attr_deleted, "a")
+
+    def test_delete_custom_delattr_method(self):
+        cls = cls_DerivedCustomDelAttr()
+        x = cls()
+        self.assertEqual(x.derived_attr_deleted, "nothing-yet")
+        self.assertEqual(x.attr_deleted, "nothing-yet")
+        del x.a
+        self.assertEqual(x.derived_attr_deleted, "a")
+        self.assertEqual(x.attr_deleted, "nothing-yet")
+        del cls.__delattr__
+        del x.a
+        self.assertEqual(x.derived_attr_deleted, "a")
+        self.assertEqual(x.attr_deleted, "a")
+
+    def test_del_nonexistent_class_attr(self):
+        cls = self.cls_DelInstanceOrClassAttr()
+        def bad_delete():
+            del cls.no_such_attr
+        self.assertRaises(AttributeError, bad_delete)
+
+    def test_del_nonexistent_instance_attr(self):
+        cls = self.cls_DelInstanceOrClassAttr()
+        x = cls()
+        def bad_delete():
+            del x.no_such_attr
+        self.assertRaises(AttributeError, bad_delete)
+
+    def test_custom_delete_descriptor(self):
+        x = WithCustomDeleteDescriptor()
+        self.assertEqual(x.a, 10)
+        self.assertFalse(x.custom_delete_called)
+        del x.a
+        self.assertEqual(x.a, 10)
+        self.assertTrue(x.custom_delete_called)
+
+    def test_raising_custom_delete_descriptor(self):
+        x = WithRaisingCustomDeleteDescriptor()
+        def bad_delete():
+            del x.a
+        self.assertRaises(ZeroDivisionError, bad_delete)
+
+    def test_delete_class_dunder(self):
+        DelInstanceOrClassAttr = self.cls_DelInstanceOrClassAttr()
+        x = DelInstanceOrClassAttr()
+        def bad_delete():
+            del x.__class__
+        self.assertRaises(TypeError, bad_delete)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add support for
```python
del foo.bar
```
which deletes the attribute named `bar` from the object `foo`.

CPython handles attributes deletion by passing `NULL` to the set-attribute machinery.  I've largely taken the same approach here.  This PR's implementation of some details doesn't completely follow the current CPython one, but I think the end result is workable.  I'm not 100% familiar with the existing code in this area, so please let me know if I've overlooked anything.  Thanks.