### PR TITLE
dir: make it match cpython

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -921,6 +921,16 @@ Sk.abstr.lookupSpecial = function (obj, pyName) {
 };
 Sk.exportSymbol("Sk.abstr.lookupSpecial", Sk.abstr.lookupSpecial);
 
+Sk.abstr.lookupAttr = function (obj, pyName) {
+    try {
+        return obj.tp$getattr(pyName);
+    } catch (e) {
+        if (!(e instanceof Sk.builtin.AttributeError)) {
+            throw e;
+        }
+    }
+};
+
 
 Sk.abstr.typeLookup = function (type_obj, pyName) {
     const res = type_obj.$typeLookup(pyName);

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ Sk.builtin.str.$imag = new Sk.builtin.str("imag");
 Sk.builtin.str.$real = new Sk.builtin.str("real");
 
 Sk.builtin.str.$abs = new Sk.builtin.str("__abs__");
+Sk.builtin.str.$bases = new Sk.builtin.str("__bases__");
 Sk.builtin.str.$bytes = new Sk.builtin.str("__bytes__");
 Sk.builtin.str.$call = new Sk.builtin.str("__call__");
 Sk.builtin.str.$class = new Sk.builtin.str("__class__");

--- a/src/type.js
+++ b/src/type.js
@@ -754,35 +754,9 @@ Sk.builtin.type.prototype.tp$methods = /**@lends {Sk.builtin.type.prototype}*/ {
     },
     __dir__: {
         $meth: function __dir__() {
-            const seen = new Set();
-            const dir = [];
-            function push_or_continue(attr) {
-                if (attr in Sk.reservedWords_) {
-                    return;
-                }
-                attr = Sk.unfixReserved(attr);
-                if (attr.indexOf("$") !== -1) {
-                    return;
-                }
-                if (!seen.has(attr)) {
-                    seen.add(attr);
-                    dir.push(new Sk.builtin.str(attr));
-                }
-            }
-            if (this.prototype.sk$prototypical) {
-                for (let attr in this.prototype) {
-                    push_or_continue(attr);
-                }
-            } else {
-                const mro = this.prototype.tp$mro;
-                for (let i = 0; i < mro.length; i++) {
-                    const attrs = Object.getOwnPropertyNames(mro[i].prototype);
-                    for (let j = 0; j < attrs.length; j++) {
-                        push_or_continue(attrs[j]);
-                    }
-                }
-            }
-            return new Sk.builtin.list(dir);
+            const dict = new Sk.builtin.dict([]);
+            this.$mergeClassDict(dict);
+            return new Sk.builtin.list(dict.sk$asarray());
         },
         $flags: { NoArgs: true },
         $doc: "Specialized __dir__ implementation for types.",

--- a/test/unit3/test_descr.py
+++ b/test/unit3/test_descr.py
@@ -2493,10 +2493,8 @@ order (MRO) for bases """
         # del junk
 
         # Just make sure these don't blow up!
-        for arg in 2, 2, 2j, 2e0, [2], "2", (2,), {2:2}, type, self.test_dir:
+        for arg in 2, 2, 2j, 2e0, [2], "2", b"2", (2,), {2:2}, type, self.test_dir:
             dir(arg)
-        # for arg in 2, 2, 2j, 2e0, [2], "2", b"2", (2,), {2:2}, type, self.test_dir:
-        #     dir(arg)
 
         # Test dir on new-style classes.  Since these have object as a
         # base class, a lot more gets sucked in.
@@ -2553,34 +2551,32 @@ order (MRO) for bases """
         m2instance.b = 2
         m2instance.a = 1
         self.assertEqual(m2instance.__dict__, "Not a dict!")
-        try:
+        with self.assertRaises(TypeError):
             dir(m2instance)
-        except TypeError:
-            pass
 
         # Two essentially featureless objects, (Ellipsis just inherits stuff
         # from object.
-        # self.assertEqual(dir(object()), dir(Ellipsis))
+        self.assertEqual(dir(object()), dir(Ellipsis))
 
         # Nasty test case for proxied objects
-        # class Wrapper(object):
-        #     def __init__(self, obj):
-        #         self.__obj = obj
-        #     def __repr__(self):
-        #         return "Wrapper(%s)" % repr(self.__obj)
-        #     def __getitem__(self, key):
-        #         return Wrapper(self.__obj[key])
-        #     def __len__(self):
-        #         return len(self.__obj)
-        #     def __getattr__(self, name):
-        #         return Wrapper(getattr(self.__obj, name))
+        class Wrapper(object):
+            def __init__(self, obj):
+                self.__obj = obj
+            def __repr__(self):
+                return "Wrapper(%s)" % repr(self.__obj)
+            def __getitem__(self, key):
+                return Wrapper(self.__obj[key])
+            def __len__(self):
+                return len(self.__obj)
+            def __getattr__(self, name):
+                return Wrapper(getattr(self.__obj, name))
 
-        # class C(object):
-        #     def __getclass(self):
-        #         return Wrapper(type(self))
-        #     __class__ = property(__getclass)
+        class C(object):
+            def __getclass(self):
+                return Wrapper(type(self))
+            __class__ = property(__getclass)
 
-        # dir(C()) # This used to segfault
+        dir(C()) # This used to segfault
 
     def test_supers(self):
         # Testing super...


### PR DESCRIPTION
If you like reading c - here are the implementations that I was following

`type__dir__`:
https://github.com/python/cpython/blob/fea7290a0ecee09bbce571d4d10f5881b7ea3485/Objects/typeobject.c#L4280-L4291

`object__dir__`:
https://github.com/python/cpython/blob/fea7290a0ecee09bbce571d4d10f5881b7ea3485/Objects/typeobject.c#L5564-L5609

`merge_class_dict`:
https://github.com/python/cpython/blob/fea7290a0ecee09bbce571d4d10f5881b7ea3485/Objects/typeobject.c#L4215-L4267

It's probably a slower implementation - but looking up the `__dir__` is mostly for introspection.
It's also more correct - I was able to uncomment a test that would have previously failed.
It came up when overriding the `__dict__` property and discovered that cpython uses the return value from `__dict__`, rather than the internal dict attribute, when resolving the dir.