### PR TITLE
Adjust the round function in datetime.js

### DIFF
--- a/src/lib/datetime.js
+++ b/src/lib/datetime.js
@@ -14,6 +14,7 @@ function $builtinmodule() {
     const { isTrue, richCompareBool, asIndexOrThrow, asIndexSized, objectRepr, opAllowsEquality } = Sk.misceval;
     const { numberBinOp, typeName, buildNativeClass, checkArgsLen, objectHash, copyKeywordsToNamedArgs } = Sk.abstr;
     const { TypeError, ValueError, OverflowError, ZeroDivisionError, NotImplementedError, checkNumber, checkFloat, checkString, checkInt, asnum$, round } = Sk.builtin;
+    const intRound = (val) => round(val).nb$int(); // because python 2 returns a float.
     const binOp = numberBinOp;
 
     const str_auto = new pyStr("auto");
@@ -575,7 +576,7 @@ function $builtinmodule() {
                     const usdouble = binOp(secondsfrac, _1e6, "Mult");
 
                     if (checkFloat(microseconds)) {
-                        microseconds = round(binOp(microseconds, usdouble, "Add"));
+                        microseconds = intRound(binOp(microseconds, usdouble, "Add"));
                         [seconds, microseconds] = pyDivMod(microseconds, _1000000);
                         [days, seconds] = pyDivMod(seconds, secs_in_day);
                         d = binOp(d, days, "Add");
@@ -586,7 +587,7 @@ function $builtinmodule() {
                         [days, seconds] = pyDivMod(seconds, secs_in_day);
                         d = binOp(d, days, "Add");
                         s = binOp(s, seconds, "Add");
-                        microseconds = round(binOp(microseconds, usdouble, "Add"));
+                        microseconds = intRound(binOp(microseconds, usdouble, "Add"));
                     }
 
                     [seconds, us] = pyDivMod(microseconds, _1000000);
@@ -2116,7 +2117,7 @@ function $builtinmodule() {
                         throw new TypeError("a number is required, (got '" + typeName(t) + "'");
                     }
                     [frac, t] = modf(t); // todo check type
-                    let us = round(binOp(frac, _1e6, "Mult"));
+                    let us = intRound(binOp(frac, _1e6, "Mult"));
                     us = us.v;
                     t = t.v;
                     if (us >= 1000000) {

--- a/test/unit/test_datetime.py
+++ b/test/unit/test_datetime.py
@@ -1,0 +1,14 @@
+import unittest
+from datetime import timedelta
+from datetime import timezone
+
+#############################################################################
+
+class TestModule(unittest.TestCase):
+
+    def test_py2(self):
+        # see pr 1338
+        self.assertIs(timezone.utc, timezone(timedelta(0)))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Because in python2 rounding a float returns a float - it becomes a problem when we assert that certain values are python integers if we happen to be in python2 mode.


`timedelta(minutes=0)` will fail in python2 mode...
