### PR TITLE
fix frozenset has a non-writable property

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -532,10 +532,7 @@ Sk.builtin.frozenset = Sk.abstr.buildNativeClass("frozenset", {
     ),
 });
 
-Sk.builtin.frozenset.$emptyset = Object.create(Sk.builtin.frozenset.prototype, {
-    v: { value: new Sk.builtin.dict([]), enumerable: true },
-    in$repr: { value: false, enumerable: true },
-});
+Sk.builtin.frozenset.$emptyset = new Sk.builtin.frozenset([]);
 
 Sk.exportSymbol("Sk.builtin.frozenset", Sk.builtin.frozenset);
 


### PR DESCRIPTION
printing a frozenset causes an error since the `in$repr` property was non writable.
This pr fixes that.