### PR TITLE
Ellipsis

### DIFF
--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -123,6 +123,8 @@ Sk.builtins = {
     "property"     : Sk.builtin.property,
     "classmethod"  : Sk.builtin.classmethod,
     "staticmethod" : Sk.builtin.staticmethod,
+
+    "Ellipsis": Sk.builtin.Ellipsis
 };
 
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -1047,7 +1047,7 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
         case Sk.astnodes.FormattedValue:
             return this.cformattedvalue(e);
         case Sk.astnodes.Ellipsis:
-            return this.makeConstant("Sk.builtin.ellipsis");
+            return this.makeConstant("Sk.builtin.Ellipsis");
         default:
             Sk.asserts.fail("unhandled case " + e.constructor.name + " vexpr");
     }

--- a/src/generic_alias.js
+++ b/src/generic_alias.js
@@ -173,7 +173,7 @@ Sk.builtin.GenericAlias = Sk.abstr.buildNativeClass("types.GenericAlias", {
             return module.toString() === "typing";
         },
         ga$repr(item) {
-            if (item === Sk.builtin.ellipsis) {
+            if (item === Sk.builtin.Ellipsis) {
                 return "...";
             }
             if (Sk.abstr.lookupSpecial(item, this.str$orig)) {

--- a/src/lib/types.py
+++ b/src/lib/types.py
@@ -83,7 +83,7 @@ except NameError:
 #     del tb
 
 SliceType = slice
-# EllipsisType = type(Ellipsis)
+EllipsisType = type(Ellipsis)
 
 # DictProxyType = type(TypeType.__dict__)
 NotImplementedType = type(NotImplemented)

--- a/src/nonetype.js
+++ b/src/nonetype.js
@@ -71,14 +71,14 @@ Sk.builtin.NotImplemented.NotImplemented$ = /** @type {Sk.builtin.NotImplemented
 }));
 
 
-const ellipsisType = Sk.abstr.buildNativeClass("ellipsis", {
+const EllipsisType = Sk.abstr.buildNativeClass("ellipsis", {
     constructor: function ellipsis() {
-        return Sk.builtin.ellipsis;
+        return Sk.builtin.Ellipsis;
     }, 
     slots : {
         tp$new(args, kwargs) {
             Sk.abstr.checkNoArgs("ellipsis", args, kwargs);
-            return Sk.builtin.ellipsis;
+            return Sk.builtin.Ellipsis;
         },
         $r() {
             return new Sk.builtin.str("Ellipsis");
@@ -89,4 +89,4 @@ const ellipsisType = Sk.abstr.buildNativeClass("ellipsis", {
     }
 });
 
-Sk.builtin.ellipsis = Object.create(ellipsisType.prototype, {v: { value: "..." }});
+Sk.builtin.Ellipsis = Object.create(EllipsisType.prototype, {v: { value: "..." }});


### PR DESCRIPTION
I didn't realise that Ellipsis were part of `__builtins__`
This pr puts `Ellipsis` in the skulpt builtindict.

It also changes the name of `Sk.builtin.ellipsis` -> `Sk.builtin.Ellipsis`.
I can't see this as breaking since it was only introduced 4 weeks ago.
Reason: In python the constant is `Ellipsis` and `type(Ellipsis)` is `ellipsis`.
