### PR TITLE
Add some attribute and descriptor tests

### DIFF
--- a/test/unit3/test_del_attr.py
+++ b/test/unit3/test_del_attr.py
@@ -1,0 +1,142 @@
+import unittest
+
+
+class CustomDelAttr:
+    def __init__(self):
+        self.a = 42
+        self.attr_deleted = "nothing-yet"
+
+    def __delattr__(self, attr_name):
+        self.attr_deleted = attr_name
+
+
+def cls_DerivedCustomDelAttr():
+    class DerivedCustomDelAttr(CustomDelAttr):
+        def __init__(self):
+            CustomDelAttr.__init__(self)
+            self.a = 99
+            self.derived_attr_deleted = "nothing-yet"
+
+        def __delattr__(self, attr_name):
+            self.derived_attr_deleted = attr_name
+
+    return DerivedCustomDelAttr
+
+
+class CustomDeleteDescriptor:
+    def __get__(self, obj, objtype=None):
+        return 10
+
+    def __set__(self, obj, value):
+        pass
+
+    def __delete__(self, obj):
+        obj.custom_delete_called = True
+
+
+class RaisingCustomDeleteDescriptor:
+    def __get__(self, obj, objtype=None):
+        return 10
+
+    def __set__(self, obj, value):
+        pass
+
+    def __delete__(self, obj):
+        obj.cause_an_error = 1 / 0
+
+
+class WithCustomDeleteDescriptor:
+    a = CustomDeleteDescriptor()
+
+    def __init__(self):
+        self.custom_delete_called = False
+
+
+class WithRaisingCustomDeleteDescriptor:
+    a = RaisingCustomDeleteDescriptor()
+
+
+class DelAttrTests(unittest.TestCase):
+    def cls_DelInstanceOrClassAttr(self):
+        class DelInstanceOrClassAttr:
+            a = 42
+        return DelInstanceOrClassAttr
+
+    def test_del_instance_attr(self):
+        DelInstanceOrClassAttr = self.cls_DelInstanceOrClassAttr()
+        x = DelInstanceOrClassAttr()
+        x.b = 99
+        self.assertEqual(x.b, 99)
+        del x.b
+        self.assertRaises(AttributeError, lambda: x.b)
+
+    def test_override_then_del_instance_attr(self):
+        DelInstanceOrClassAttr = self.cls_DelInstanceOrClassAttr()
+        x = DelInstanceOrClassAttr()
+        x.a = 99
+        self.assertEqual(x.a, 99)
+        del x.a
+        self.assertEqual(x.a, 42)
+
+    def test_del_class_attr(self):
+        cls = self.cls_DelInstanceOrClassAttr()
+        del cls.a
+        self.assertRaises(AttributeError, lambda: cls.a)
+
+    def test_custom_delattr(self):
+        x = CustomDelAttr()
+        self.assertEqual(x.a, 42)
+        del x.a
+        self.assertEqual(x.a, 42)
+        self.assertEqual(x.attr_deleted, "a")
+
+    def test_delete_custom_delattr_method(self):
+        cls = cls_DerivedCustomDelAttr()
+        x = cls()
+        self.assertEqual(x.derived_attr_deleted, "nothing-yet")
+        self.assertEqual(x.attr_deleted, "nothing-yet")
+        del x.a
+        self.assertEqual(x.derived_attr_deleted, "a")
+        self.assertEqual(x.attr_deleted, "nothing-yet")
+        del cls.__delattr__
+        del x.a
+        self.assertEqual(x.derived_attr_deleted, "a")
+        self.assertEqual(x.attr_deleted, "a")
+
+    def test_del_nonexistent_class_attr(self):
+        cls = self.cls_DelInstanceOrClassAttr()
+        def bad_delete():
+            del cls.no_such_attr
+        self.assertRaises(AttributeError, bad_delete)
+
+    def test_del_nonexistent_instance_attr(self):
+        cls = self.cls_DelInstanceOrClassAttr()
+        x = cls()
+        def bad_delete():
+            del x.no_such_attr
+        self.assertRaises(AttributeError, bad_delete)
+
+    def test_custom_delete_descriptor(self):
+        x = WithCustomDeleteDescriptor()
+        self.assertEqual(x.a, 10)
+        self.assertFalse(x.custom_delete_called)
+        del x.a
+        self.assertEqual(x.a, 10)
+        self.assertTrue(x.custom_delete_called)
+
+    def test_raising_custom_delete_descriptor(self):
+        x = WithRaisingCustomDeleteDescriptor()
+        def bad_delete():
+            del x.a
+        self.assertRaises(ZeroDivisionError, bad_delete)
+
+    def test_delete_class_dunder(self):
+        DelInstanceOrClassAttr = self.cls_DelInstanceOrClassAttr()
+        x = DelInstanceOrClassAttr()
+        def bad_delete():
+            del x.__class__
+        self.assertRaises(TypeError, bad_delete)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_raising_descriptor_get.py
+++ b/test/unit3/test_raising_descriptor_get.py
@@ -1,0 +1,20 @@
+import unittest
+
+
+class RaisingDescriptor:
+    def __get__(self, obj, objtype=None):
+        return obj.no_such_attribute
+
+
+class WithRaisingDescriptor:
+    a = RaisingDescriptor()
+
+
+class TestRaisingDescriptor(unittest.TestCase):
+    def test_raising_descriptor(self):
+        x = WithRaisingDescriptor()
+        self.assertFalse(hasattr(x, "a"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add some (passing) tests for:
 * deleting attributes, taken from #1248 (which was closed as superseded by #1092)
 * a corner case for `hasattr()` which failed pre-#1092