### PR TITLE
functools: implement lru_cache

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -501,7 +501,7 @@ function astForDecorator (c, n) {
     }
     else if (NCH(n) === 5) // call with no args
     {
-        return new Sk.astnodes.Call(nameExpr, [], [], null, null, n.lineno, n.col_offset);
+        return new Sk.astnodes.Call(nameExpr, [], [], n.lineno, n.col_offset);
     }
     else {
         return ast_for_call(c, CHILD(n, 3), nameExpr);

--- a/src/lib/functools.js
+++ b/src/lib/functools.js
@@ -78,8 +78,6 @@ function functools_mod(functools) {
                 "cache",
                 "lru_cache",
                 "reduce",
-                "TopologicalSorter" /**@todo TopologicalSorter */,
-                "CycleError" /**@todo CycleError */,
                 "partial",
                 "partialmethod",
                 "singledispatch" /**@todo singledispatch */,
@@ -95,8 +93,6 @@ function functools_mod(functools) {
         WRAPPER_UPDATES: new pyTuple([new pyStr("__dict__")]),
 
         /**@todo */
-        TopologicalSorter: proxyFail("TopologicalSorter"),
-        CycleError: proxyFail("CycleError"),
         singledispatch: proxyFail("singledispatch"),
         singledispatchmethod: proxyFail("singledispatchmethod"),
         cached_property: proxyFail("cached_property"),

--- a/test/unit3/test_functools.py
+++ b/test/unit3/test_functools.py
@@ -1163,5 +1163,602 @@ class TestTotalOrdering(unittest.TestCase):
 #     def __eq__(self, other):
 #         return self.value == other.value
 
+class TestCache:
+    # This tests that the pass-through is working as designed.
+    # The underlying functionality is tested in TestLRU.
+
+    def test_cache(self):
+        @self.module.cache
+        def fib(n):
+            if n < 2:
+                return n
+            return fib(n-1) + fib(n-2)
+        self.assertEqual([fib(n) for n in range(16)],
+            [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610])
+        self.assertEqual(fib.cache_info(),
+            self.module._CacheInfo(hits=28, misses=16, maxsize=None, currsize=16))
+        fib.cache_clear()
+        self.assertEqual(fib.cache_info(),
+            self.module._CacheInfo(hits=0, misses=0, maxsize=None, currsize=0))
+
+
+
+class TestLRU:
+
+    def test_lru(self):
+        def orig(x, y):
+            return 3 * x + y
+        f = self.module.lru_cache(maxsize=20)(orig)
+        hits, misses, maxsize, currsize = f.cache_info()
+        self.assertEqual(maxsize, 20)
+        self.assertEqual(currsize, 0)
+        self.assertEqual(hits, 0)
+        self.assertEqual(misses, 0)
+
+        domain = range(5)
+        for i in range(1000):
+            x, y = choice(domain), choice(domain)
+            actual = f(x, y)
+            expected = orig(x, y)
+            self.assertEqual(actual, expected)
+        hits, misses, maxsize, currsize = f.cache_info()
+        self.assertTrue(hits > misses)
+        self.assertEqual(hits + misses, 1000)
+        self.assertEqual(currsize, 20)
+
+        f.cache_clear()   # test clearing
+        hits, misses, maxsize, currsize = f.cache_info()
+        self.assertEqual(hits, 0)
+        self.assertEqual(misses, 0)
+        self.assertEqual(currsize, 0)
+        f(x, y)
+        hits, misses, maxsize, currsize = f.cache_info()
+        self.assertEqual(hits, 0)
+        self.assertEqual(misses, 1)
+        self.assertEqual(currsize, 1)
+
+        # Test bypassing the cache
+        self.assertIs(f.__wrapped__, orig)
+        f.__wrapped__(x, y)
+        hits, misses, maxsize, currsize = f.cache_info()
+        self.assertEqual(hits, 0)
+        self.assertEqual(misses, 1)
+        self.assertEqual(currsize, 1)
+
+        # test size zero (which means "never-cache")
+        @self.module.lru_cache(0)
+        def f():
+            nonlocal f_cnt
+            f_cnt += 1
+            return 20
+        self.assertEqual(f.cache_info().maxsize, 0)
+        f_cnt = 0
+        for i in range(5):
+            self.assertEqual(f(), 20)
+        self.assertEqual(f_cnt, 5)
+        hits, misses, maxsize, currsize = f.cache_info()
+        self.assertEqual(hits, 0)
+        self.assertEqual(misses, 5)
+        self.assertEqual(currsize, 0)
+
+        # test size one
+        @self.module.lru_cache(1)
+        def f():
+            nonlocal f_cnt
+            f_cnt += 1
+            return 20
+        self.assertEqual(f.cache_info().maxsize, 1)
+        f_cnt = 0
+        for i in range(5):
+            self.assertEqual(f(), 20)
+        self.assertEqual(f_cnt, 1)
+        hits, misses, maxsize, currsize = f.cache_info()
+        self.assertEqual(hits, 4)
+        self.assertEqual(misses, 1)
+        self.assertEqual(currsize, 1)
+
+        # test size two
+        @self.module.lru_cache(2)
+        def f(x):
+            nonlocal f_cnt
+            f_cnt += 1
+            return x*10
+        self.assertEqual(f.cache_info().maxsize, 2)
+        f_cnt = 0
+        for x in 7, 9, 7, 9, 7, 9, 8, 8, 8, 9, 9, 9, 8, 8, 8, 7:
+            #    *  *              *                          *
+            self.assertEqual(f(x), x*10)
+        self.assertEqual(f_cnt, 4)
+        hits, misses, maxsize, currsize = f.cache_info()
+        self.assertEqual(hits, 12)
+        self.assertEqual(misses, 4)
+        self.assertEqual(currsize, 2)
+
+    def test_lru_no_args(self):
+        @self.module.lru_cache
+        def square(x):
+            return x ** 2
+
+        self.assertEqual(list(map(square, [10, 20, 10])),
+                         [100, 400, 100])
+        self.assertEqual(square.cache_info().hits, 1)
+        self.assertEqual(square.cache_info().misses, 2)
+        self.assertEqual(square.cache_info().maxsize, 128)
+        self.assertEqual(square.cache_info().currsize, 2)
+
+    def test_lru_bug_35780(self):
+        # C version of the lru_cache was not checking to see if
+        # the user function call has already modified the cache
+        # (this arises in recursive calls and in multi-threading).
+        # This cause the cache to have orphan links not referenced
+        # by the cache dictionary.
+
+        once = True                 # Modified by f(x) below
+
+        @self.module.lru_cache(maxsize=10)
+        def f(x):
+            nonlocal once
+            rv = f'.{x}.'
+            if x == 20 and once:
+                once = False
+                rv = f(x)
+            return rv
+
+        # Fill the cache
+        for x in range(15):
+            self.assertEqual(f(x), f'.{x}.')
+        self.assertEqual(f.cache_info().currsize, 10)
+
+        # Make a recursive call and make sure the cache remains full
+        self.assertEqual(f(20), '.20.')
+        self.assertEqual(f.cache_info().currsize, 10)
+
+    def test_lru_bug_36650(self):
+        # C version of lru_cache was treating a call with an empty **kwargs
+        # dictionary as being distinct from a call with no keywords at all.
+        # This did not result in an incorrect answer, but it did trigger
+        # an unexpected cache miss.
+
+        @self.module.lru_cache()
+        def f(x):
+            pass
+
+        f(0)
+        f(0, **{})
+        self.assertEqual(f.cache_info().hits, 1)
+
+    def test_lru_hash_only_once(self):
+        # To protect against weird reentrancy bugs and to improve
+        # efficiency when faced with slow __hash__ methods, the
+        # LRU cache guarantees that it will only call __hash__
+        # only once per use as an argument to the cached function.
+
+        @self.module.lru_cache(maxsize=1)
+        def f(x, y):
+            return x * 3 + y
+
+        # Simulate the integer 5
+        mock_int = unittest.mock.Mock()
+        mock_int.__mul__ = unittest.mock.Mock(return_value=15)
+        mock_int.__hash__ = unittest.mock.Mock(return_value=999)
+
+        # Add to cache:  One use as an argument gives one call
+        self.assertEqual(f(mock_int, 1), 16)
+        self.assertEqual(mock_int.__hash__.call_count, 1)
+        self.assertEqual(f.cache_info(), (0, 1, 1, 1))
+
+        # Cache hit: One use as an argument gives one additional call
+        self.assertEqual(f(mock_int, 1), 16)
+        self.assertEqual(mock_int.__hash__.call_count, 2)
+        self.assertEqual(f.cache_info(), (1, 1, 1, 1))
+
+        # Cache eviction: No use as an argument gives no additional call
+        self.assertEqual(f(6, 2), 20)
+        self.assertEqual(mock_int.__hash__.call_count, 2)
+        self.assertEqual(f.cache_info(), (1, 2, 1, 1))
+
+        # Cache miss: One use as an argument gives one additional call
+        self.assertEqual(f(mock_int, 1), 16)
+        self.assertEqual(mock_int.__hash__.call_count, 3)
+        self.assertEqual(f.cache_info(), (1, 3, 1, 1))
+
+    def test_lru_reentrancy_with_len(self):
+        # Test to make sure the LRU cache code isn't thrown-off by
+        # caching the built-in len() function.  Since len() can be
+        # cached, we shouldn't use it inside the lru code itself.
+        old_len = builtins.len
+        try:
+            builtins.len = self.module.lru_cache(4)(len)
+            for i in [0, 0, 1, 2, 3, 3, 4, 5, 6, 1, 7, 2, 1]:
+                self.assertEqual(len('abcdefghijklmn'[:i]), i)
+        finally:
+            builtins.len = old_len
+
+    def test_lru_star_arg_handling(self):
+        # Test regression that arose in ea064ff3c10f
+        @functools.lru_cache()
+        def f(*args):
+            return args
+
+        self.assertEqual(f(1, 2), (1, 2))
+        self.assertEqual(f((1, 2)), ((1, 2),))
+
+    def test_lru_type_error(self):
+        # Regression test for issue #28653.
+        # lru_cache was leaking when one of the arguments
+        # wasn't cacheable.
+
+        @functools.lru_cache(maxsize=None)
+        def infinite_cache(o):
+            pass
+
+        @functools.lru_cache(maxsize=10)
+        def limited_cache(o):
+            pass
+
+        with self.assertRaises(TypeError):
+            infinite_cache([])
+
+        with self.assertRaises(TypeError):
+            limited_cache([])
+
+    def test_lru_with_maxsize_none(self):
+        @self.module.lru_cache(maxsize=None)
+        def fib(n):
+            if n < 2:
+                return n
+            return fib(n-1) + fib(n-2)
+        self.assertEqual([fib(n) for n in range(16)],
+            [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610])
+        self.assertEqual(fib.cache_info(),
+            self.module._CacheInfo(hits=28, misses=16, maxsize=None, currsize=16))
+        fib.cache_clear()
+        self.assertEqual(fib.cache_info(),
+            self.module._CacheInfo(hits=0, misses=0, maxsize=None, currsize=0))
+
+    def test_lru_with_maxsize_negative(self):
+        @self.module.lru_cache(maxsize=-10)
+        def eq(n):
+            return n
+        for i in (0, 1):
+            self.assertEqual([eq(n) for n in range(150)], list(range(150)))
+        self.assertEqual(eq.cache_info(),
+            self.module._CacheInfo(hits=0, misses=300, maxsize=0, currsize=0))
+
+    def test_lru_with_exceptions(self):
+        # Verify that user_function exceptions get passed through without
+        # creating a hard-to-read chained exception.
+        # http://bugs.python.org/issue13177
+        for maxsize in (None, 128):
+            @self.module.lru_cache(maxsize)
+            def func(i):
+                return 'abc'[i]
+            self.assertEqual(func(0), 'a')
+            with self.assertRaises(IndexError) as cm:
+                func(15)
+            self.assertIsNone(cm.exception.__context__)
+            # Verify that the previous exception did not result in a cached entry
+            with self.assertRaises(IndexError):
+                func(15)
+
+    def test_lru_with_types(self):
+        for maxsize in (None, 128):
+            @self.module.lru_cache(maxsize=maxsize, typed=True)
+            def square(x):
+                return x * x
+            self.assertEqual(square(3), 9)
+            self.assertEqual(type(square(3)), type(9))
+            self.assertEqual(square(3.0), 9.0)
+            self.assertEqual(type(square(3.0)), type(9.0))
+            self.assertEqual(square(x=3), 9)
+            self.assertEqual(type(square(x=3)), type(9))
+            self.assertEqual(square(x=3.0), 9.0)
+            self.assertEqual(type(square(x=3.0)), type(9.0))
+            self.assertEqual(square.cache_info().hits, 4)
+            self.assertEqual(square.cache_info().misses, 4)
+
+    def test_lru_with_keyword_args(self):
+        @self.module.lru_cache()
+        def fib(n):
+            if n < 2:
+                return n
+            return fib(n=n-1) + fib(n=n-2)
+        self.assertEqual(
+            [fib(n=number) for number in range(16)],
+            [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610]
+        )
+        self.assertEqual(fib.cache_info(),
+            self.module._CacheInfo(hits=28, misses=16, maxsize=128, currsize=16))
+        fib.cache_clear()
+        self.assertEqual(fib.cache_info(),
+            self.module._CacheInfo(hits=0, misses=0, maxsize=128, currsize=0))
+
+    def test_lru_with_keyword_args_maxsize_none(self):
+        @self.module.lru_cache(maxsize=None)
+        def fib(n):
+            if n < 2:
+                return n
+            return fib(n=n-1) + fib(n=n-2)
+        self.assertEqual([fib(n=number) for number in range(16)],
+            [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610])
+        self.assertEqual(fib.cache_info(),
+            self.module._CacheInfo(hits=28, misses=16, maxsize=None, currsize=16))
+        fib.cache_clear()
+        self.assertEqual(fib.cache_info(),
+            self.module._CacheInfo(hits=0, misses=0, maxsize=None, currsize=0))
+
+    def test_kwargs_order(self):
+        # PEP 468: Preserving Keyword Argument Order
+        @self.module.lru_cache(maxsize=10)
+        def f(**kwargs):
+            return list(kwargs.items())
+        self.assertEqual(f(a=1, b=2), [('a', 1), ('b', 2)])
+        self.assertEqual(f(b=2, a=1), [('b', 2), ('a', 1)])
+        self.assertEqual(f.cache_info(),
+            self.module._CacheInfo(hits=0, misses=2, maxsize=10, currsize=2))
+
+    def test_lru_cache_decoration(self):
+        def f(zomg: 'zomg_annotation'):
+            """f doc string"""
+            return 42
+        g = self.module.lru_cache()(f)
+        for attr in self.module.WRAPPER_ASSIGNMENTS:
+            self.assertEqual(getattr(g, attr), getattr(f, attr))
+
+    def test_lru_cache_threaded(self):
+        n, m = 5, 11
+        def orig(x, y):
+            return 3 * x + y
+        f = self.module.lru_cache(maxsize=n*m)(orig)
+        hits, misses, maxsize, currsize = f.cache_info()
+        self.assertEqual(currsize, 0)
+
+        start = threading.Event()
+        def full(k):
+            start.wait(10)
+            for _ in range(m):
+                self.assertEqual(f(k, 0), orig(k, 0))
+
+        def clear():
+            start.wait(10)
+            for _ in range(2*m):
+                f.cache_clear()
+
+        orig_si = sys.getswitchinterval()
+        support.setswitchinterval(1e-6)
+        try:
+            # create n threads in order to fill cache
+            threads = [threading.Thread(target=full, args=[k])
+                       for k in range(n)]
+            with threading_helper.start_threads(threads):
+                start.set()
+
+            hits, misses, maxsize, currsize = f.cache_info()
+            if self.module is py_functools:
+                # XXX: Why can be not equal?
+                self.assertLessEqual(misses, n)
+                self.assertLessEqual(hits, m*n - misses)
+            else:
+                self.assertEqual(misses, n)
+                self.assertEqual(hits, m*n - misses)
+            self.assertEqual(currsize, n)
+
+            # create n threads in order to fill cache and 1 to clear it
+            threads = [threading.Thread(target=clear)]
+            threads += [threading.Thread(target=full, args=[k])
+                        for k in range(n)]
+            start.clear()
+            with threading_helper.start_threads(threads):
+                start.set()
+        finally:
+            sys.setswitchinterval(orig_si)
+
+    def test_lru_cache_threaded2(self):
+        # Simultaneous call with the same arguments
+        n, m = 5, 7
+        start = threading.Barrier(n+1)
+        pause = threading.Barrier(n+1)
+        stop = threading.Barrier(n+1)
+        @self.module.lru_cache(maxsize=m*n)
+        def f(x):
+            pause.wait(10)
+            return 3 * x
+        self.assertEqual(f.cache_info(), (0, 0, m*n, 0))
+        def test():
+            for i in range(m):
+                start.wait(10)
+                self.assertEqual(f(i), 3 * i)
+                stop.wait(10)
+        threads = [threading.Thread(target=test) for k in range(n)]
+        with threading_helper.start_threads(threads):
+            for i in range(m):
+                start.wait(10)
+                stop.reset()
+                pause.wait(10)
+                start.reset()
+                stop.wait(10)
+                pause.reset()
+                self.assertEqual(f.cache_info(), (0, (i+1)*n, m*n, i+1))
+
+    def test_lru_cache_threaded3(self):
+        @self.module.lru_cache(maxsize=2)
+        def f(x):
+            time.sleep(.01)
+            return 3 * x
+        def test(i, x):
+            with self.subTest(thread=i):
+                self.assertEqual(f(x), 3 * x, i)
+        threads = [threading.Thread(target=test, args=(i, v))
+                   for i, v in enumerate([1, 2, 2, 3, 2])]
+        with threading_helper.start_threads(threads):
+            pass
+
+    def test_need_for_rlock(self):
+        # This will deadlock on an LRU cache that uses a regular lock
+
+        @self.module.lru_cache(maxsize=10)
+        def test_func(x):
+            'Used to demonstrate a reentrant lru_cache call within a single thread'
+            return x
+
+        class DoubleEq:
+            'Demonstrate a reentrant lru_cache call within a single thread'
+            def __init__(self, x):
+                self.x = x
+            def __hash__(self):
+                return self.x
+            def __eq__(self, other):
+                if self.x == 2:
+                    test_func(DoubleEq(1))
+                return self.x == other.x
+
+        test_func(DoubleEq(1))                      # Load the cache
+        test_func(DoubleEq(2))                      # Load the cache
+        self.assertEqual(test_func(DoubleEq(2)),    # Trigger a re-entrant __eq__ call
+                         DoubleEq(2))               # Verify the correct return value
+
+    def test_lru_method(self):
+        class X(int):
+            f_cnt = 0
+            @self.module.lru_cache(2)
+            def f(self, x):
+                self.f_cnt += 1
+                return x*10+self
+        a = X(5)
+        b = X(5)
+        c = X(7)
+        self.assertEqual(X.f.cache_info(), (0, 0, 2, 0))
+
+        for x in 1, 2, 2, 3, 1, 1, 1, 2, 3, 3:
+            self.assertEqual(a.f(x), x*10 + 5)
+        self.assertEqual((a.f_cnt, b.f_cnt, c.f_cnt), (6, 0, 0))
+        self.assertEqual(X.f.cache_info(), (4, 6, 2, 2))
+
+        for x in 1, 2, 1, 1, 1, 1, 3, 2, 2, 2:
+            self.assertEqual(b.f(x), x*10 + 5)
+        self.assertEqual((a.f_cnt, b.f_cnt, c.f_cnt), (6, 4, 0))
+        self.assertEqual(X.f.cache_info(), (10, 10, 2, 2))
+
+        for x in 2, 1, 1, 1, 1, 2, 1, 3, 2, 1:
+            self.assertEqual(c.f(x), x*10 + 7)
+        self.assertEqual((a.f_cnt, b.f_cnt, c.f_cnt), (6, 4, 5))
+        self.assertEqual(X.f.cache_info(), (15, 15, 2, 2))
+
+        self.assertEqual(a.f.cache_info(), X.f.cache_info())
+        self.assertEqual(b.f.cache_info(), X.f.cache_info())
+        self.assertEqual(c.f.cache_info(), X.f.cache_info())
+
+    def test_pickle(self):
+        cls = self.__class__
+        for f in cls.cached_func[0], cls.cached_meth, cls.cached_staticmeth:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                with self.subTest(proto=proto, func=f):
+                    f_copy = pickle.loads(pickle.dumps(f, proto))
+                    self.assertIs(f_copy, f)
+
+    def test_copy(self):
+        cls = self.__class__
+        def orig(x, y):
+            return 3 * x + y
+        part = self.module.partial(orig, 2)
+        funcs = (cls.cached_func[0], cls.cached_meth, cls.cached_staticmeth,
+                 self.module.lru_cache(2)(part))
+        for f in funcs:
+            with self.subTest(func=f):
+                f_copy = copy.copy(f)
+                self.assertIs(f_copy, f)
+
+    def test_deepcopy(self):
+        cls = self.__class__
+        def orig(x, y):
+            return 3 * x + y
+        part = self.module.partial(orig, 2)
+        funcs = (cls.cached_func[0], cls.cached_meth, cls.cached_staticmeth,
+                 self.module.lru_cache(2)(part))
+        for f in funcs:
+            with self.subTest(func=f):
+                f_copy = copy.deepcopy(f)
+                self.assertIs(f_copy, f)
+
+    def test_lru_cache_parameters(self):
+        @self.module.lru_cache(maxsize=2)
+        def f():
+            return 1
+        self.assertEqual(f.cache_parameters(), {'maxsize': 2, "typed": False})
+
+        @self.module.lru_cache(maxsize=1000, typed=True)
+        def f():
+            return 1
+        self.assertEqual(f.cache_parameters(), {'maxsize': 1000, "typed": True})
+
+    def test_lru_cache_weakrefable(self):
+        @self.module.lru_cache
+        def test_function(x):
+            return x
+
+        class A:
+            @self.module.lru_cache
+            def test_method(self, x):
+                return (self, x)
+
+            @staticmethod
+            @self.module.lru_cache
+            def test_staticmethod(x):
+                return (self, x)
+
+        refs = [weakref.ref(test_function),
+                weakref.ref(A.test_method),
+                weakref.ref(A.test_staticmethod)]
+
+        for ref in refs:
+            self.assertIsNotNone(ref())
+
+        del A
+        del test_function
+        gc.collect()
+
+        for ref in refs:
+            self.assertIsNone(ref())
+
+
+@py_functools.lru_cache()
+def py_cached_func(x, y):
+    return 3 * x + y
+
+@c_functools.lru_cache()
+def c_cached_func(x, y):
+    return 3 * x + y
+
+
+# class TestLRUPy(TestLRU, unittest.TestCase):
+#     module = py_functools
+#     cached_func = py_cached_func,
+
+#     @module.lru_cache()
+#     def cached_meth(self, x, y):
+#         return 3 * x + y
+
+#     @staticmethod
+#     @module.lru_cache()
+#     def cached_staticmeth(x, y):
+#         return 3 * x + y
+
+
+class TestLRUC(TestLRU, unittest.TestCase):
+    module = c_functools
+    cached_func = c_cached_func,
+
+    @module.lru_cache()
+    def cached_meth(self, x, y):
+        return 3 * x + y
+
+    @staticmethod
+    @module.lru_cache()
+    def cached_staticmeth(x, y):
+        return 3 * x + y
+
+
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=1)


### PR DESCRIPTION
This extends the functools implementation to include `lru_cache`.

It also adds the `@cache` decorator which was included in python 3.9

I used the cpython tests and adjusted for skulpt.

As part of the pr I also assigned Sk objects into the local scope for functools.

