### PR TITLE
If feedback passed to assertRegex, use that for failed tests instead …

### DIFF
--- a/src/lib/unittest/__init__.py
+++ b/src/lib/unittest/__init__.py
@@ -191,8 +191,9 @@ class TestCase(object):
             expected_regex = re.compile(expected_regex)
         if not expected_regex.search(text):
             res = False
-            feedback = "Regex didn't match: %r not found in %r" % (
-                repr(expected_regex), text)
+            if feedback == "":
+                feedback = "Regex didn't match: %r not found in %r" % (
+                    repr(expected_regex), text)
         else:
             res = True
         self.appendResult(res, text, expected_regex, feedback)


### PR DESCRIPTION
…of auto generated string

Standardizes with other asserts. 

Especially for use in contexts like Runestone, it is important to be able to specify novice readable feedback messages.