### PR TITLE
Improve error messages for __format__

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -700,6 +700,11 @@ Sk.abstr.checkArgsLen = function (func_name, args, minargs, maxargs) {
 Sk.exportSymbol("Sk.abstr.checkArgsLen", Sk.abstr.checkArgsLen);
 
 Sk.abstr.objectFormat = function (obj, format_spec) {
+    if (format_spec === undefined) {
+        format_spec = Sk.builtin.str.$emptystr;
+    } else if (!Sk.builtin.checkString(format_spec)) {
+        throw new Sk.builtin.TypeError("Format specifier must be a string, not " + Sk.abstr.typeName(format_spec));
+    }
     const meth = Sk.abstr.lookupSpecial(obj, Sk.builtin.str.$format); // inherited from object so guaranteed to exist
     const result = Sk.misceval.callsimArray(meth, [format_spec]);
     if (!Sk.builtin.checkString(result)) {

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -1083,10 +1083,6 @@ Sk.builtin.divmod = function divmod(a, b) {
  * built-in types: Format Specification Mini-Language.
  */
 Sk.builtin.format = function format(value, format_spec) {
-    if (format_spec === undefined) {
-        format_spec = Sk.builtin.str.$emptystr;
-    }
-
     return Sk.abstr.objectFormat(value, format_spec);
 };
 

--- a/src/object.js
+++ b/src/object.js
@@ -134,18 +134,10 @@ Sk.builtin.object = Sk.abstr.buildNativeClass("object", {
         },
         __format__: {
             $meth(format_spec) {
-                let formatstr;
                 if (!Sk.builtin.checkString(format_spec)) {
-                    if (Sk.__future__.exceptions) {
-                        throw new Sk.builtin.TypeError("format() argument 2 must be str, not " + Sk.abstr.typeName(format_spec));
-                    } else {
-                        throw new Sk.builtin.TypeError("format expects arg 2 to be string or unicode, not " + Sk.abstr.typeName(format_spec));
-                    }
-                } else {
-                    formatstr = Sk.ffi.remapToJs(format_spec);
-                    if (formatstr !== "") {
-                        throw new Sk.builtin.NotImplementedError("format spec is not yet implemented");
-                    }
+                    throw new Sk.builtin.TypeError("__format__() argument must be str, not " + Sk.abstr.typeName(format_spec));
+                } else if (format_spec !== Sk.builtin.str.$empty) {
+                    throw new Sk.builtin.TypeError(`unsupported format string passed to ${Sk.abstr.typeName(this)}.__format__`);
                 }
                 return this.tp$str();
             },


### PR DESCRIPTION
brings error messages up to date with cpython error messages for `format` and `__format__`