### PR TITLE
Support a traceback for SuspensionErrors

### DIFF
--- a/src/misceval.js
+++ b/src/misceval.js
@@ -56,7 +56,19 @@ Sk.exportSymbol("Sk.misceval.Suspension", Sk.misceval.Suspension);
 Sk.misceval.retryOptionalSuspensionOrThrow = function (susp, message) {
     while (susp instanceof Sk.misceval.Suspension) {
         if (!susp.optional) {
-            throw new Sk.builtin.SuspensionError(message || "Cannot call a function that blocks or suspends here");
+            const err = new Sk.builtin.SuspensionError(message || "Cannot call a function that blocks or suspends here");
+            let prev_susp = susp;
+            const tb = [];
+            while (prev_susp != null) {
+                if (prev_susp.$lineno) {
+                    // compile code added attributes so fill the traceback
+                    tb.push({ filename: prev_susp.$filename, lineno: prev_susp.$lineno, colno: prev_susp.$colno });
+                }
+                prev_susp = prev_susp.child;
+            }
+            tb.reverse();
+            err.traceback.push(...tb);
+            throw err;
         }
         susp = susp.resume();
     }


### PR DESCRIPTION
With SuspensionErrors, we throw the error at the location where we couldn't handle a Suspension.
This might be incredibly frustrating to debug

e.g. 
```python
from time import sleep

def foo():
   sleep(.1)

class A:
   def __iter__(self):
        foo() # I block
        return iter([1,2,3])

a = A()
for _ in a:
# SuspensionError: you can't call a function that blocks or suspends here
    pass
```
If the user got an error at line 12 they'd have little idea how to deal with it.

But whenever a Suspension occurs in Python we have traceback information based on the child suspensions.
So we can fill our traceback with information that can then be reported to the user.

e.g.
```text
SuspensionError: Cannot call a function that blocks or suspends here
at Form1, line 4
called from Form1, line 8
called from Form1, line 12
```