### PR TITLE
reduce parsenumber complexity

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -2677,94 +2677,39 @@ function parsestrplus (c, n) {
     }
 }
 
-const invalidSyntax = /_[eE]|[eE]_|\._|j_/;
-const invalidDecimalLiteral = /_\.|[+-]_|^0_\D|_j/;
-const validUnderscores = /_(?=[^_])/g;
-function parsenumber (c, s, lineno) {
-    var neg;
-    var val;
-    var tmp;
-    var end = s.charAt(s.length - 1);
-    
-    if (s.indexOf("_") !== -1) {
-        if (invalidSyntax.test(s)) {
-            throw new Sk.builtin.SyntaxError("invalid syntax", c.c_filename, lineno);
-        }
-    
-        if (invalidDecimalLiteral.test(s)) {
-            throw new Sk.builtin.SyntaxError("invalid decimal literal", c.c_filename, lineno);
-        }
-        
-        s = s.replace(validUnderscores, "");
-    }
-    
-    // call internal complex type constructor for complex strings
+const FLOAT_RE = new RegExp(Sk._tokenize.Floatnumber);
+
+function parsenumber(c, s, lineno) {
+    s = s.replaceAll("_", ""); // we already know that we have a valid underscore number from the tokenizer
+
+    const end = s[s.length - 1];
+    // we know it's just a single floating point imaginary complex number
     if (end === "j" || end === "J") {
-        return Sk.builtin.complex.complex_subtype_from_string(s);
+        return new Sk.builtin.complex(0, parseFloat(s.slice(0, -1)));
     }
 
-    // Handle longs
+    // use the tokenizer float test
+    if (FLOAT_RE.test(s)) {
+        return new Sk.builtin.float_(parseFloat(s));
+    }
+
+    const start = s[0];
+    // python 2 compatiblity
+    if (start === "0" && s !== "0" && s.charCodeAt(1) < 65 /** i.e. the second char is a digit and not a base */) {
+        s = "0o" + s.substring(1); // silent octal
+    }
     if (end === "l" || end === "L") {
-        return Sk.longFromStr(s.substr(0, s.length - 1), 0);
+        return new Sk.builtin.lng(JSBI.BigInt(s.slice(0, -1)));
     }
 
-    // todo; we don't currently distinguish between int and float so
-    // str is wrong for these.
-    if (s.indexOf(".") !== -1) {
-        return new Sk.builtin.float_(parseFloat(s));
+    // we know it's a valid octal, hex, binary or decimal so let Number do its thing
+    const val = Number(s); // we can rely on this since we know s is positive and is already a valid int literal
+    if (val > Number.MAX_SAFE_INTEGER) {
+        return Sk.__future__.python3 ? new Sk.builtin.int_(JSBI.BigInt(s)) : new Sk.builtin.lng(JSBI.BigInt(s));
     }
-
-    // Handle integers of various bases
-    tmp = s;
-    neg = false;
-    if (s.charAt(0) === "-") {
-        tmp = s.substr(1);
-        neg = true;
-    }
-
-    if (tmp.charAt(0) === "0" && (tmp.charAt(1) === "x" || tmp.charAt(1) === "X")) {
-        // Hex
-        tmp = tmp.substring(2);
-        val = parseInt(tmp, 16);
-    } else if ((s.indexOf("e") !== -1) || (s.indexOf("E") !== -1)) {
-        // Float with exponent (needed to make sure e/E wasn't hex first)
-        return new Sk.builtin.float_(parseFloat(s));
-    } else if (tmp.charAt(0) === "0" && (tmp.charAt(1) === "b" || tmp.charAt(1) === "B")) {
-        // Binary
-        tmp = tmp.substring(2);
-        val = parseInt(tmp, 2);
-    } else if (tmp.charAt(0) === "0") {
-        if (tmp === "0") {
-            // Zero
-            val = 0;
-        } else {
-            // Octal
-            tmp = tmp.substring(1);
-            if ((tmp.charAt(0) === "o") || (tmp.charAt(0) === "O")) {
-                tmp = tmp.substring(1);
-            }
-            val = parseInt(tmp, 8);
-        }
-    }
-    else {
-        // Decimal
-        val = parseInt(tmp, 10);
-    }
-
-    // Convert to long
-    if (val > Number.MAX_SAFE_INTEGER &&
-        Math.floor(val) === val &&
-        (s.indexOf("e") === -1 && s.indexOf("E") === -1)) {
-        return Sk.longFromStr(s, 0);
-    }
-
-    // Small enough, return parsed number
-    if (neg) {
-        return new Sk.builtin.int_(-val);
-    } else {
-        return new Sk.builtin.int_(val);
-    }
+    return new Sk.builtin.int_(val);
 }
+
 
 function astForSlice (c, n) {
     var n2;

--- a/src/ast.js
+++ b/src/ast.js
@@ -2678,9 +2678,10 @@ function parsestrplus (c, n) {
 }
 
 const FLOAT_RE = new RegExp(Sk._tokenize.Floatnumber);
+const underscore = /_/g;
 
 function parsenumber(c, s, lineno) {
-    s = s.replaceAll("_", ""); // we already know that we have a valid underscore number from the tokenizer
+    s = s.replace(underscore, ""); // we already know that we have a valid underscore number from the tokenizer
 
     const end = s[s.length - 1];
     // we know it's just a single floating point imaginary complex number

--- a/src/ast.js
+++ b/src/ast.js
@@ -2699,16 +2699,20 @@ function parsenumber(c, s, lineno) {
     if (start === "0" && s !== "0" && s.charCodeAt(1) < 65 /** i.e. the second char is a digit and not a base */) {
         s = "0o" + s.substring(1); // silent octal
     }
+    // python2 makes no guarantee about the size of a long
+    // so only make the int literal a long if it has an L suffix
+    let isInt = true;
     if (end === "l" || end === "L") {
-        return new Sk.builtin.lng(JSBI.BigInt(s.slice(0, -1)));
+        s = s.slice(0, -1);
+        isInt = false;
     }
 
     // we know it's a valid octal, hex, binary or decimal so let Number do its thing
     const val = Number(s); // we can rely on this since we know s is positive and is already a valid int literal
     if (val > Number.MAX_SAFE_INTEGER) {
-        return Sk.__future__.python3 ? new Sk.builtin.int_(JSBI.BigInt(s)) : new Sk.builtin.lng(JSBI.BigInt(s));
+        return isInt ? new Sk.builtin.int_(JSBI.BigInt(s)) : new Sk.builtin.lng(JSBI.BigInt(s));
     }
-    return new Sk.builtin.int_(val);
+    return isInt ? new Sk.builtin.int_(val) : new Sk.builtin.lng(val);
 }
 
 

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -481,5 +481,7 @@ function _tokenize(filename, readline, encoding, yield_) {
 }
 
 Sk._tokenize = _tokenize;
+// we use this in ast
+Sk._tokenize.Floatnumber = Floatnumber;
 
 Sk.exportSymbol("Sk._tokenize", Sk._tokenize);

--- a/test/run/t246.py.real
+++ b/test/run/t246.py.real
@@ -1,3 +1,3 @@
 <type 'int'>
-<type 'long'>
+<type 'int'>
 <type 'float'>


### PR DESCRIPTION
When the skulpt tokenizer produces a `NUMBER` token we know it's positive and:
- a valid int literal
- or float
- or purely imaginary complex number

We don't need to do quite as much work to turn it into the correct python type. 

