### PR TITLE
fix: error message with an index that's too large

### DIFF
--- a/src/tuple.js
+++ b/src/tuple.js
@@ -82,7 +82,7 @@ Sk.builtin.tuple = Sk.abstr.buildNativeClass("tuple", {
         // sequence and mapping slots
         mp$subscript(index) {
             if (Sk.misceval.isIndex(index)) {
-                let i = Sk.misceval.asIndexSized(index);
+                let i = Sk.misceval.asIndexSized(index, Sk.builtin.IndexError);
                 if (i < 0) {
                     i = this.v.length + i;
                 }


### PR DESCRIPTION
Hard to test exactly since it will still throw an IndexError, but the message is corrected in this PR

```python
>>> x = (1, 2, 3, 4)
>>> x[2**75]
IndexError: cannot fit 'int' into an index-sized integer
```

This PR brings tuple.js inline with what's already there in list.js

If an error class isn't supplied to `asIndexSized` then then if the index is too large it will be returned as `±Number.MAX_SAFE_INTEGER`.
So this PR doesn't change the ultimately thrown IndexError, but it does fix the error message, since it gets thrown on line 85 rather than a few lines later.

