### PR TITLE
Always provide the second argument to `tp$descr_get`

### DIFF
--- a/src/slotdefs.js
+++ b/src/slotdefs.js
@@ -121,7 +121,7 @@ function wrapperCallBack(wrapper, callback) {
  */
 function slotFuncNoArgs(dunderFunc) {
     return function () {
-        const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) : dunderFunc;
+        const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) : dunderFunc;
         return Sk.misceval.callsimArray(func, []);
     };
 }
@@ -136,7 +136,7 @@ function slotFuncNoArgs(dunderFunc) {
 function slotFuncNoArgsWithCheck(dunderName, checkFunc, checkMsg, f) {
     return function (dunderFunc) {
         return function () {
-            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) : dunderFunc;
+            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) : dunderFunc;
             let res = Sk.misceval.callsimArray(func, []);
             if (!checkFunc(res)) {
                 throw new Sk.builtin.TypeError(dunderName + " should return " + checkMsg + " (returned " + Sk.abstr.typeName(res) + ")");
@@ -152,7 +152,7 @@ function slotFuncNoArgsWithCheck(dunderName, checkFunc, checkMsg, f) {
 
 function slotFuncOneArg(dunderFunc) {
     return function (value) {
-        const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) : dunderFunc;
+        const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) : dunderFunc;
         return Sk.misceval.callsimArray(func, [value]);
     };
 }
@@ -164,7 +164,7 @@ function slotFuncGetAttribute(pyName, canSuspend) {
         return getattributeFn.d$wrapped.call(this, pyName, canSuspend);
     }
     if (getattributeFn.tp$descr_get) {
-        getattributeFn = getattributeFn.tp$descr_get(this);
+        getattributeFn = getattributeFn.tp$descr_get(this, this.ob$type);
     }
     const ret = Sk.misceval.tryCatch(
         () => Sk.misceval.callsimOrSuspendArray(getattributeFn, [pyName]),
@@ -181,7 +181,7 @@ function slotFuncGetAttribute(pyName, canSuspend) {
 
 function slotFuncFastCall(dunderFunc) {
     return function (args, kwargs) {
-        const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) : dunderFunc;
+        const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) : dunderFunc;
         return Sk.misceval.callsimOrSuspendArray(func, args, kwargs);
     };
 }
@@ -270,7 +270,7 @@ Sk.slots.__init__ = {
     $slot_name: "tp$init",
     $slot_func: function (dunderFunc) {
         return function tp$init(args, kwargs) {
-            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) : dunderFunc;
+            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) : dunderFunc;
             let ret = Sk.misceval.callsimOrSuspendArray(func, args, kwargs);
             return Sk.misceval.chain(ret, (r) => {
                 if (!Sk.builtin.checkNone(r) && r !== undefined) {
@@ -441,7 +441,7 @@ slots.__getattribute__ = {
                             return val;
                         }
                         if (getattrFn.tp$descr_get) {
-                            getattrFn = getattrFn.tp$descr_get(this);
+                            getattrFn = getattrFn.tp$descr_get(this, this.ob$type);
                         }
                         return Sk.misceval.callsimOrSuspendArray(getattrFn, [pyName]);
                     },
@@ -561,7 +561,7 @@ slots.__get__ = {
             if (obtype == null) {
                 obtype = Sk.builtin.none.none$;
             }
-            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) :  dunderFunc;
+            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) :  dunderFunc;
             const ret = Sk.misceval.callsimOrSuspendArray(func, [obj, obtype]);
             return canSuspend ? ret : Sk.misceval.retryOptionalSuspensionOrThrow(ret);
         };
@@ -762,7 +762,7 @@ slots.__next__ = {
     $slot_name: "tp$iternext",
     $slot_func: function (dunderFunc) {
         return function tp$iternext(canSuspend) {
-            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) :  dunderFunc;
+            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) :  dunderFunc;
             const ret = Sk.misceval.tryCatch(
                 () => Sk.misceval.callsimOrSuspendArray(func, []),
                 (e) => {
@@ -850,7 +850,7 @@ slots.__len__ = {
     $slot_func: function (dunderFunc) {
         return function sq$length(canSuspend) {
             let res;
-            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) :  dunderFunc;
+            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) :  dunderFunc;
             if (canSuspend) {
                 res = Sk.misceval.callsimOrSuspendArray(func, []);
                 return Sk.misceval.chain(res, (r) => {
@@ -884,7 +884,7 @@ slots.__contains__ = {
     $slot_name: "sq$contains",
     $slot_func: function (dunderFunc) {
         return function sq$contains(key, canSuspend) {
-            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) :  dunderFunc;
+            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) :  dunderFunc;
             let res = Sk.misceval.callsimOrSuspendArray(func, [key]);
             res = Sk.misceval.chain(res, (r) => Sk.misceval.isTrue(r));
             if (res.$isSuspension) {
@@ -915,7 +915,7 @@ slots.__getitem__ = {
     $slot_name: "mp$subscript",
     $slot_func: function (dunderFunc) {
         return function mp$subscript(key, canSuspend) {
-            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) :  dunderFunc;
+            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) :  dunderFunc;
             const ret = Sk.misceval.callsimOrSuspendArray(func, [key]);
             return canSuspend ? ret : Sk.misceval.retryOptionalSuspensionOrThrow(ret);
         };
@@ -1647,7 +1647,7 @@ slots.__pow__ = {
     $slot_name: "nb$power",
     $slot_func: function (dunderFunc) {
         return function (value, mod) {
-            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this) :  dunderFunc;
+            const func = dunderFunc.tp$descr_get ? dunderFunc.tp$descr_get(this, this.ob$type) :  dunderFunc;
             if (mod == undefined) {
                 return Sk.misceval.callsimArray(func, [value]);
             } else {


### PR DESCRIPTION
For internal calls to `tp$descr_get` we should send both the instance and the type argument.

Whilst most builtins that use `__get__` cope without the second argument, it's possible that a custom `__get__` will expect it to be there.
(I found this recently with another library).

Quite a small change, I don't think it really needs any additional tests since the call signature to `__get__` is typically `def __get__(self, __obj: Any, __type: type | None = None) -> Any:`

