### PR TITLE
Fix/suspension dunders

### DIFF
--- a/src/slotdefs.js
+++ b/src/slotdefs.js
@@ -464,11 +464,13 @@ slots.__getattribute__ = {
         if (!Sk.builtin.checkString(pyName)) {
             throw new Sk.builtin.TypeError("attribute name must be string, not '" + Sk.abstr.typeName(pyName) + "'");
         }
-        const res = this.call(self, pyName);
-        if (res === undefined) {
-            throw new Sk.builtin.AttributeError(Sk.abstr.typeName(self) + " has no attribute " + pyName.$jsstr());
-        }
-        return res;
+        const res = this.call(self, pyName, true);
+        return Sk.misceval.chain(res, (res) => {
+            if (res === undefined) {
+                throw new Sk.builtin.AttributeError(Sk.abstr.typeName(self) + " has no attribute " + pyName.$jsstr());
+            }
+            return res;
+        });
     },
     $textsig: "($self, name, /)",
     $flags: { OneArg: true },

--- a/src/slotdefs.js
+++ b/src/slotdefs.js
@@ -124,9 +124,11 @@ function wrapperRichCompare(self, args, kwargs) {
 }
 
 function wrapperCallBack(wrapper, callback, canSuspend) {
-    return function (self,args, kwargs) {
+    return function (self, args, kwargs) {
         const res = wrapper.call(this, self, args, kwargs);
-        return canSuspend ? Sk.misceval.chain(res, callback) : callback(res);
+        return canSuspend
+            ? Sk.misceval.chain(res, callback)
+            : callback(Sk.misceval.retryOptionalSuspensionOrThrow(res));
     };
 }
 
@@ -918,8 +920,7 @@ slots.__contains__ = {
             return res;
         };
     },
-    // todo - allow for suspensions - but no internal functions suspend here
-    $wrapper: wrapperCallBack(wrapperCallOneArg, (res) => new Sk.builtin.bool(res)),
+    $wrapper: wrapperCallBack(wrapperCallOneArgSuspend, (res) => new Sk.builtin.bool(res), true),
     $textsig: "($self, key, /)",
     $flags: { OneArg: true },
     $doc: "Return key in self.",

--- a/test/unit3/test_suspensions.py
+++ b/test/unit3/test_suspensions.py
@@ -31,6 +31,16 @@ class SleepingDunderFail:
         sleep(0.01)
         return iter([0, 1, 2])
 
+class SleepingObjectGetatttr:
+    @property
+    def _foo(self):
+        sleep(.01)
+        return "foo"
+
+    @property
+    def foo(self):
+        return object.__getattribute__(self, "_foo")
+
 class Test_Suspensions(unittest.TestCase):
     def test_min_max(self):
         x = [4, 1, 5]
@@ -85,6 +95,9 @@ class Test_Suspensions(unittest.TestCase):
                 pass
         self.assertIn("Cannot call a function that blocks or suspends", str(e.exception))
         self.assertTrue(repr(e.exception).startswith("SuspensionError"))
+    
+    def test_suspension_bug_getattribute(self):
+        self.assertEqual(SleepingObjectGetatttr().foo, "foo")
 
 
 

--- a/test/unit3/test_suspensions.py
+++ b/test/unit3/test_suspensions.py
@@ -97,7 +97,9 @@ class Test_Suspensions(unittest.TestCase):
         self.assertTrue(repr(e.exception).startswith("SuspensionError"))
     
     def test_suspension_bug_getattribute(self):
-        self.assertEqual(SleepingObjectGetatttr().foo, "foo")
+        obj = SleepingObjectGetatttr()
+        self.assertEqual(obj.foo, "foo")
+        self.assertEqual(SleepingObjectGetatttr._foo.__get__(obj, None), "foo")
 
 
 


### PR DESCRIPTION
A couple of dunders were not entirely suspension aware.

This is mostly ok, because skulpt doesn't use suspensions for these internally - e.g. a skulpt dictionary never suspends.

However it's not great for user code with a `@property` decorator
and anything that calls `object.__getattribute__` in a way that might lead to a suspension.
I added tests for these two cases that failed.

I also added suspension awareness to the other dunders that can take a `canSuspend` argument.
These can't be tested internally because we don't have native classes that care about suspension for say the `__len__`/`sq$length`.
But it's feasible others might want to make use of suspensions in this way.