### PR TITLE
Fix/keyword repeats

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -685,32 +685,6 @@ Compiler.prototype.ccall = function (e) {
     let positionalArgs = this.cunpackstarstoarray(e.args, !Sk.__future__.python3);
     let keywordArgs = this.cunpackkwstoarray(e.keywords, func);
 
-    if (e.keywords && e.keywords.length > 0) {
-        let hasStars = false;
-        kwarray = [];
-        for (let kw of e.keywords) {
-            if (hasStars && !Sk.__future__.python3) {
-                throw new Sk.builtin.SyntaxError("Advanced unpacking of function arguments is not supported in Python 2");
-            }
-            if (kw.arg) {
-                kwarray.push("'" + kw.arg.v + "'");
-                kwarray.push(this.vexpr(kw.value));
-            } else {
-                hasStars = true;
-            }
-        }
-        keywordArgs = "[" + kwarray.join(",") + "]";
-        if (hasStars) {
-            keywordArgs = this._gr("keywordArgs", keywordArgs);
-            for (let kw of e.keywords) {
-                if (!kw.arg) {
-                    out("$ret = Sk.abstr.mappingUnpackIntoKeywordArray(",keywordArgs,",",this.vexpr(kw.value),",",func,");");
-                    this._checkSuspension();
-                }
-            }
-        }
-    }
-
     if (Sk.__future__.super_args && e.func.id && e.func.id.v === "super" && positionalArgs === "[]") {
         // make sure there is a self variable
         // note that it's part of the js API spec: https://developer.mozilla.org/en/docs/Web/API/Window/self

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -23,6 +23,23 @@ class TestSuper(unittest.TestCase):
         except Exception:
             self.fail("this shouldn't fail")
 
+class TestRegressions(unittest.TestCase):
+    def test_bug_1470(self):
+        global i
+        i = 0
+
+        def g():
+            global i
+            i += 1
+        
+        def f(x):
+            pass
+
+        f(x=g())
+
+        self.assertEqual(i, 1)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
close #1470 

Probably the result of a bad rebase
Removes duplicate code

The exact code removed was refactored into `this.cunpackkwstoarray`, so ends up being called twice.