### PR TITLE
Fix resume from yielding

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -224,12 +224,13 @@ Compiler.prototype.outputInterruptTest = function () { // Added by RNL
             output += "if ($dateNow - Sk.execStart > Sk.execLimit) {throw new Sk.builtin.TimeLimitError(Sk.timeoutMsg())}";
         }
         if (Sk.yieldLimit !== null && this.u.canSuspend) {
-            output += "if ($dateNow - Sk.lastYield > Sk.yieldLimit) {";
+            output += "if (!$waking && ($dateNow - Sk.lastYield > Sk.yieldLimit)) {";
             output += "var $susp = $saveSuspension({data: {type: 'Sk.yield'}, resume: function() {}}, '"+this.filename+"',$currLineNo,$currColNo);";
             output += "$susp.$blk = $blk;";
             output += "$susp.optional = true;";
             output += "return $susp;";
             output += "}";
+            output += "$waking = false;";
             this.u.doesSuspend = true;
         }
     }
@@ -1922,7 +1923,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     // If there is a suspension, resume from it. Otherwise, initialise
     // parameters appropriately.
     //
-    this.u.varDeclsCode += "if ("+scopename+".$wakingSuspension!==undefined) { $wakeFromSuspension(); } else {";
+    this.u.varDeclsCode += "var $waking=false; if ("+scopename+".$wakingSuspension!==undefined) { $wakeFromSuspension(); $waking=true; } else {";
 
     if (fastCall) {
         // Resolve our arguments from $posargs+$kwargs.
@@ -2777,7 +2778,7 @@ Compiler.prototype.cmod = function (mod) {
         this.u.varDeclsCode += "if (typeof Sk.lastYield === 'undefined') {Sk.lastYield = Date.now()}";
     }
 
-    this.u.varDeclsCode += "if ("+modf+".$wakingSuspension!==undefined) { $wakeFromSuspension(); }" +
+    this.u.varDeclsCode += "var $waking=false; if ("+modf+".$wakingSuspension!==undefined) { $wakeFromSuspension(); $waking=true; }" +
         "if (Sk.retainGlobals) {" +
         "    if (Sk.globals) { $gbl = Sk.globals; Sk.globals = $gbl; $loc = $gbl; }" +
         "    if (Sk.globals) { $gbl = Sk.globals; Sk.globals = $gbl; $loc = $gbl; $loc.__file__=new Sk.builtins.str('" + this.filename + "');}" +


### PR DESCRIPTION
Currently, if the yieldLimit is set and you yield from a deeply nested long running function, state may be lost.

The situation occurs when you resumqe from a yield. At that point, each Python function resumes it's children.  However, if one of those children exceeds the yield limit again before returning, it will return an Sk.yield suspension.  That gets stored in ```$ret``` in ```$wakeFromSuspension```.  The code then enters the main while loop, where it detects that it is past the yield limit.  At that point, it creates a *new* yield suspension (throwing away the suspension currently stored in ```$ret```) and returns that.  This will occur all the way back up the chain.  When you try to resume again, all state is lost.

This pull request simply guarantees that you will run through the while loop body once after waking from a suspension, thereby guaranteeing that ```$ret``` is dealt with correctly.  I feel that this is the smallest perturbation to the code that fixes the issue.

You can see the problem by setting a relatively short ```yieldLimit``` in the Skulpt configuration and running the following program:

```
def one():
    for i in range(1000):
        two()

def two():
    for i in range(100000):
        print(i)

one()
```
