### PR TITLE
fix bad variable declaration in compile code.

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2073,15 +2073,13 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         } else {
             this.u.varDeclsCode += "\nvar $args = this.$resolveArgs($posargs,$kwargs)\n";
         }
-        const sup_i = kwarg ? 1 : 0;
-        let supDeclare = "";
         for (let i = 0; i < funcArgs.length; i++) {
-            if (i === sup_i) {
-                supDeclare = `,$sup=${funcArgs[i]}`;
-            }
             this.u.varDeclsCode += "," + funcArgs[i] + "=$args[" + i + "]";
         }
-        this.u.varDeclsCode += supDeclare;
+        const instanceForSuper = funcArgs[kwarg ? 1 : 0];
+        if (instanceForSuper) {
+            this.u.varDeclsCode += `,$sup=${instanceForSuper}`;
+        }
         this.u.varDeclsCode += ";\n";
     }
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -2074,10 +2074,14 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
             this.u.varDeclsCode += "\nvar $args = this.$resolveArgs($posargs,$kwargs)\n";
         }
         const sup_i = kwarg ? 1 : 0;
+        let supDeclare = "";
         for (let i = 0; i < funcArgs.length; i++) {
-            const sup = i === sup_i ? "$sup = " : "";
-            this.u.varDeclsCode += "," + sup + funcArgs[i] + "=$args[" + i + "]";
+            if (i === sup_i) {
+                supDeclare = `,$sup=${funcArgs[i]}`;
+            }
+            this.u.varDeclsCode += "," + funcArgs[i] + "=$args[" + i + "]";
         }
+        this.u.varDeclsCode += supDeclare;
         this.u.varDeclsCode += ";\n";
     }
 


### PR DESCRIPTION
Fix a bug from recent PRs

In a previous PR we declared a variable for the instance that would be passed to `super()`
(previous to that PR the instance to `super()` was always assumed to be variable named `self` but it could easily be `cls` for a classmethod).

But the compile code ended up with a bug
```js
var $sup = self = args[0], ...;
```
Now fixed to be
```js
var self = args[0], ..., $sup = self;
```

The former overrides the global self - i.e. window.self! 😬
The latter uses the locally scoped self ☑️