### PR TITLE
update math test_prod with recent cpython changes

### DIFF
--- a/test/unit3/test_math.py
+++ b/test/unit3/test_math.py
@@ -1649,17 +1649,23 @@ class MathTests(unittest.TestCase):
         self.assertRaises(TypeError, prod)
         self.assertRaises(TypeError, prod, 42)
         self.assertRaises(TypeError, prod, ['a', 'b', 'c'])
-        self.assertRaises(TypeError, prod, ['a', 'b', 'c'], '')
-        self.assertRaises(TypeError, prod, [b'a', b'c'], b'')
+        self.assertRaises(TypeError, prod, ['a', 'b', 'c'], start='')
+        self.assertRaises(TypeError, prod, [b'a', b'c'], start=b'')
         # bytearray not implemented in Skulpt yet
         # values = [bytearray(b'a'), bytearray(b'b')]
-        # self.assertRaises(TypeError, prod, values, bytearray(b''))
+        # self.assertRaises(TypeError, prod, values, start=bytearray(b''))
         self.assertRaises(TypeError, prod, [[1], [2], [3]])
         self.assertRaises(TypeError, prod, [{2:3}])
-        self.assertRaises(TypeError, prod, [{2:3}]*2, {2:3})
-        self.assertRaises(TypeError, prod, [[1], [2], [3]], [])
+        self.assertRaises(TypeError, prod, [{2:3}]*2, start={2:3})
+        self.assertRaises(TypeError, prod, [[1], [2], [3]], start=[])
+
+        # Some odd cases
+        self.assertEqual(prod([2, 3], start='ab'), 'abababababab')
+        self.assertEqual(prod([2, 3], start=[1, 2]), [1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2])
+        self.assertEqual(prod([], start={2: 3}), {2:3})
+
         with self.assertRaises(TypeError):
-            prod([10, 20], [30, 40])     # start is a keyword-only argument
+            prod([10, 20], 1)     # start is a keyword-only argument
 
         self.assertEqual(prod([0, 1, 2, 3]), 0)
         self.assertEqual(prod([1, 0, 2, 3]), 0)
@@ -1714,7 +1720,7 @@ class MathTests(unittest.TestCase):
         self.assertEqual(type(prod(range(1, 10000), start=1.0)), float)
         # Decimal not implemented in Skulpt yet
         # self.assertEqual(type(prod([1, decimal.Decimal(2.0), 3, 4, 5, 6])),
-        #                 decimal.Decimal)
+                        #  decimal.Decimal)
 
     def testPerm(self):
         perm = math.perm


### PR DESCRIPTION
After #1369 cpython updated their tests in https://github.com/python/cpython/pull/28595

This pr updates our own set of prod tests to match.