### PR TITLE
Add partial docstring support

### DIFF
--- a/src/classmethod.py
+++ b/src/classmethod.py
@@ -9,4 +9,5 @@ class classmethod(object):
             klass = type(obj)
         def newfunc(*args, **kwargs):
             return self.f(klass, *args, **kwargs)
+        newfunc.__doc__ = self.f.__doc__
         return newfunc

--- a/src/compile.js
+++ b/src/compile.js
@@ -2163,6 +2163,29 @@ Compiler.prototype.maybeCDocstringOfBody = function(body) {
     return this.vexpr(expr);
 };
 
+/** JavaScript for the docstring of the given node.  Only called from
+ * buildcodeobj(), and expects a FunctionDef, Lambda, or GeneratorExp
+ * node.  We give a "None" docstring to a GeneratorExp node, although
+ * it is not carried over to the final generator; this is harmless.
+ */
+Compiler.prototype.cDocstringOfCode = function(node) {
+    switch (node.constructor) {
+    case Sk.astnodes.AsyncFunctionDef:  // For when it's supported
+    case Sk.astnodes.FunctionDef:
+        return (
+            this.maybeCDocstringOfBody(node.body)
+            || "Sk.builtin.none.none$"
+        );
+
+    case Sk.astnodes.Lambda:
+    case Sk.astnodes.GeneratorExp:
+        return "Sk.builtin.none.none$";
+
+    default:
+        Sk.asserts.fail(`unexpected node kind ${node.constructor.name}`);
+    }
+}
+
 Compiler.prototype.cfunction = function (s, class_for_super) {
     var funcorgen;
     Sk.asserts.assert(s instanceof Sk.astnodes.FunctionDef);

--- a/src/compile.js
+++ b/src/compile.js
@@ -2138,7 +2138,6 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         }
     }
     else {
-        var res;
         if (decos.length > 0) {
             out("$ret = new Sk.builtins['function'](", scopename, ",$gbl", frees, ");");
             for (let decorator of decos.reverse()) {

--- a/src/compile.js
+++ b/src/compile.js
@@ -2080,6 +2080,13 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     }
 
     //
+    // Skulpt doesn't have "co_consts", but we keep the docstring (or None)
+    // with the code object for possible future use with a descriptor.  This
+    // happens for named functions, lambdas, and generator-expressions.
+    //
+    out(scopename, ".co_docstring=", this.cDocstringOfCode(n), ";");
+
+    //
     // attach flags
     //
     if (kwarg) {

--- a/src/compile.js
+++ b/src/compile.js
@@ -2145,6 +2145,24 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     }
 };
 
+/** JavaScript for the docstring of the given body, or null if the
+ * body has no docstring.
+ */
+Compiler.prototype.maybeCDocstringOfBody = function(body) {
+    if (body.length === 0)  // Don't think this can happen?
+        return null;
+
+    const stmt_0 = body[0];
+    if (stmt_0.constructor !== Sk.astnodes.Expr)
+        return null;
+
+    const expr = stmt_0.value;
+    if (expr.constructor !== Sk.astnodes.Str)
+        return null;
+
+    return this.vexpr(expr);
+};
+
 Compiler.prototype.cfunction = function (s, class_for_super) {
     var funcorgen;
     Sk.asserts.assert(s instanceof Sk.astnodes.FunctionDef);

--- a/src/compile.js
+++ b/src/compile.js
@@ -2730,8 +2730,19 @@ Compiler.prototype.exitScope = function () {
  * @param {Sk.builtin.str=} class_for_super
  */
 Compiler.prototype.cbody = function (stmts, class_for_super) {
-    var i;
-    for (i = 0; i < stmts.length; ++i) {
+    var i = 0;
+
+    // If we have a docstring, then assign it to __doc__, and skip over
+    // the expression when properly compiling the rest of the body.  This
+    // happens for class and module bodies.
+    //
+    const maybeDocstring = this.maybeCDocstringOfBody(stmts);
+    if (maybeDocstring !== null) {
+        out("$loc.__doc__ = ", maybeDocstring, ";");
+        i = 1;
+    }
+
+    for (; i < stmts.length; ++i) {
         this.vstmt(stmts[i], class_for_super);
     }
 };

--- a/src/compile.js
+++ b/src/compile.js
@@ -2080,8 +2080,9 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     }
 
     //
-    // Skulpt doesn't have "co_consts", but we keep the docstring (or None)
-    // with the code object for possible future use with a descriptor.  This
+    // Skulpt doesn't have "co_consts", so we keep the docstring (or None)
+    // with the code object explicitly.  It is used by the builtin.func
+    // constructor, and might be used in the future by a descriptor.  This
     // happens for named functions, lambdas, and generator-expressions.
     //
     out(scopename, ".co_docstring=", this.cDocstringOfCode(n), ";");

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,6 +37,7 @@ Sk.builtin.str.$contains = new Sk.builtin.str("__contains__");
 Sk.builtin.str.$copy = new Sk.builtin.str("__copy__");
 Sk.builtin.str.$dict = new Sk.builtin.str("__dict__");
 Sk.builtin.str.$dir = new Sk.builtin.str("__dir__");
+Sk.builtin.str.$doc = new Sk.builtin.str("__doc__");
 Sk.builtin.str.$enter = new Sk.builtin.str("__enter__");
 Sk.builtin.str.$eq = new Sk.builtin.str("__eq__");
 Sk.builtin.str.$exit = new Sk.builtin.str("__exit__");

--- a/src/function.js
+++ b/src/function.js
@@ -254,6 +254,7 @@ Sk.builtin.func = function (code, globals, closure, closure2) {
 
     this["$d"] = {
         "__name__": code["co_name"],
+        "__doc__": code["co_docstring"] || Sk.builtin.none.none$,
         "__class__": Sk.builtin.func
     };
     this.func_closure = closure;

--- a/src/method.js
+++ b/src/method.js
@@ -24,7 +24,9 @@ Sk.builtin.method = function (func, self, klass, builtin) {
     this.im_self = self || Sk.builtin.none.none$;
     this.im_class = klass || Sk.builtin.none.none$;
     this.im_builtin = builtin;
+
     this["$d"] = {
+        __doc__: func.$d["__doc__"],
         im_func: func,
         im_self: self,
         im_class: klass

--- a/src/type.js
+++ b/src/type.js
@@ -240,6 +240,11 @@ Sk.builtin.type = function (name, bases, dict) {
             dict.mp$ass_subscript(Sk.builtin.str.$module, Sk.globals["__name__"]);
         }
 
+        // set __doc__ if not present
+        if(dict.mp$lookup(Sk.builtin.str.$doc) === undefined) {
+            dict.mp$ass_subscript(Sk.builtin.str.$doc, Sk.builtin.none.none$);
+        }
+
         // copy properties into our klass object
         // uses python iter methods
         var k;

--- a/test/run/t407.py.real
+++ b/test/run/t407.py.real
@@ -1,3 +1,3 @@
-['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
-['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
+['__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']

--- a/test/run/t407.py.real.force
+++ b/test/run/t407.py.real.force
@@ -1,3 +1,3 @@
-['__eq__', '__format__', '__ge__', '__get__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
-['__eq__', '__format__', '__ge__', '__get__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
+['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']

--- a/test/run/t407.py.real.force
+++ b/test/run/t407.py.real.force
@@ -1,3 +1,3 @@
-['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
-['__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
+['__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c']
+['__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__repr__', '__setattr__', '__str__', 'a', 'b', 'c', 'd']
 ['a', 'b', 'c', 'd']

--- a/test/unit3/copydocstring.py
+++ b/test/unit3/copydocstring.py
@@ -1,0 +1,2 @@
+"Copy docstring"
+doc = __doc__

--- a/test/unit3/test_docstring.py
+++ b/test/unit3/test_docstring.py
@@ -45,6 +45,11 @@ class Strawberry:
         return None
 
 
+class Tangerine:
+    def peel():
+        pass
+
+
 class TestDocstrings(unittest.TestCase):
     def test_function(self):
         self.assertEqual(banana.__doc__, "Yellow")
@@ -63,6 +68,11 @@ class TestDocstrings(unittest.TestCase):
     def test_class(self):
         self.assertEqual(Strawberry.__doc__, "Delicious")
         self.assertEqual(Strawberry.doc, "Delicious")
+
+    def test_class_no_docstring(self):
+        self.assertEqual(Tangerine.__doc__, None)
+        self.assertEqual(Tangerine.peel.__doc__, None)
+        self.assertEqual(Tangerine().peel.__doc__, None)
 
     def test_method(self):
         self.assertEqual(Strawberry.weight.__doc__, "Heavy")

--- a/test/unit3/test_docstring.py
+++ b/test/unit3/test_docstring.py
@@ -88,6 +88,11 @@ class TestDocstrings(unittest.TestCase):
         f = lambda x: 42
         self.assertEqual(f.__doc__, None)
 
+    def test_internal_no_docstring(self):
+        # This test will need updating if/when divmod is given
+        # a docstring.
+        self.assertEqual(divmod.__doc__, None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit3/test_docstring.py
+++ b/test/unit3/test_docstring.py
@@ -1,0 +1,93 @@
+import unittest
+
+
+def banana():
+    "Yellow"
+    return 42
+
+
+def orange():
+    "Oran" "ge"
+
+
+def blackbirds():
+    4 + 20  # Not a docstring
+
+
+def do_nothing():
+    pass
+
+
+def make_adder(n):
+    "Function adding N"
+    def add(x):
+        "Compute N + X"
+        return n + x
+    return add
+
+
+class Strawberry:
+    "Delicious"
+    doc = __doc__
+
+    def weight(self):
+        "Heavy"
+        return 0.25
+
+    @classmethod
+    def is_red(cls):
+        "Very red"
+        return True
+
+    @staticmethod
+    def pick():
+        "Picked"
+        return None
+
+
+class TestDocstrings(unittest.TestCase):
+    def test_function(self):
+        self.assertEqual(banana.__doc__, "Yellow")
+        self.assertEqual(orange.__doc__, "Orange")
+        self.assertEqual(make_adder.__doc__, "Function adding N")
+
+    def test_runtime_function(self):
+        self.assertEqual(make_adder(3).__doc__, "Compute N + X")
+
+    def test_non_string_expr(self):
+        self.assertEqual(blackbirds.__doc__, None)
+
+    def test_no_expr(self):
+        self.assertEqual(do_nothing.__doc__, None)
+
+    def test_class(self):
+        self.assertEqual(Strawberry.__doc__, "Delicious")
+        self.assertEqual(Strawberry.doc, "Delicious")
+
+    def test_method(self):
+        self.assertEqual(Strawberry.weight.__doc__, "Heavy")
+        s = Strawberry()
+        self.assertEqual(s.weight.__doc__, "Heavy")
+
+    def test_classmethod(self):
+        self.assertEqual(Strawberry.is_red.__doc__, "Very red")
+
+    def test_staticmethod(self):
+        self.assertEqual(Strawberry.pick.__doc__, "Picked")
+
+    def test_module(self):
+        import bisect
+        self.assertEqual(bisect.__doc__, "Bisection algorithms.")
+
+    def test_local_module(self):
+        import copydocstring
+        self.assertEqual(copydocstring.__doc__, "Copy docstring")
+        self.assertEqual(copydocstring.doc, "Copy docstring")
+
+    def test_lambda(self):
+        f = lambda x: 42
+        self.assertEqual(f.__doc__, None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit3/test_docstring.py
+++ b/test/unit3/test_docstring.py
@@ -50,6 +50,11 @@ class Tangerine:
         pass
 
 
+class Pear:
+    "This will not be the __doc__"
+    __doc__ = "Conference"
+
+
 class TestDocstrings(unittest.TestCase):
     def test_function(self):
         self.assertEqual(banana.__doc__, "Yellow")
@@ -73,6 +78,9 @@ class TestDocstrings(unittest.TestCase):
         self.assertEqual(Tangerine.__doc__, None)
         self.assertEqual(Tangerine.peel.__doc__, None)
         self.assertEqual(Tangerine().peel.__doc__, None)
+
+    def test_class_explicit_docstring(self):
+        self.assertEqual(Pear.__doc__, "Conference")
 
     def test_method(self):
         self.assertEqual(Strawberry.weight.__doc__, "Heavy")


### PR DESCRIPTION
Assign `__doc__` attribute to functions, methods, classmethods, classes, and modules.

\[Edited: the first version of this PR did not support module docstrings.\]