### PR TITLE
Fix: multiple class decorators applied in wrong order

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2562,7 +2562,7 @@ Compiler.prototype.cclass = function (s) {
 
     // apply decorators
 
-    for (let decorator of decos) {
+    for (let decorator of decos.reverse()) {
         out("$ret = Sk.misceval.callsimOrSuspendArray(", decorator, ", [$ret]);");
         this._checkSuspension();
     }


### PR DESCRIPTION
This fixes the order in which decorators are applied to classes.

Previously this was fixed for functions in #1149. The same fix is applied in this PR.

I also added a test for this, and extended the existing test for functions.
