### PR TITLE
Add Github actions config to deploy to NPM on version tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: deploy
+on:
+  push:
+    tags: v*
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    environment: CI
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "name": "Brad Miller"
   },
   "license": "MIT",
-  "private": true,
+  "private": false,
   "devDependencies": {
     "acorn": "^6.1.1",
     "babel-minify": "^0.5.0",


### PR DESCRIPTION
This sets up GitHub actions to deploy to NPM automatically on a tag prefixed with "v".

This isn't complete in itself; it will require an NPM auth token to be set up and deployed as a GitHub secret called `NPM_TOKEN`.