### PR TITLE
Fix nesting import chaining

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -495,7 +495,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
             var i;
             var fromName;
             var leafModule;
-            const chainedImports = [null];
+            var importChain;
 
             leafModule = Sk.sysmodules.mp$subscript(
                 new Sk.builtin.str((relativeToPackageName || "") +
@@ -508,13 +508,13 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
                 // "ret" is the module we're importing from
                 // Only import from file system if we have not found the fromName in the current module
                 if (fromName != "*" && leafModule.tp$getattr(new Sk.builtin.str(fromName)) === undefined) {
-                    chainedImports.push(() =>
+                    importChain = Sk.misceval.chain(importChain, () => 
                         Sk.importModuleInternal_(fromName, undefined, undefined, undefined, leafModule, true, true)
                     );
                 }
             }
 
-            return Sk.misceval.chain(...chainedImports, function () {
+            return Sk.misceval.chain(importChain, function() {
                 // if there's a fromlist we want to return the leaf module
                 // (ret), not the toplevel namespace
                 Sk.asserts.assert(leafModule);

--- a/src/import.js
+++ b/src/import.js
@@ -492,29 +492,26 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
         } else {
             // try to load from-names as modules from the file system
             // if they are not present on the module itself
-            var i;
-            var fromName;
-            var leafModule;
-            var importChain;
+            const chainedImports = [null];
 
-            leafModule = Sk.sysmodules.mp$subscript(
+            const leafModule = Sk.sysmodules.mp$subscript(
                 new Sk.builtin.str((relativeToPackageName || "") +
                     ((relativeToPackageName && name) ? "." : "") +
                     name));
 
-            for (i = 0; i < fromlist.length; i++) {
-                fromName = fromlist[i];
+            for (let i = 0; i < fromlist.length; i++) {
+                const fromName = fromlist[i];
 
                 // "ret" is the module we're importing from
                 // Only import from file system if we have not found the fromName in the current module
-                if (fromName != "*" && leafModule.tp$getattr(new Sk.builtin.str(fromName)) === undefined) {
-                    importChain = Sk.misceval.chain(importChain, () => 
+                if (fromName !== "*" && leafModule.tp$getattr(new Sk.builtin.str(fromName)) === undefined) {
+                    chainedImports.push(() =>
                         Sk.importModuleInternal_(fromName, undefined, undefined, undefined, leafModule, true, true)
                     );
                 }
             }
 
-            return Sk.misceval.chain(importChain, function() {
+            return Sk.misceval.chain(...chainedImports, function() {
                 // if there's a fromlist we want to return the leaf module
                 // (ret), not the toplevel namespace
                 Sk.asserts.assert(leafModule);

--- a/test/unit3/test_import/__init__.py
+++ b/test/unit3/test_import/__init__.py
@@ -69,7 +69,6 @@ class CircularImportTests(unittest.TestCase):
             "partially initialized module ",
             str(cm.exception)
         )
-        print(cm.exception)
         self.assertIn(".circular_imports.from_cycle1'", str(cm.exception))
         self.assertIn("(most likely due to a circular import)", str(cm.exception))
 


### PR DESCRIPTION
fix regression from #1419 

Javascript scoping rules meant that the formName was not scoped correctly
This Pr fixes that

(prior to #1419 we nested the call at each iteration, which meant we didn't need to worry about scoping in the same way)