### PR TITLE
fix slow repl.js

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -798,7 +798,7 @@ Sk.builtin.exec = function (code, globals, locals) {
     globals = globals || tmp;
     return Sk.misceval.chain(
         code,
-        (co) => eval(co.code)(globals, locals),
+        (co) => Sk.global["eval"](co.code)(globals, locals),
         (new_locals) => {
             Sk.globals = tmp;
             // we return new_locals internally for eval

--- a/src/compile.js
+++ b/src/compile.js
@@ -2473,7 +2473,7 @@ Compiler.prototype.cclass = function (s) {
     scopename = this.enterScope(s.name, s, s.lineno);
     entryBlock = this.newBlock("class entry");
 
-    this.u.prefixCode = "var " + scopename + "=(function $" + s.name.v + "$class_outer($globals,$locals,$cell){var $gbl=$globals,$loc=$locals;$free=$globals;";
+    this.u.prefixCode = "var " + scopename + "=(function $" + s.name.v + "$class_outer($globals,$locals,$cell){var $gbl=$globals,$loc=$locals,$free=$globals;";
     this.u.switchCode += "(function $" + s.name.v + "$_closure($cell){";
     this.u.switchCode += "var $blk=" + entryBlock + ",$exc=[],$ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;";
 


### PR DESCRIPTION
I have no idea why this makes any difference to the repl.js speed. 
It only affects the repl and doesn't affect running in the browser.
It also only affects devbuild and not build.

The cause of slowness was from commit 6100446677f755384c64e4ec3bae30ed068688b4 which added `var` before `$compiledmod`. 
Removing the `var` also fixed the slow speed of repl.js.
Adding `"use strict";` before `var $compiledmod` also fixed the speed.
(but we can't add `"use strict";` because of the way skulpt handles local variables in compiled python functions)

I only found this fix because `Sk.importMainWithBody` was fast in `repl.js` and experimenting with a few differences between `Sk.builtin.exec` and `Sk.importMainWithBody` I stumbled across using `Sk.global["eval"]` instead of `eval`. Which doesn't make sense to me because they are the same object.


In terms of performance - repl.js was 5 times slower from the commit above!
Tested on fields.py


---

I also found an undeclared variable in our compile code so I changed that `$free`.
