### PR TITLE
Implement __import__

### DIFF
--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -43,6 +43,7 @@ Sk.builtins = {
     "ZeroDivisionError"  : Sk.builtin.ZeroDivisionError,
     "AssertionError"     : Sk.builtin.AssertionError,
     "ImportError"        : Sk.builtin.ImportError,
+    "ModuleNotFoundError": Sk.builtin.ModuleNotFoundError,
     "IndentationError"   : Sk.builtin.IndentationError,
     "IndexError"         : Sk.builtin.IndexError,
     "LookupError"        : Sk.builtin.LookupError,
@@ -128,6 +129,9 @@ Sk.builtins = {
     "Ellipsis": Sk.builtin.Ellipsis
 };
 
+const pyNone = Sk.builtin.none.none$;
+const emptyTuple = new Sk.builtin.tuple();
+const pyZero = new Sk.builtin.int_(0);
 
 Sk.abstr.setUpModuleMethods("builtins", Sk.builtins, {
     // __build_class__: {
@@ -138,11 +142,25 @@ Sk.abstr.setUpModuleMethods("builtins", Sk.builtins, {
     // },
 
     __import__: {
-        $meth: Sk.builtin.__import__,
-        $flags: { NamedArgs: ["name", "globals", "locals", "fromlist", "level"] },
+        $meth(name, globals, _locals, formlist, level) {
+            if (!Sk.builtin.checkString(name)) {
+                throw new Sk.builtin.TypeError("__import__() argument 1 must be str, not " + name.tp$name);
+            } else if (name === Sk.builtin.str.$empty && level.v === 0) {
+                throw new Sk.builtin.ValueError("Empty module name");
+            }
+            // check globals - locals is just ignored __import__
+            globals = globLocToJs(globals, "globals") || {};
+            formlist = Sk.ffi.remapToJs(formlist);
+            level = Sk.ffi.remapToJs(level);
+
+            return Sk.builtin.__import__(name, globals, undefined, formlist, level);
+        },
+        $flags: {
+            NamedArgs: ["name", "globals", "locals", "fromlist", "level"],
+            Defaults: [pyNone, pyNone, emptyTuple, pyZero],
+        },
         $textsig: null,
-        $doc:
-            "__import__(name, globals=None, locals=None, fromlist=(), level=0) -> module\n\nImport a module. Because this function is meant for use by the Python\ninterpreter and not for general use, it is better to use\nimportlib.import_module() to programmatically import a module.\n\nThe globals argument is only used to determine the context;\nthey are not modified.  The locals argument is unused.  The fromlist\nshould be a list of names to emulate ``from name import ...'', or an\nempty list to emulate ``import name''.\nWhen importing a module from a package, note that __import__('A.B', ...)\nreturns package A when fromlist is empty, but its submodule B when\nfromlist is not empty.  The level argument is used to determine whether to\nperform absolute or relative imports: 0 is absolute, while a positive number\nis the number of parent directories to search relative to the current module.",
+        $doc: "__import__(name, globals=None, locals=None, fromlist=(), level=0) -> module\n\nImport a module. Because this function is meant for use by the Python\ninterpreter and not for general use, it is better to use\nimportlib.import_module() to programmatically import a module.\n\nThe globals argument is only used to determine the context;\nthey are not modified.  The locals argument is unused.  The fromlist\nshould be a list of names to emulate ``from name import ...'', or an\nempty list to emulate ``import name''.\nWhen importing a module from a package, note that __import__('A.B', ...)\nreturns package A when fromlist is empty, but its submodule B when\nfromlist is not empty.  The level argument is used to determine whether to\nperform absolute or relative imports: 0 is absolute, while a positive number\nis the number of parent directories to search relative to the current module.",
     },
 
     abs: {

--- a/src/import.js
+++ b/src/import.js
@@ -319,7 +319,7 @@ Sk.importModuleInternal_ = function (name, dumpJS, modname, suppliedPyBody, rela
                 if (returnUndefinedOnTopLevelNotFound && !topLevelModuleToReturn) {
                     return undefined;
                 } else {
-                    throw new Sk.builtin.ImportError("No module named " + name);
+                    throw new Sk.builtin.ModuleNotFoundError("No module named " + Sk.misceval.objectRepr(new Sk.builtin.str(name)));
                 }
             }
 
@@ -424,6 +424,7 @@ Sk.importBuiltinWithBody = function (name, dumpJS, body, canSuspend) {
 Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
     //print("Importing: ", JSON.stringify(name), JSON.stringify(fromlist), level);
     //if (name == "") { debugger; }
+    name = name.toString();
 
     // Save the Sk.globals variable importModuleInternal_ may replace it when it compiles
     // a Python language module.
@@ -437,7 +438,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
     var relativeToPackageName;
     var relativeToPackageNames;
 
-    if (level === undefined) {
+    if (level == null) {
         level = Sk.__future__.absolute_import ? 0 : -1;
     }
 
@@ -447,7 +448,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
             // Trim <level> packages off the end
             relativeToPackageNames = relativeToPackageName.split(".");
             if (level-1 >= relativeToPackageNames.length) {
-                throw new Sk.builtin.ValueError("Attempted relative import beyond toplevel package");
+                throw new Sk.builtin.ImportError("Attempted relative import beyond toplevel package");
             }
             relativeToPackageNames.length -= level-1;
             relativeToPackageName = relativeToPackageNames.join(".");
@@ -457,7 +458,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist, level) {
     }
 
     if (level > 0 && relativeToPackage === undefined) {
-        throw new Sk.builtin.ValueError("Attempted relative import in non-package");
+        throw new Sk.builtin.ImportError("Attempted relative import in non-package");
     }
 
     var dottedName = name.split(".");

--- a/test/unit3/test_builtin.py
+++ b/test/unit3/test_builtin.py
@@ -72,6 +72,24 @@ class AttrTest(unittest.TestCase):
 
 class BuiltinTest(unittest.TestCase):
 
+    def test_import(self):
+        __import__('sys')
+        __import__('time')
+        __import__('string')
+        __import__(name='sys')
+        __import__(name='time', level=0)
+        self.assertRaises(ImportError, __import__, 'spamspam')
+        self.assertRaises(TypeError, __import__, 1, 2, 3, 4)
+        self.assertRaises(ValueError, __import__, '')
+        self.assertRaises(TypeError, __import__, 'sys', name='sys')
+        # Relative import outside of a package with no __package__ or __spec__ (bpo-37409).
+        self.assertRaises(ImportError, __import__, '',
+                            {'__package__': None, '__spec__': None, '__name__': '__main__'},
+                            locals={}, fromlist=('foo',), level=1)
+        # embedded null character
+        self.assertRaises(ModuleNotFoundError, __import__, 'string\x00')
+
+
     def test_abs(self):
         # int
         self.assertEqual(abs(0), 0)


### PR DESCRIPTION
tests taken from cpython

I think the the `__import__` implementation is fairly well tested since it's part of our compile code,
so really this pr just supports actually calling `__import__` from python code.
Which currently just breaks because it expects javascript types.

I do some type checking but also do the lazy thing of just remapping the objects to javascript since:
- from list should be a tuple/list of strings, and
- level should be an integer
