### PR TITLE
fix property and super should be suspension aware

### DIFF
--- a/src/property_class_static.js
+++ b/src/property_class_static.js
@@ -39,14 +39,15 @@ Sk.builtin.property = Sk.abstr.buildNativeClass("property", {
         },
         tp$doc:
             "Property attribute.\n\n  fget\n    function to be used for getting an attribute value\n  fset\n    function to be used for setting an attribute value\n  fdel\n    function to be used for del'ing an attribute\n  doc\n    docstring\n\nTypical use is to define a managed attribute x:\n\nclass C(object):\n    def getx(self): return self._x\n    def setx(self, value): self._x = value\n    def delx(self): del self._x\n    x = property(getx, setx, delx, 'I'm the 'x' property.')\n\nDecorators make defining new properties or modifying existing ones easy:\n\nclass C(object):\n    @property\n    def x(self):\n        'I am the 'x' property.'\n        return self._x\n    @x.setter\n    def x(self, value):\n        self._x = value\n    @x.deleter\n    def x(self):\n        del self._x",
-        tp$descr_get(obj, type) {
+        tp$descr_get(obj, type, canSuspend) {
             if (obj === null) {
                 return this;
             }
             if (this.prop$get === undefined) {
                 throw new Sk.builtin.AttributeError("unreadable attribute");
             }
-            return Sk.misceval.callsimOrSuspendArray(this.prop$get, [obj]);
+            const rv = Sk.misceval.callsimOrSuspendArray(this.prop$get, [obj]);
+            return canSuspend ? rv : Sk.misceval.retryOptionalSuspensionOrThrow(rv);
         },
         tp$descr_set(obj, value) {
             let func;
@@ -140,7 +141,7 @@ Sk.builtin.classmethod = Sk.abstr.buildNativeClass("classmethod", {
         },
         tp$doc:
             "classmethod(function) -> method\n\nConvert a function to be a class method.\n\nA class method receives the class as implicit first argument,\njust like an instance method receives the instance.\nTo declare a class method, use this idiom:\n\n  class C:\n      @classmethod\n      def f(cls, arg1, arg2, ...):\n          ...\n\nIt can be called either on the class (e.g. C.f()) or on an instance\n(e.g. C().f()).  The instance is ignored except for its class.\nIf a class method is called for a derived class, the derived class\nobject is passed as the implied first argument.\n\nClass methods are different than C++ or Java static methods.\nIf you want those, see the staticmethod builtin.",
-        tp$descr_get(obj, type) {
+        tp$descr_get(obj, type, canSuspend) {
             const callable = this.cm$callable;
             if (callable === undefined) {
                 throw new Sk.builtin.RuntimeError("uninitialized classmethod object");
@@ -150,7 +151,7 @@ Sk.builtin.classmethod = Sk.abstr.buildNativeClass("classmethod", {
             }
             const f = callable.tp$descr_get;
             if (f) {
-                return f.call(callable, type);
+                return f.call(callable, type, canSuspend);
             }
             return new Sk.builtin.method(callable, type);
         },

--- a/src/super.js
+++ b/src/super.js
@@ -92,14 +92,15 @@ Sk.builtin.super_ = Sk.abstr.buildNativeClass("super", {
                 i++;
             }
         },
-        tp$descr_get(obj, obtype) {
+        tp$descr_get(obj, obtype, canSuspend) {
             if (obj === null || this.obj != null) {
                 return this;
             }
             if (this.ob$type !== Sk.builtin.super_) {
                 /* If su is an instance of a (strict) subclass of super,
                 call its type */
-                return Sk.misceval.callsimOrSuspendArray(this.ob$type, [this.type, obj]);
+                const rv = Sk.misceval.callsimOrSuspendArray(this.ob$type, [this.type, obj]);
+                return canSuspend ? rv : Sk.misceval.retryOptionalSuspensionOrThrow(rv);
             } else {
                 /* Inline the common case */
                 const obj_type = this.$supercheck(this.type, obj);


### PR DESCRIPTION
Not particularly easy to add tests for this since python attribute access, when compiled to javascript, checks for suspensions

But it will be an issue for any internal code that expects `tp$gettattr` or `Sk.abstr.gattr` to not suspend unexpectedly.
