### PR TITLE
Minor tweak to copyKeywordsToNamedArgs

### DIFF
--- a/src/abstract.js
+++ b/src/abstract.js
@@ -619,7 +619,7 @@ Sk.abstr.copyKeywordsToNamedArgs = function (func_name, varnames, args, kwargs, 
     args = args.slice(0); // make a copy of args
 
     for (let i = 0; i < kwargs.length; i += 2) {
-        const name = kwargs[i]; // JS string
+        const name = kwargs[i].toString(); // JS string but account for python string
         const value = kwargs[i + 1]; // Python value
         const idx = varnames.indexOf(name);
 


### PR DESCRIPTION
I had some code where a python string leaked into a keyword array when it should have been a javascript string
This tweak accounts for that leak

The leak itself was our own doing, but it's probably best to handle it nicely.
