### PR TITLE
fix bug #1345

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -677,7 +677,7 @@ Compiler.prototype.ccall = function (e) {
         // note that it's part of the js API spec: https://developer.mozilla.org/en/docs/Web/API/Window/self
         // so we should probably add self to the mangling
         // TODO: feel free to ignore the above
-        out("if (typeof self === \"undefined\" || self.toString().indexOf(\"Window\") > 0) { throw new Sk.builtin.RuntimeError(\"super(): no arguments\") };");
+        out("if (typeof self === \"undefined\" || self === Sk.global) { throw new Sk.builtin.RuntimeError(\"super(): no arguments\") };");
         positionalArgs = "[$gbl.__class__,self]";
     }
     out ("$ret = (",func,".tp$call)?",func,".tp$call(",positionalArgs,",",keywordArgs,") : Sk.misceval.applyOrSuspend(",func,",undefined,undefined,",keywordArgs,",",positionalArgs,");");

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -1,0 +1,28 @@
+"""Unit tests for zero-argument super() & related machinery."""
+
+import unittest
+
+
+class A:
+    def __init__(self, foo):
+        self.foo = foo
+    def __str__(self):
+
+        return f"{self.__class__.__name__}({self.foo})"
+
+class B(A):
+    def __init__(self, foo):
+        super().__init__(foo)
+
+
+class TestSuper(unittest.TestCase):
+    def test_bug_1345(self):
+        """defining a __str__ broke super"""
+        try:
+            B('foo')
+        except Exception:
+            self.fail("this shouldn't fail")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The bug happens becuase `__str__` gets called before the instance is instantiated. Because calling `toString` on a skulpt object calls it's repr.

(it's a 1 line change the rest are tests)

close #1345 