### PR TITLE
time.time() should be increasing

### DIFF
--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -10,24 +10,6 @@
 var $builtinmodule = function (name) {
     var mod = {};
 
-    var getTimeStamp = (function () {
-        const performance = Sk.global.performance;
-        // all modern browsers support performance (IE10+) but node does not without the use of require('perf_hooks');
-        const timeOrigin =
-            performance && (performance.timeOrigin || (performance.timing && performance.timing.navigationStart));
-        // timeOrigin is experimental but supported by all modern browsers except safari - https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin
-        // performance.timing.navigationStart is depracated but supported by all browsers - https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/navigationStart
-        if (performance && performance.now && timeOrigin) {
-            return function () {
-                return (timeOrigin + performance.now()) / 1000;
-            };
-        }
-        // fallback
-        return function () {
-            return Date.now() / 1000;
-        };
-    })();
-
     mod.__package__ = new Sk.builtin.str("");
 
     var struct_time_fields = {
@@ -68,7 +50,7 @@ var $builtinmodule = function (name) {
 
     mod.time = new Sk.builtin.func(function () {
         Sk.builtin.pyCheckArgsLen("time", arguments.length, 0, 0);
-        return new Sk.builtin.float_(getTimeStamp());
+        return new Sk.builtin.float_(Date.now() / 1000);
     });
 
     // This is an experimental implementation of time.sleep(), using suspensions


### PR DESCRIPTION
it's possible to get negative timestamp differences in skulpt
But all timestamps should really be monotonically increasing 
(unless the system time was changed between calls)

```python
from time import time
t = time()
for _ in range(1000):
  if time() < t:
    print('back in time!')
  t = time()
```

This pr fixes that with an implementation that entirely depends on the browser `performance` api.
(falling back to the `Date.now()` api if the `performance` api is not available)
The previous implementation combined the two apis which led to negative timings since the fractional offset was not accurate with respect to `Date.now()`.

I've added comments for browser compatibility links to mdn.
I haven't added additional tests since node doesn't support `performance` without a `require('perf_hooks')`.

---

I also replace `this` with `Sk.global` in a few places which I think is safer.
