### PR TITLE
Bugfix: Overlooked localtime f usage

### DIFF
--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -285,7 +285,7 @@ var $builtinmodule = function (name) {
         }
         if (!t)
         {
-            t = localtime_f();
+            t = from_seconds();
         } else if (!(t instanceof struct_time_f)) {
             t = new struct_time_f(t);
         }

--- a/test/unit3/test_time.py
+++ b/test/unit3/test_time.py
@@ -120,6 +120,10 @@ class TimeTestCase(unittest.TestCase):
             "Feb 03 2002 01:01:01"
         );
 
+    def test_strftime_format_arg_only(self):
+        year_str = time.strftime("%Y")
+        self.assertEqual(year_str[:2], "20")
+
     def _test_dir(self):
         # this test fails because the compare 
         self.assertEqual(dir(time), [


### PR DESCRIPTION
As @s-cork notes in #1233, I overlooked a usage of `localtime_f()` in that refactoring, sorry.  Add a test for the situation where this comes up, and fix the failure by using the new `from_seconds()` instead.