### PR TITLE
Changed TimeLimitError to TimeoutError in compile.js

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -221,7 +221,7 @@ Compiler.prototype.outputInterruptTest = function () { // Added by RNL
     if (Sk.execLimit !== null || Sk.yieldLimit !== null && this.u.canSuspend) {
         output += "var $dateNow = Date.now();";
         if (Sk.execLimit !== null) {
-            output += "if ($dateNow - Sk.execStart > Sk.execLimit) {throw new Sk.builtin.TimeLimitError(Sk.timeoutMsg())}";
+            output += "if ($dateNow - Sk.execStart > Sk.execLimit) {throw new Sk.builtin.TimeoutError(Sk.timeoutMsg())}";
         }
         if (Sk.yieldLimit !== null && this.u.canSuspend) {
             output += "if (!$waking && ($dateNow - Sk.lastYield > Sk.yieldLimit)) {";


### PR DESCRIPTION
Whenever my Python program times out, I get the following error: `ExternalError: TypeError: Sk.builtin.TimeLimitError is not a constructor on line undefined`. This happens because `TimeLimitError` has been changed to `TimeoutError`.

A very small change but this fixes the problem.