### PR TITLE
string interning: don't do it - rely on compiled constants

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -1072,7 +1072,7 @@ function ast_for_call(c, n, func, allowgen)
                 key = e.id;
                 for (k = 0; k < nkeywords; k++) {
                     tmp = keywords[k].arg;
-                    if (tmp && tmp === key) {
+                    if (tmp && tmp.v === key.v) {
                         ast_error(c, chch,
                                 "keyword argument repeated");
                         return NULL;

--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -146,7 +146,7 @@ Sk.abstr.setUpModuleMethods("builtins", Sk.builtins, {
         $meth(name, globals, _locals, formlist, level) {
             if (!Sk.builtin.checkString(name)) {
                 throw new Sk.builtin.TypeError("__import__() argument 1 must be str, not " + name.tp$name);
-            } else if (name === Sk.builtin.str.$empty && level.v === 0) {
+            } else if (name.v === "" && level.v === 0) {
                 throw new Sk.builtin.ValueError("Empty module name");
             }
             // check globals - locals is just ignored __import__

--- a/src/function.js
+++ b/src/function.js
@@ -32,11 +32,12 @@ Sk.builtin.func = Sk.abstr.buildNativeClass("function", {
         this.func_code = code;
         this.func_globals = globals || null;
 
-        this.$name = (code.co_name && code.co_name.v) || code.name || "<native JS>";
+        // use python str to preserve identity from compilation
+        this.$name = code.co_name || new Sk.builtin.str(code.name || "<native JS>");
         this.$d = Sk.builtin.dict ? new Sk.builtin.dict() : undefined;
         this.$doc = code.co_docstring || Sk.builtin.none.none$;
         this.$module = (Sk.globals && Sk.globals["__name__"]) || Sk.builtin.none.none$;
-        this.$qualname = (code.co_qualname && code.co_qualname.v) || this.$name;
+        this.$qualname = code.co_qualname || this.$name;
 
         if (closure2 !== undefined) {
             // todo; confirm that modification here can't cause problems
@@ -73,13 +74,13 @@ Sk.builtin.func = Sk.abstr.buildNativeClass("function", {
     getsets: {
         __name__: {
             $get() {
-                return new Sk.builtin.str(this.$name);
+                return this.$name;
             },
             $set(value) {
                 if (!Sk.builtin.checkString(value)) {
                     throw new Sk.builtin.TypeError("__name__ must be set to a string object");
                 }
-                this.$name = value.$jsstr();
+                this.$name = value;
             },
         },
         __qualname__: {
@@ -90,7 +91,7 @@ Sk.builtin.func = Sk.abstr.buildNativeClass("function", {
                 if (!Sk.builtin.checkString(value)) {
                     throw new Sk.builtin.TypeError("__qualname__ must be set to a string object");
                 }
-                this.$qualname = value.$jsstr();
+                this.$qualname = value;
             },
         },
         __dict__: Sk.generic.getSetDict,

--- a/src/generic_alias.js
+++ b/src/generic_alias.js
@@ -15,7 +15,7 @@ Sk.builtin.GenericAlias = Sk.abstr.buildNativeClass("types.GenericAlias", {
         },
         tp$getattr(pyName, canSuspend) {
             if (Sk.builtin.checkString(pyName)) {
-                if (!this.attr$exc.includes(pyName)) {
+                if (!this.attr$exc.includes(pyName.v)) {
                     return this.$origin.tp$getattr(pyName, canSuspend);
                 }
             }
@@ -202,6 +202,6 @@ Sk.builtin.GenericAlias = Sk.abstr.buildNativeClass("types.GenericAlias", {
             "__mro_entries__",
             "__reduce_ex__", // needed so we don't look up object.__reduce_ex__
             "__reduce__",
-        ].map((x) => new Sk.builtin.str(x)),
+        ],
     },
 });

--- a/src/lib/collections.js
+++ b/src/lib/collections.js
@@ -1050,7 +1050,8 @@ function collections_mod(collections) {
                 const offset = start >= 0 ? start : start < -size ? 0 : size + start;
                 stop = stop >= 0 ? stop : stop < -size ? 0 : size + stop;
                 for (let i = offset; i < stop; i++) {
-                    if (list[(head + i) & mask] === x) {
+                    const v = list[(head + i) & mask];
+                    if (v === x || Sk.misceval.richCompareBool(v, x, "Eq")) {
                         return i;
                     }
                 }

--- a/src/lib/datetime.js
+++ b/src/lib/datetime.js
@@ -1034,7 +1034,7 @@ function $builtinmodule() {
                         if (!checkString(fmt)) {
                             throw new TypeError("must be str, not " + typeName(fmt));
                         }
-                        if (fmt !== pyStr.$empty) {
+                        if (fmt.v !== "") {
                             return this.tp$getattr(str_strftime).tp$call([fmt]);
                         }
                         return this.tp$str();
@@ -1433,7 +1433,7 @@ function $builtinmodule() {
                         if (!checkString(fmt)) {
                             throw new TypeError("must be str, not " + typeName(fmt));
                         }
-                        if (fmt !== pyStr.$empty) {
+                        if (fmt.v !== "") {
                             return this.tp$getattr(str_strftime).tp$call([fmt]);
                         }
                         return this.tp$str();

--- a/src/object.js
+++ b/src/object.js
@@ -129,7 +129,7 @@ Sk.builtin.object = Sk.abstr.buildNativeClass("object", {
             $meth(format_spec) {
                 if (!Sk.builtin.checkString(format_spec)) {
                     throw new Sk.builtin.TypeError("__format__() argument must be str, not " + Sk.abstr.typeName(format_spec));
-                } else if (format_spec !== Sk.builtin.str.$empty) {
+                } else if (format_spec.v !== "") {
                     throw new Sk.builtin.TypeError(`unsupported format string passed to ${Sk.abstr.typeName(this)}.__format__`);
                 }
                 return this.tp$str();

--- a/src/super.js
+++ b/src/super.js
@@ -57,7 +57,7 @@ Sk.builtin.super_ = Sk.abstr.buildNativeClass("super", {
             const n = mro.length;
             /* We want __class__ to return the class of the super object
             (i.e. super, or a subclass), not the class of su->obj. */
-            if (pyName === Sk.builtin.str.$class) {
+            if (pyName.v === "__class__") {
                 return Sk.generic.getAttr.call(this, pyName, canSuspend);
             }
             /* No need to check the last one: it's gonna be skipped anyway.  */


### PR DESCRIPTION
Motivation:
str interning for a long running python program could use a lot of memory
our current implementation is also not quite the same as cpython

Our constants are cached during compilation so tests that look for compiled str identity will still work
I actually didn't need to change any tests here.

I adjusted places where we rely on str identity in the code base

This reliance also meant implementing `tp$hash` for `Sk.builtin.str`
(The python 2.7 [implementation](https://github.com/python/cpython/blob/2.7/Objects/unicodeobject.c#L6654) is much easier to follow so I used that)

I adjusted the internals of `$name` for `Sk.builtin.func` to be a python string.
There was a test for this in `test_functools` that expected `__name__` to be identical after wrapping



