### PR TITLE
fractions module

### DIFF
--- a/src/builtin/sys.js
+++ b/src/builtin/sys.js
@@ -75,21 +75,21 @@ var $builtinmodule = function (name) {
     });
 
     const float_info_fields = {
-        "max": "DBL_MAX -- maximum representable finite float",
-        "max_exp": "DBL_MAX_EXP -- maximum int e such that radix**(e-1) is representable",
-        "max_10_exp": "DBL_MAX_10_EXP -- maximum int e such that 10**e is representable",
-        "min": "DBL_MIN -- Minimum positive normalized float",
-        "min_exp": "DBL_MIN_EXP -- minimum int e such that radix**(e-1) is a normalized float",
-        "min_10_exp": "DBL_MIN_10_EXP -- minimum int e such that 10**e is a normalized",
-        "dig": "DBL_DIG -- digits",
-        "mant_dig": "DBL_MANT_DIG -- mantissa digits",
-        "epsilon": "DBL_EPSILON -- Difference between 1 and the next representable float",
-        "radix": "FLT_RADIX -- radix of exponent",
-        "rounds": "FLT_ROUNDS -- rounding mode"
+        max: "DBL_MAX -- maximum representable finite float",
+        max_exp: "DBL_MAX_EXP -- maximum int e such that radix**(e-1) is representable",
+        max_10_exp: "DBL_MAX_10_EXP -- maximum int e such that 10**e is representable",
+        min: "DBL_MIN -- Minimum positive normalized float",
+        min_exp: "DBL_MIN_EXP -- minimum int e such that radix**(e-1) is a normalized float",
+        min_10_exp: "DBL_MIN_10_EXP -- minimum int e such that 10**e is a normalized",
+        dig: "DBL_DIG -- digits",
+        mant_dig: "DBL_MANT_DIG -- mantissa digits",
+        epsilon: "DBL_EPSILON -- Difference between 1 and the next representable float",
+        radix: "FLT_RADIX -- radix of exponent",
+        rounds: "FLT_ROUNDS -- rounding mode",
     };
     
-    const float_info_type = Sk.builtin.make_structseq('sys', 'float_info', float_info_fields);
-    sys.float_info = new float_info_type([
+    const FloatInfoType = Sk.builtin.make_structseq("sys", "float_info", float_info_fields);
+    sys.float_info = new FloatInfoType([
         Number.MAX_VALUE,
         Math.floor(Math.log2(Number.MAX_VALUE)),
         Math.floor(Math.log10(Number.MAX_VALUE)),
@@ -101,14 +101,35 @@ var $builtinmodule = function (name) {
         Number.EPSILON,
         2,
         1,
-    ].map(x => Sk.ffi.remapToPy(x)))
+    ].map(x => Sk.ffi.remapToPy(x)));
 
     const int_info_fields = {
         bits_per_digit: "size of a digit in bits",
         sizeof_digit: "size in bytes of the C type used to represent a digit"
-    }
-    const int_info_type = Sk.builtin.make_structseq('sys', 'int_info', int_info_fields);
-    sys.int_info = new int_info_type([30, 4].map((x) => Sk.ffi.remapToPy(x)));
+    };
+    const IntInfoType = Sk.builtin.make_structseq("sys", "int_info", int_info_fields);
+    sys.int_info = new IntInfoType([30, 4].map((x) => Sk.ffi.remapToPy(x)));
+
+    const hash_info_fields = {
+        width: "width of the type used for hashing, in bits",
+        modulus: "prime number giving the modulus on which the hash function is based",
+        inf: "value to be used for hash of a positive infinity",
+        nan: "value to be used for hash of a nan",
+        imag: "multiplier used for the imaginary part of a complex number",
+        algorithm: "name of the algorithm for hashing of str, bytes and memoryviews",
+        hash_bits: "internal output size of hash algorithm",
+        seed_bits: "seed size of hash algorithm",
+        cutoff: "small string optimization cutoff",
+    };
+
+    const HashInfoType = Sk.builtin.make_structseq("sys", "hash_info", hash_info_fields);
+
+    sys.hash_info = new HashInfoType(
+        [64, JSBI.BigInt("2305843009213693951"), 314159, 0, 1000003, "siphash24", 64, 128, 0].map((x) =>
+            Sk.ffi.remapToPy(x)
+        )
+    );
+
 
     sys.__stdout__ = new Sk.builtin.file(new Sk.builtin.str("/dev/stdout"), new Sk.builtin.str("w"));
     sys.__stdin__ = new Sk.builtin.file(new Sk.builtin.str("/dev/stdin"), new Sk.builtin.str("r"));

--- a/src/builtin/sys.js
+++ b/src/builtin/sys.js
@@ -124,10 +124,9 @@ var $builtinmodule = function (name) {
 
     const HashInfoType = Sk.builtin.make_structseq("sys", "hash_info", hash_info_fields);
 
+    // not the same as CPYTHON - we want modulo to be a prime < Number.MAX_SAFE_INTEGER
     sys.hash_info = new HashInfoType(
-        [64, JSBI.BigInt("2305843009213693951"), 314159, 0, 1000003, "siphash24", 64, 128, 0].map((x) =>
-            Sk.ffi.remapToPy(x)
-        )
+        [32, 536870911, 314159, 0, 1000003, "siphash24", 32, 128, 0].map((x) => Sk.ffi.remapToPy(x))
     );
 
 

--- a/src/complex.js
+++ b/src/complex.js
@@ -106,7 +106,12 @@ Sk.builtin.complex = Sk.abstr.buildNativeClass("complex", {
             }
             return power.call(this, other);
         },
-
+        nb$reflected_power(other, z) {
+            if (z != null && !Sk.builtin.checkNone(z)) {
+                throw new Sk.builtin.ValueError("complex modulo");
+            }
+            return reflected_power.call(this, other);
+        },
         nb$abs() {
             const _real = this.real;
             const _imag = this.imag;
@@ -645,14 +650,16 @@ function divide(a_real, a_imag, b_real, b_imag) {
     return new Sk.builtin.complex(real, imag);
 }
 
-const power = complexNumberSlot((a_real, a_imag, b_real, b_imag) => {
+const _pow = (a_real, a_imag, b_real, b_imag) => {
     const int_exponent = b_real | 0; // js convert to int
     if (b_imag === 0.0 && b_real === int_exponent) {
         return c_powi(a_real, a_imag, int_exponent);
     } else {
         return c_pow(a_real, a_imag, b_real, b_imag);
     }
-});
+};
+const power = complexNumberSlot(_pow);
+const reflected_power = complexNumberSlot((a_real, a_imag, b_real, b_imag) => _pow(b_real, b_imag, a_real, a_imag));
 
 // power of complex a and complex exponent b
 function c_pow(a_real, a_imag, b_real, b_imag) {

--- a/src/float.js
+++ b/src/float.js
@@ -49,7 +49,7 @@ Sk.builtin.float_ = Sk.abstr.buildNativeClass("float", {
                 m = -m;
             }
 
-            let x = 0;
+            let x = 0, y;
             while (m) {
                 x = ((x << 28) & _HASH_MOD) | x >> (_HASH_BITS - 28);
                 m *= 268435456; // 2 ** 28

--- a/src/float.js
+++ b/src/float.js
@@ -1,10 +1,10 @@
 /** @typedef {Sk.builtin.object} */ var pyObject;
 
-const hashMap = Object.create(null, {
-    Infinity: { value: 314159 },
-    "-Infinity": { value: -314159 },
-    NaN: { value: 0 },
-});
+// should match sys.hash_info
+const _HASH_INF = 314159;
+const _HASH_NAN = 0;
+const _HASH_BITS = 29;
+const _HASH_MOD = (1 << 29) - 1;
 
 /**
  * @constructor
@@ -36,16 +36,38 @@ Sk.builtin.float_ = Sk.abstr.buildNativeClass("float", {
         tp$doc: "Convert a string or number to a floating point number, if possible.",
         tp$hash() {
             const v = this.v;
-            let hash = hashMap[v];
-            if (hash !== undefined) {
-                return hash;
-            } else if (Number.isInteger(v)) {
-                hash = this.nb$int().tp$hash();
-            } else {
-                hash = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER - Number.MAX_SAFE_INTEGER / 2);
+            if (!Number.isFinite(v)) {
+                if (Number.isNaN(v)) {
+                    return _HASH_NAN;
+                }
+                return v > 0 ? _HASH_INF : -_HASH_INF;
             }
-            hashMap[this.v] = hash;
-            return hash;
+            let [m, e] = frexp(v);
+            let sign = 1;
+            if (m < 0) {
+                sign = -1;
+                m = -m;
+            }
+
+            let x = 0;
+            while (m) {
+                x = ((x << 28) & _HASH_MOD) | x >> (_HASH_BITS - 28);
+                m *= 268435456; // 2 ** 28
+                e -= 28;
+                y = Math.trunc(m); // pull out integer part
+                m -= y;
+                x += y;
+                if (x >= _HASH_MOD) {
+                    x -= _HASH_MOD;
+                }
+            }
+            e = e >= 0 ? e % _HASH_BITS : _HASH_BITS-1-((-1-e) % _HASH_BITS);
+            x = ((x << e) & _HASH_MOD) | (x >> (_HASH_BITS - e));
+            x *= sign;
+            if (x === -1) {
+                return -2;
+            }
+            return x;
         },
         $r() {
             return new Sk.builtin.str(this.str$(10, true));

--- a/src/float.js
+++ b/src/float.js
@@ -485,7 +485,8 @@ function remainder(v, w) {
 
 function power(v, w) {
     if (v < 0 && w % 1 !== 0) {
-        throw new Sk.builtin.ValueError("negative number cannot be raised to a fractional power");
+        // let complex deal with it - like CPython does
+        return new Sk.builtin.complex(v, 0).nb$power(new Sk.builtin.complex(w, 0));
     }
     if (v === 0 && w < 0) {
         throw new Sk.builtin.ZeroDivisionError("0.0 cannot be raised to a negative power");

--- a/src/float.js
+++ b/src/float.js
@@ -474,7 +474,7 @@ function remainder(v, w) {
         return new Sk.builtin.float_(0);
     }
     if (w === Infinity) {
-        if (v === Infinity || this.v === -Infinity) {
+        if (v === Infinity || v === -Infinity) {
             return new Sk.builtin.float_(NaN);
         } else if (v > 0) {
             return new Sk.builtin.float_(v);

--- a/src/int.js
+++ b/src/int.js
@@ -41,8 +41,18 @@ Sk.builtin.int_ = Sk.abstr.buildNativeClass("int", {
             return new Sk.builtin.str(this.v.toString());
         },
         tp$hash() {
-            const v = this.v;
-            return typeof v === "number" ? v : JSBI.toNumber(JSBI.remainder(v, JSBI.__MAX_SAFE));
+            let v = this.v;
+            if (typeof v === "number") {
+                if (v === -1) {
+                    return -2;
+                }
+                if (v < NUM_HASH_MOD && v > NEG_NUM_HASH_MOD) {
+                    return v;
+                }
+                v = bigUp(v);
+            }
+            const rv = JSBI.toNumber(JSBI.remainder(v, BIG_HASH_MODULUS));
+            return rv === -1 ? -2 : rv;
         },
         tp$new(args, kwargs) {
             let x, base;
@@ -198,7 +208,7 @@ Sk.builtin.int_ = Sk.abstr.buildNativeClass("int", {
                 if (ret !== undefined) {
                     return ret.nb$remainder(mod);
                 }
-                return new Sk.builtin.int_(JSBI.powermod(bigUp(v), bigUp(w), bigUp(mod.v)));
+                return new Sk.builtin.int_(JSBI.numberIfSafe(JSBI.powermod(bigUp(v), bigUp(w), bigUp(mod.v))));
             }
             // if we're here then we've fallen through so do bigint exponentiate
             return new Sk.builtin.int_(JSBI.exponentiate(bigUp(v), bigUp(w)));
@@ -522,6 +532,9 @@ function cloneSelf() {
     return new Sk.builtin.int_(this.v);
 }
 
+const NUM_HASH_MOD = 536870911;
+const NEG_NUM_HASH_MOD = -536870911;
+const BIG_HASH_MODULUS = JSBI.BigInt("536870911");
 const DBL_MANT_DIG = Math.log2(Number.MAX_SAFE_INTEGER);
 const DBL_MAX_EXP = JSBI.BigInt(Math.floor(Math.log2(Number.MAX_VALUE)));
 const DBL_MIN_EXP = Math.ceil(Math.log2(Number.MIN_VALUE));

--- a/src/int.js
+++ b/src/int.js
@@ -218,6 +218,14 @@ Sk.builtin.int_ = Sk.abstr.buildNativeClass("int", {
             },
             $doc: "the imaginary part of a complex number",
         },
+        numerator: {
+            $get: cloneSelf,
+        },
+        denominator: {
+            $get() {
+                return INT_ONE;
+            }
+        }
     },
     classmethods: {
         from_bytes: {
@@ -986,6 +994,7 @@ for (let i = -5; i < 257; i++) {
     INTERNED_INT[i] = Object.create(Sk.builtin.int_.prototype, {v: {value: i}});
 }
 const INT_ZERO = INTERNED_INT[0];
+const INT_ONE = INTERNED_INT[1];
 
 // from_bytes and to_bytes
 function isLittleEndian(byteorder) {

--- a/src/lib/fractions.js
+++ b/src/lib/fractions.js
@@ -1,4 +1,3 @@
-// @ts-check
 function $builtinmodule(name) {
     const mods = {};
 
@@ -514,6 +513,7 @@ function fractionsMod({ math, sys }) {
                     return this.$den;
                 },
             },
+            // seems silly really but it gets tested
             _numerator: {
                 $get() {
                     return this.$num;

--- a/src/lib/fractions.js
+++ b/src/lib/fractions.js
@@ -1,0 +1,504 @@
+// @ts-check
+function $builtinmodule(name) {
+    const mods = {};
+
+    return Sk.misceval.chain(
+        Sk.importModule("math", false, true),
+        (mathMod) => {
+            mods.math = mathMod;
+            return Sk.importModule("sys", false, true);
+        },
+        (sysMod) => {
+            mods.sys = sysMod;
+            return fractionsMod(mods);
+        }
+    );
+}
+
+function fractionsMod({math, sys}) {
+    const {
+        builtin: {
+            int_: pyInt,
+            bool: { true$: pyTrue },
+            none: { none$: pyNone },
+            NotImplemented: { NotImplemented$: pyNotImplemented },
+            tuple: pyTuple,
+            float_: pyFloat,
+            complex: pyComplex,
+            str: pyStr,
+            isinstance: pyIsInstance,
+            TypeError: pyTypeError,
+            ZeroDivisionError: pyZeroDivisionError,
+            ValueError: pyValueError,
+            NotImplementedError: pyNotImplementedError,
+            abs: pyAbs,
+            round: pyRound,
+            power: pyPower,
+        },
+        ffi: { remapToPy: toPy },
+        abstr: { buildNativeClass, copyKeywordsToNamedArgs, numberBinOp, typeName, lookupSpecial, checkArgsLen },
+        misceval: { isTrue, richCompareBool, callsimArray: pyCall, objectRepr },
+    } = Sk;
+
+    const fractionsMod = { __name__: new pyStr("fractions"), __all__: toPy(["Fraction"]) };
+
+    const _RATIONAL_FORMAT =
+        /^\s*(?<sign>[-+]?)(?=\d|\.\d)(?<num>\d*)(?:(?:\/(?<denom>\d+))?|(?:\.(?<decimal>\d*))?(?:E(?<exp>[-+]?\d+))?)\s*$/i;
+    const _0 = new pyInt(0);
+    const _1 = new pyInt(1);
+    const _2 = new pyInt(2);
+    const _10 = new pyInt(10);
+    const _neg_1 = new pyInt(-1);
+    const _neg_2 = new pyInt(-2);
+    const s_numerator = new pyStr("numerator");
+    const s_denominator = new pyStr("denominator");
+    const s_int_ratio = new pyStr("as_integer_ratio");
+    const s_from_float = new pyStr("from_float");
+
+    const getNumer = (x) => x.tp$getattr(s_numerator);
+    const getDenom = (x) => x.tp$getattr(s_denominator);
+
+    const mul = (a, b) => numberBinOp(a, b, "Mult");
+    const div = (a, b) => numberBinOp(a, b, "Div");
+    const pow = (a, b) => numberBinOp(a, b, "Pow");
+    const add = (a, b) => numberBinOp(a, b, "Add");
+    const sub = (a, b) => numberBinOp(a, b, "Sub");
+    const floorDiv = (a, b) => numberBinOp(a, b, "FloorDiv");
+    const divmod = (a, b) => numberBinOp(a, b, "DivMod");
+    const mod = (a, b) => numberBinOp(a, b, "Mod");
+    const gcd = math.tp$getattr(new pyStr("gcd"));
+
+    const eq = (a, b) => richCompareBool(a, b, "Eq");
+    const lt = (a, b) => richCompareBool(a, b, "Lt");
+    const ge = (a, b) => richCompareBool(a, b, "GtE");
+
+    const METH_NO_ARGS = { NoArgs: true };
+    const METH_ONE_ARG = { OneArg: true };
+
+    const hash_info = sys.tp$getattr(new pyStr("hash_info"));
+    const _PyHASH_MODULUS = hash_info.tp$getattr(new pyStr("modulus"));
+    const _PyHASH_INF = hash_info.tp$getattr(new pyStr("inf"));
+
+    function _operator_fallbacks(monomorphic, fallback) {
+        const forward = function (other) {
+            if (isTrue(pyIsInstance(other, _NUMBERS_RATIONAL))) {
+                return monomorphic(this, other);
+            } else if (other instanceof pyFloat) {
+                return fallback(this.nb$float(), other);
+            } else if (other instanceof pyComplex) {
+                return fallback(pyCall(pyComplex, [this]), other);
+            } else {
+                return pyNotImplemented;
+            }
+        };
+        const reverse = function (other) {
+            if (isTrue(pyIsInstance(other, _NUMBERS_RATIONAL))) {
+                return monomorphic(other, this);
+            } else if (other instanceof pyFloat) {
+                return fallback(other, this.nb$float());
+            } else if (other instanceof pyComplex) {
+                return fallback(other, pyCall(pyComplex, [this]));
+            } else {
+                return pyNotImplemented;
+            }
+        };
+        return [forward, reverse];
+    }
+
+    const [nb$add, nb$reflected_add] = _operator_fallbacks((a, b) => {
+        const da = getDenom(a);
+        const db = getDenom(b);
+        return pyCall(Fraction, [add(mul(getNumer(a), db), mul(getNumer(b), da)), mul(da, db)]);
+    }, add);
+
+    const [nb$subtract, nb$reflected_subtract] = _operator_fallbacks((a, b) => {
+        const da = getDenom(a);
+        const db = getDenom(b);
+        return pyCall(Fraction, [sub(mul(getNumer(a), db), mul(getNumer(b), da)), mul(da, db)]);
+    }, sub);
+
+    const [nb$multiply, nb$reflected_multiply] = _operator_fallbacks(
+        (a, b) => pyCall(Fraction, [mul(getNumer(a), getNumer(b)), mul(getDenom(a), getDenom(b))]),
+        mul
+    );
+
+    const [nb$divide, nb$reflected_divide] = _operator_fallbacks(
+        (a, b) => pyCall(Fraction, [mul(getNumer(a), getDenom(b)), mul(getDenom(a), getNumer(b))]),
+        div
+    );
+
+    const [nb$floor_divide, nb$reflected_floor_divide] = _operator_fallbacks(
+        (a, b) => floorDiv(mul(getNumer(a), getDenom(b)), mul(getDenom(a), getNumer(b))),
+        floorDiv
+    );
+
+    const [nb$divmod, nb$reflected_divmod] = _operator_fallbacks((a, b) => {
+        const da = getDenom(a);
+        const db = getDenom(b);
+        const [div, n_mod] = divmod(mul(getNumer(a), db), mul(da, getNumer(b))).valueOf();
+        return new pyTuple([div, pyCall(Fraction, [n_mod, mul(da, db)])]);
+    }, divmod);
+
+    const [nb$remainder, nb$reflected_remainder] = _operator_fallbacks((a, b) => {
+        const da = getDenom(a);
+        const db = getDenom(b);
+        const num = mod(mul(getNumer(a), db), mul(getNumer(b), da));
+        return pyCall(Fraction, [num, mul(da, db)]);
+    }, mod);
+
+    const Fraction = (fractionsMod.Fraction = buildNativeClass("fractions.Fraction", {
+        constructor: function (numerator, denominator) {
+            this.$num = numerator || _0;
+            this.$den = denominator || _1;
+        },
+        slots: {
+            tp$new(args, kws) {
+                checkArgsLen("Fraction", args, 0, 2);
+
+                let [numerator, denominator, _normalize] = copyKeywordsToNamedArgs(
+                    "Fraction",
+                    ["numerator", "denominator", "_normalize"],
+                    args,
+                    kws,
+                    [_0, pyNone, pyTrue]
+                );
+
+                const self = new this.constructor();
+
+                if (denominator === pyNone) {
+                    if (numerator.ob$type === pyInt) {
+                        self.$num = numerator;
+                        self.$den = _1;
+                        return self;
+                    } else if (isTrue(pyIsInstance(numerator, _NUMBERS_RATIONAL))) {
+                        self.$num = getNumer(numerator);
+                        self.$den = getDenom(numerator);
+                        return self;
+                    } else if (numerator instanceof pyFloat) {
+                        // todo decimal.Decimal
+                        [self.$num, self.$den] = pyCall(numerator.tp$getattr(s_int_ratio)).valueOf();
+                        return self;
+                    } else if (numerator instanceof pyStr) {
+                        const s = numerator.toString();
+                        const m = s.match(_RATIONAL_FORMAT);
+                        if (m === null) {
+                            throw new pyValueError("Invalid literal for Fraction: " + objectRepr(numerator));
+                        }
+                        numerator = new pyInt(m.groups.num || "0");
+                        const denom = m.groups.denom;
+                        if (denom) {
+                            denominator = new pyInt(denom);
+                        } else {
+                            denominator = _1;
+                            const decimal = m.groups.decimal;
+                            if (decimal) {
+                                const scale = new pyInt("" + 10 ** decimal.length);
+                                numerator = add(mul(numerator, scale), new pyInt(decimal));
+                                denominator = mul(denominator, scale);
+                            }
+                            let exp = m.groups.exp;
+                            if (exp) {
+                                exp = new pyInt(exp);
+                                if (lt(exp, _0)) {
+                                    denominator = mul(denominator, pow(_10, exp.nb$negative()));
+                                } else {
+                                    numerator = mul(numerator, pow(_10, exp));
+                                }
+                            }
+                        }
+                        if (m.groups.sign == "-") {
+                            numerator = numerator.nb$negative();
+                        }
+                    } else {
+                        throw new pyTypeError("argument should be a string or a Rational instance");
+                    }
+                } else if (numerator.ob$type === pyInt && denominator.ob$type === pyInt) {
+                    // normal case pass
+                } else if (
+                    isTrue(pyIsInstance(numerator, _NUMBERS_RATIONAL)) &&
+                    isTrue(pyIsInstance(denominator, _NUMBERS_RATIONAL))
+                ) {
+                    [numerator, denominator] = [
+                        mul(getNumer(numerator), getDenom(denominator)),
+                        mul(getNumer(denominator), getDenom(numerator)),
+                    ];
+                } else {
+                    throw new pyTypeError("both arguments should be Rational instances");
+                }
+
+                if (eq(denominator, _0)) {
+                    throw new pyZeroDivisionError(`Fraction(${numerator}, 0)`);
+                }
+                if (isTrue(_normalize)) {
+                    let g = pyCall(gcd, [numerator, denominator]);
+                    if (lt(denominator, _0)) {
+                        g = g.nb$negative();
+                    }
+                    numerator = floorDiv(numerator, g);
+                    denominator = floorDiv(denominator, g);
+                }
+
+                self.$num = numerator;
+                self.$den = denominator;
+                return self;
+            },
+            $r() {
+                const name = lookupSpecial(this.ob$type, pyStr.$name);
+                return new pyStr(`${name}(${this.$num}, ${this.$den})`);
+            },
+            tp$str() {
+                if (eq(this.$den, _1)) {
+                    return new pyStr(this.$num);
+                }
+                return new pyStr(`${this.$num}/${this.$den}`);
+            },
+            tp$hash() {
+                const dinv = pyPower(this.$den, sub(_PyHASH_MODULUS, 2), _PyHASH_MODULUS);
+                let hash_;
+                if (!isTrue(dinv)) {
+                    hash_ = _PyHASH_INF;
+                } else {
+                    hash_ = mod(mul(pyAbs(this.$num), dinv), _PyHASH_MODULUS);
+                }
+                const rv = ge(this, _0) ? hash_ : hash_.nb$negative();
+                return eq(rv, _neg_1) ? _neg_2 : rv;
+            },
+            tp$richcompare(other, OP) {
+                const op = (a, b) => richCompareBool(a, b, OP);
+
+                if (OP === "Eq" || OP == "NotEq") {
+                    if (other.ob$type === pyInt) {
+                        const rv = eq(this.$num, other) && eq(this.$den, _1);
+                        return OP === "Eq" ? rv : !rv;
+                    }
+                    if (other instanceof Fraction || other instanceof pyInt) {
+                        const rv = eq(this.$num, getNumer(other)) && eq(this.$den, getDenom(other));
+                        return OP === "Eq" ? rv : !rv;
+                    }
+                    if (other instanceof pyComplex) {
+                        if (eq(other.tp$getattr(new pyStr("imag")), _0)) {
+                            other = other.tp$getattr(new pyStr("real"));
+                        }
+                    }
+                }
+
+                if (isTrue(pyIsInstance(other, _NUMBERS_RATIONAL))) {
+                    return op(mul(getNumer(this), getDenom(other)), mul(getDenom(this), getNumer(other)));
+                }
+                if (other instanceof pyFloat) {
+                    if (!Number.isFinite(other.valueOf())) {
+                        return op(new pyFloat(0), other);
+                    } else {
+                        return op(this, pyCall(this.tp$getattr(s_from_float), [other]));
+                    }
+                }
+                return pyNotImplemented;
+            },
+
+            tp$as_number: true,
+            nb$add,
+            nb$reflected_add,
+            nb$subtract,
+            nb$reflected_subtract,
+            nb$multiply,
+            nb$reflected_multiply,
+            nb$divide,
+            nb$reflected_divide,
+            nb$floor_divide,
+            nb$reflected_floor_divide,
+            nb$divmod,
+            nb$reflected_divmod,
+            nb$remainder,
+            nb$reflected_remainder,
+            nb$power(other) {
+                if (isTrue(pyIsInstance(other, _NUMBERS_RATIONAL))) {
+                    if (eq(getDenom(other), _1)) {
+                        let power = getNumer(other);
+                        if (ge(power, _0)) {
+                            return pyCall(Fraction, [pow(this.$num, power), pow(this.$den, power)]);
+                        } else if (ge(this.$num, _0)) {
+                            power = power.nb$negative();
+                            return pyCall(Fraction, [pow(this.$den, power), pow(this.$num, power)]);
+                        } else {
+                            power = power.nb$negative();
+                            return pyCall(Fraction, [
+                                pow(this.$den.nb$negative(), power),
+                                pow(this.$num.nb$negative(), power),
+                            ]);
+                        }
+                    } else {
+                        return pow(this.nb$float(), pyCall(pyFloat, [other]));
+                    }
+                } else {
+                    return pow(this.nb$float(), other);
+                }
+            },
+            nb$reflected_power(other) {
+                if (eq(this.$den, _1) && ge(this.$num, _0)) {
+                    return pow(other, this.$num);
+                }
+
+                if (isTrue(pyIsInstance(other, _NUMBERS_RATIONAL))) {
+                    return pow(new Fraction(getNumer(other), getDenom(other)), this);
+                }
+
+                if (eq(this.$den, _1)) {
+                    return pow(other, this.$num);
+                }
+
+                return pow(other, this.nb$float());
+            },
+            nb$positive() {
+                return new Fraction(this.$num, this.$den);
+            },
+            nb$negative() {
+                return new Fraction(this.$num.nb$negative(), this.$den);
+            },
+            nb$abs() {
+                return new Fraction(this.$num.nb$abs(), this.$den);
+            },
+            nb$bool() {
+                return this.$num.nb$bool();
+            },
+            nb$float() {
+                return div(this.$num, this.$den);
+            },
+        },
+        methods: {
+            as_integer_ratio: {
+                $meth() {
+                    return new pyTuple([this.$num, this.$den]);
+                },
+                $flags: METH_NO_ARGS,
+            },
+            limit_denominator: {},
+            __trunc__: {
+                $meth() {
+                    if (lt(this.$num, _0)) {
+                        return floorDiv(this.$num.nb$negative(), this.$den).nb$negative();
+                    } else {
+                        return floorDiv(this.$num, this.$den);
+                    }
+                },
+                $flags: METH_NO_ARGS,
+            },
+            __floor__: {
+                $meth() {
+                    return floorDiv(this.$num, this.$den);
+                },
+                $flags: METH_NO_ARGS,
+            },
+            __ceil__: {
+                $meth() {
+                    return floorDiv(this.$num.nb$negative(), this.$den).nb$negative();
+                },
+                $flags: METH_NO_ARGS,
+            },
+            __round__: {
+                $meth(ndigits) {
+                    if (ndigits === pyNone) {
+                        const [floor, rem] = divmod(this.$num, this.$den).valueOf();
+                        const doub = mul(rem, _2);
+                        if (lt(doub, this.$den)) {
+                            return floor;
+                        } else if (lt(this.$den, doub)) {
+                            return add(floor, _1);
+                        } else if (eq(mod(floor, _2), _0)) {
+                            return floor;
+                        } else {
+                            return add(floor, _1);
+                        }
+                    }
+
+                    const shift = pow(_10, pyAbs(ndigits));
+
+                    if (lt(_0, ndigits)) {
+                        return pyCall(Fraction, [pyRound(mul(this, shift)), shift]);
+                    } else {
+                        return pyCall(Fraction, [mul(pyRound(div(this, shift)), shift)]);
+                    }
+                },
+                $flags: { NamedArgs: ["ndigits"], Defaults: [pyNone] },
+            },
+            __reduce__: {
+                $meth() {
+                    return new pyTuple([this.ob$type, new pyTuple([new pyStr(this)])]);
+                },
+                $flags: METH_NO_ARGS,
+            },
+            __copy__: {
+                $meth() {
+                    if (this.ob$type === Fraction) {
+                        return this;
+                    }
+                    return pyCall(this.ob$type, [this.$num, this.$den]);
+                },
+                $flags: METH_NO_ARGS,
+            },
+            __deepcopy__: {
+                $meth(_memo) {
+                    if (this.ob$type === Fraction) {
+                        return this;
+                    }
+                    return pyCall(this.ob$type, [this.$num, this.$den]);
+                },
+                $flags: METH_ONE_ARG,
+            },
+        },
+        classmethods: {
+            from_float: {
+                $meth(f) {
+                    if (f instanceof pyInt) {
+                        return pyCall(this, [f]);
+                    } else if (!(f instanceof pyFloat)) {
+                        throw new pyTypeError(
+                            `${typeName(this)}.from_float() only takes floats, not ${objectRepr(f)}, (${typeName(f)})`
+                        );
+                    } else {
+                        const [num, den] = pyCall(f.tp$getattr(s_int_ratio)).valueOf();
+                        return pyCall(this, [num, den]);
+                    }
+                },
+                $flags: METH_ONE_ARG,
+            },
+            from_decimal: {
+                $meth() {
+                    throw pyNotImplementedError("from_decimal not yet implemented in SKulpt");
+                },
+                $flags: METH_ONE_ARG,
+            },
+        },
+        getsets: {
+            numerator: {
+                $get() {
+                    return this.$num;
+                },
+            },
+            denominator: {
+                $get() {
+                    return this.$den;
+                },
+            },
+            _numerator: {
+                $get() {
+                    return this.$num;
+                },
+                $set(v) {
+                    this.$num = v;
+                },
+            },
+            _denominator: {
+                $get() {
+                    return this.$den;
+                },
+                $set(v) {
+                    this.$den = v;
+                },
+            },
+        },
+    }));
+
+    const _NUMBERS_RATIONAL = new pyTuple([pyInt, Fraction]);
+
+    return fractionsMod;
+}

--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -1,7 +1,7 @@
 const $builtinmodule = function (name) {
 
     const {
-        builtin: { str: pyStr, float_: pyFloat, TypeError: pyTypeError, pyCheckType, checkNumber },
+        builtin: { str: pyStr, int_: pyInt, float_: pyFloat, TypeError: pyTypeError, pyCheckType, checkNumber },
         abstr: { lookupSpecial },
         misceval: { callsimOrSuspendArray: pyCallOrSuspend },
     } = Sk;
@@ -30,7 +30,7 @@ const $builtinmodule = function (name) {
         } else {
             _x = x.v;
         }
-        return new pyFloat(Math.ceil(_x));
+        return new pyInt(Math.ceil(_x));
     };
 
     function comb(n, k) {
@@ -149,7 +149,7 @@ const $builtinmodule = function (name) {
             pyCheckType("x", "number", checkNumber(x));
             _x = Sk.builtin.asnum$(x);
         }
-        return new pyFloat(Math.floor(_x));
+        return new pyInt(Math.floor(_x));
     };
 
     function fmod(x, y) {

--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -1,4 +1,11 @@
 const $builtinmodule = function (name) {
+
+    const {
+        builtin: { str: pyStr, float_: pyFloat, TypeError: pyTypeError, pyCheckType, checkNumber },
+        abstr: { lookupSpecial },
+        misceval: { callsimOrSuspendArray: pyCallOrSuspend },
+    } = Sk;
+
     const math = {
         // Mathematical Constants
         pi: new Sk.builtin.float_(Math.PI),
@@ -9,13 +16,21 @@ const $builtinmodule = function (name) {
     };
 
     // Number-theoretic and representation functions
+    const s_ceil = new pyStr("__ceil__");
+
     function ceil(x) {
-        Sk.builtin.pyCheckType("", "real number", Sk.builtin.checkNumber(x));
-        const _x = Sk.builtin.asnum$(x);
-        if (Sk.__future__.ceil_floor_int) {
-            return new Sk.builtin.int_(Math.ceil(_x));
+        let _x;
+        if (x.ob$type !== pyFloat) {
+            const method = lookupSpecial(x, s_ceil);
+            if (method !== undefined) {
+                return pyCallOrSuspend(method);
+            }
+            pyCheckType("", "real number", checkNumber(x));
+            _x = Sk.builtin.asnum$(x);
+        } else {
+            _x = x.v;
         }
-        return new Sk.builtin.float_(Math.ceil(_x));
+        return new pyFloat(Math.ceil(_x));
     };
 
     function comb(n, k) {
@@ -120,14 +135,21 @@ const $builtinmodule = function (name) {
         }
     };
 
+    const s_floor = new pyStr("__floor__");
+
     function floor(x) {
-        Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
-
-        if (Sk.__future__.ceil_floor_int) {
-            return new Sk.builtin.int_(Math.floor(Sk.builtin.asnum$(x)));
+        let _x;
+        if (x.ob$type === pyFloat) {
+            _x = x.v;
+        } else {
+            const method = lookupSpecial(x, s_floor);
+            if (method !== undefined) {
+                return pyCallOrSuspend(method);
+            } 
+            pyCheckType("x", "number", checkNumber(x));
+            _x = Sk.builtin.asnum$(x);
         }
-
-        return new Sk.builtin.float_(Math.floor(Sk.builtin.asnum$(x)));
+        return new pyFloat(Math.floor(_x));
     };
 
     function fmod(x, y) {
@@ -652,11 +674,14 @@ const $builtinmodule = function (name) {
     };
 
     function trunc(x) {
-        Sk.builtin.pyCheckType("x", "number", Sk.builtin.checkNumber(x));
-        if (Sk.builtin.checkInt(x)) {
-            return x; //deals with large ints being passed
+        if (x.ob$type === pyFloat) {
+            return x.nb$int();
         }
-        return new Sk.builtin.int_(Sk.builtin.asnum$(x) | 0);
+        const truncFn = lookupSpecial(x, pyStr.$trunc);
+        if (truncFn === undefined) {
+            throw new pyTypeError(`type ${x.tp$name} doesn't define __trunc__ method`);
+        }
+        return pyCallOrSuspend(truncFn);
     };
 
     // Power and logarithmic functions

--- a/test/run/t498.py
+++ b/test/run/t498.py
@@ -61,11 +61,11 @@ try:
 except TypeError as e:
     print repr(e)
 
-try:
-    print pow(-2.5, 3.7)
-    print "you shouldn't see this"
-except ValueError as e:
-    print repr(e)
+# try:
+#     print pow(-2.5, 3.7)
+#     print "you shouldn't see this"
+# except ValueError as e:
+#     print repr(e)
 
 try:
     print pow(4.0, 5.0, 3)

--- a/test/run/t498.py.real
+++ b/test/run/t498.py.real
@@ -52,6 +52,5 @@ floating point and long integers
 ERROR CHECKING:
 TypeError("unsupported operand type(s) for ** or pow(): 'list' and 'str'")
 TypeError("unsupported operand type(s) for ** or pow(): 'list', 'str', 'int'")
-ValueError('negative number cannot be raised to a fractional power')
 TypeError('pow() 3rd argument not allowed unless all arguments are integers')
 ValueError('pow() 2nd argument cannot be negative when 3rd argument specified')

--- a/test/unit3/test_builtin.py
+++ b/test/unit3/test_builtin.py
@@ -722,6 +722,27 @@ class BuiltinTest(unittest.TestCase):
         self.assertTrue(flag2)
         self.assertFalse(hasattr(F,'a'))
 
+    def test_hash(self):
+        hash(None)
+        self.assertEqual(hash(1), hash(1))
+        self.assertEqual(hash(1), hash(1.0))
+        hash('spam')
+        self.assertEqual(hash('spam'), hash(b'spam'))
+        hash((0,1,2,3))
+        def f(): pass
+        hash(f)
+        self.assertRaises(TypeError, hash, [])
+        self.assertRaises(TypeError, hash, {})
+        # Bug 1536021: Allow hash to return long objects
+        class X:
+            def __hash__(self):
+                return 2**100
+        self.assertEqual(type(hash(X())), int)
+        class Z(int):
+            def __hash__(self):
+                return self
+        self.assertEqual(hash(Z(42)), hash(42))
+
     def test_hex(self):
         self.assertEqual(hex(16), '0x10')
         self.assertEqual(hex(-16), '-0x10')

--- a/test/unit3/test_fractions.py
+++ b/test/unit3/test_fractions.py
@@ -1,0 +1,753 @@
+"""Tests for Lib/fractions.py."""
+
+# from decimal import Decimal
+# from test.support import requires_IEEE_754
+import math
+# import numbers
+import operator
+import fractions
+import functools
+import sys
+import unittest
+from copy import copy, deepcopy
+# from pickle import dumps, loads
+F = fractions.Fraction
+
+def skip_skulpt(f):
+    @functools.wraps(f)
+    def skip(self):
+        return
+    return skip
+
+
+# HACK for missing numbers module
+ModType = type(sys)
+
+numbers = ModType("numbers")
+
+class Rational_(tuple):
+    def register(self, cls):
+        numbers.Rational = self + (cls,)
+numbers.Rational = Rational_([int, F])
+
+
+class DummyFloat(object):
+    """Dummy float class for testing comparisons with Fractions"""
+
+    def __init__(self, value):
+        if not isinstance(value, float):
+            raise TypeError("DummyFloat can only be initialized from float")
+        self.value = value
+
+    def _richcmp(self, other, op):
+        if isinstance(other, numbers.Rational):
+            return op(F.from_float(self.value), other)
+        elif isinstance(other, DummyFloat):
+            return op(self.value, other.value)
+        else:
+            return NotImplemented
+
+    def __eq__(self, other): return self._richcmp(other, operator.eq)
+    def __le__(self, other): return self._richcmp(other, operator.le)
+    def __lt__(self, other): return self._richcmp(other, operator.lt)
+    def __ge__(self, other): return self._richcmp(other, operator.ge)
+    def __gt__(self, other): return self._richcmp(other, operator.gt)
+
+    # shouldn't be calling __float__ at all when doing comparisons
+    def __float__(self):
+        assert False, "__float__ should not be invoked for comparisons"
+
+    # same goes for subtraction
+    def __sub__(self, other):
+        assert False, "__sub__ should not be invoked for comparisons"
+    __rsub__ = __sub__
+
+
+class DummyRational(object):
+    """Test comparison of Fraction with a naive rational implementation."""
+
+    def __init__(self, num, den):
+        g = math.gcd(num, den)
+        self.num = num // g
+        self.den = den // g
+
+    def __eq__(self, other):
+        if isinstance(other, fractions.Fraction):
+            return (self.num == other._numerator and
+                    self.den == other._denominator)
+        else:
+            return NotImplemented
+
+    def __lt__(self, other):
+        return(self.num * other._denominator < self.den * other._numerator)
+
+    def __gt__(self, other):
+        return(self.num * other._denominator > self.den * other._numerator)
+
+    def __le__(self, other):
+        return(self.num * other._denominator <= self.den * other._numerator)
+
+    def __ge__(self, other):
+        return(self.num * other._denominator >= self.den * other._numerator)
+
+    # this class is for testing comparisons; conversion to float
+    # should never be used for a comparison, since it loses accuracy
+    def __float__(self):
+        assert False, "__float__ should not be invoked"
+
+class DummyFraction(fractions.Fraction):
+    """Dummy Fraction subclass for copy and deepcopy testing."""
+
+
+def _components(r):
+    return (r.numerator, r.denominator)
+
+
+class FractionTest(unittest.TestCase):
+
+    assertTupleEqual = unittest.TestCase.assertEqual
+    assertListEqual = unittest.TestCase.assertEqual
+
+    def assertTypedEquals(self, expected, actual):
+        """Asserts that both the types and values are the same."""
+        self.assertEqual(type(expected), type(actual))
+        self.assertEqual(expected, actual)
+
+    def assertTypedTupleEquals(self, expected, actual):
+        """Asserts that both the types and values in the tuples are the same."""
+        self.assertTupleEqual(expected, actual)
+        self.assertListEqual(list(map(type, expected)), list(map(type, actual)))
+
+    def assertRaisesMessage(self, exc_type, message,
+                            callable, *args, **kwargs):
+        """Asserts that callable(*args, **kwargs) raises exc_type(message)."""
+        try:
+            callable(*args, **kwargs)
+        except exc_type as e:
+            self.assertEqual(message, str(e))
+        else:
+            self.fail("%s not raised" % exc_type.__name__)
+
+    def testInit(self):
+        self.assertEqual((0, 1), _components(F()))
+        self.assertEqual((7, 1), _components(F(7)))
+        self.assertEqual((7, 3), _components(F(F(7, 3))))
+
+        self.assertEqual((-1, 1), _components(F(-1, 1)))
+        self.assertEqual((-1, 1), _components(F(1, -1)))
+        self.assertEqual((1, 1), _components(F(-2, -2)))
+        self.assertEqual((1, 2), _components(F(5, 10)))
+        self.assertEqual((7, 15), _components(F(7, 15)))
+        self.assertEqual((10**23, 1), _components(F(10**23)))
+
+        self.assertEqual((3, 77), _components(F(F(3, 7), 11)))
+        self.assertEqual((-9, 5), _components(F(2, F(-10, 9))))
+        self.assertEqual((2486, 2485), _components(F(F(22, 7), F(355, 113))))
+
+        self.assertRaisesMessage(ZeroDivisionError, "Fraction(12, 0)",
+                                 F, 12, 0)
+        self.assertRaises(TypeError, F, 1.5 + 3j)
+
+        self.assertRaises(TypeError, F, "3/2", 3)
+        self.assertRaises(TypeError, F, 3, 0j)
+        self.assertRaises(TypeError, F, 3, 1j)
+        self.assertRaises(TypeError, F, 1, 2, 3)
+
+    # @requires_IEEE_754
+    def testInitFromFloat(self):
+        self.assertEqual((5, 2), _components(F(2.5)))
+        self.assertEqual((0, 1), _components(F(-0.0)))
+        self.assertEqual((3602879701896397, 36028797018963968),
+                         _components(F(0.1)))
+        # bug 16469: error types should be consistent with float -> int
+        self.assertRaises(ValueError, F, float('nan'))
+        self.assertRaises(OverflowError, F, float('inf'))
+        self.assertRaises(OverflowError, F, float('-inf'))
+
+    @skip_skulpt
+    def testInitFromDecimal(self):
+        self.assertEqual((11, 10),
+                         _components(F(Decimal('1.1'))))
+        self.assertEqual((7, 200),
+                         _components(F(Decimal('3.5e-2'))))
+        self.assertEqual((0, 1),
+                         _components(F(Decimal('.000e20'))))
+        # bug 16469: error types should be consistent with decimal -> int
+        self.assertRaises(ValueError, F, Decimal('nan'))
+        self.assertRaises(ValueError, F, Decimal('snan'))
+        self.assertRaises(OverflowError, F, Decimal('inf'))
+        self.assertRaises(OverflowError, F, Decimal('-inf'))
+
+    def testFromString(self):
+        self.assertEqual((5, 1), _components(F("5")))
+        self.assertEqual((3, 2), _components(F("3/2")))
+        self.assertEqual((3, 2), _components(F(" \n  +3/2")))
+        self.assertEqual((-3, 2), _components(F("-3/2  ")))
+        self.assertEqual((13, 2), _components(F("    013/02 \n  ")))
+        self.assertEqual((16, 5), _components(F(" 3.2 ")))
+        self.assertEqual((-16, 5), _components(F(" -3.2 ")))
+        self.assertEqual((-3, 1), _components(F(" -3. ")))
+        self.assertEqual((3, 5), _components(F(" .6 ")))
+        self.assertEqual((1, 3125), _components(F("32.e-5")))
+        self.assertEqual((1000000, 1), _components(F("1E+06")))
+        self.assertEqual((-12300, 1), _components(F("-1.23e4")))
+        self.assertEqual((0, 1), _components(F(" .0e+0\t")))
+        self.assertEqual((0, 1), _components(F("-0.000e0")))
+
+        self.assertRaisesMessage(
+            ZeroDivisionError, "Fraction(3, 0)",
+            F, "3/0")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '3/'",
+            F, "3/")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '/2'",
+            F, "/2")
+        self.assertRaisesMessage(
+            ValueError, "Invalid literal for Fraction: '3 /2'",
+            F, "3 /2")
+        self.assertRaisesMessage(
+            # Denominators don't need a sign.
+            ValueError, "Invalid literal for Fraction: '3/+2'",
+            F, "3/+2")
+        self.assertRaisesMessage(
+            # Imitate float's parsing.
+            ValueError, "Invalid literal for Fraction: '+ 3/2'",
+            F, "+ 3/2")
+        self.assertRaisesMessage(
+            # Avoid treating '.' as a regex special character.
+            ValueError, "Invalid literal for Fraction: '3a2'",
+            F, "3a2")
+        self.assertRaisesMessage(
+            # Don't accept combinations of decimals and rationals.
+            ValueError, "Invalid literal for Fraction: '3/7.2'",
+            F, "3/7.2")
+        self.assertRaisesMessage(
+            # Don't accept combinations of decimals and rationals.
+            ValueError, "Invalid literal for Fraction: '3.2/7'",
+            F, "3.2/7")
+        self.assertRaisesMessage(
+            # Allow 3. and .3, but not .
+            ValueError, "Invalid literal for Fraction: '.'",
+            F, ".")
+
+    def testImmutable(self):
+        r = F(7, 3)
+        r.__init__(2, 15)
+        self.assertEqual((7, 3), _components(r))
+
+        self.assertRaises(AttributeError, setattr, r, 'numerator', 12)
+        self.assertRaises(AttributeError, setattr, r, 'denominator', 6)
+        self.assertEqual((7, 3), _components(r))
+
+        # But if you _really_ need to:
+        r._numerator = 4
+        r._denominator = 2
+        self.assertEqual((4, 2), _components(r))
+        # Which breaks some important operations:
+        self.assertNotEqual(F(4, 2), r)
+
+    def testFromFloat(self):
+        self.assertRaises(TypeError, F.from_float, 3+4j)
+        self.assertEqual((10, 1), _components(F.from_float(10)))
+        bigint = 1234567890123456789
+        self.assertEqual((bigint, 1), _components(F.from_float(bigint)))
+        self.assertEqual((0, 1), _components(F.from_float(-0.0)))
+        self.assertEqual((10, 1), _components(F.from_float(10.0)))
+        self.assertEqual((-5, 2), _components(F.from_float(-2.5)))
+        self.assertEqual((99999999999999991611392, 1),
+                         _components(F.from_float(1e23)))
+        self.assertEqual(float(10**23), float(F.from_float(1e23)))
+        self.assertEqual((3602879701896397, 1125899906842624),
+                         _components(F.from_float(3.2)))
+        self.assertEqual(3.2, float(F.from_float(3.2)))
+
+        inf = 1e1000
+        nan = inf - inf
+        # bug 16469: error types should be consistent with float -> int
+        self.assertRaisesMessage(
+            OverflowError, "cannot convert Infinity to integer ratio",
+            F.from_float, inf)
+        self.assertRaisesMessage(
+            OverflowError, "cannot convert Infinity to integer ratio",
+            F.from_float, -inf)
+        self.assertRaisesMessage(
+            ValueError, "cannot convert NaN to integer ratio",
+            F.from_float, nan)
+
+    @skip_skulpt
+    def testFromDecimal(self):
+        self.assertRaises(TypeError, F.from_decimal, 3+4j)
+        self.assertEqual(F(10, 1), F.from_decimal(10))
+        self.assertEqual(F(0), F.from_decimal(Decimal("-0")))
+        self.assertEqual(F(5, 10), F.from_decimal(Decimal("0.5")))
+        self.assertEqual(F(5, 1000), F.from_decimal(Decimal("5e-3")))
+        self.assertEqual(F(5000), F.from_decimal(Decimal("5e3")))
+        self.assertEqual(1 - F(1, 10**30),
+                         F.from_decimal(Decimal("0." + "9" * 30)))
+
+        # bug 16469: error types should be consistent with decimal -> int
+        self.assertRaisesMessage(
+            OverflowError, "cannot convert Infinity to integer ratio",
+            F.from_decimal, Decimal("inf"))
+        self.assertRaisesMessage(
+            OverflowError, "cannot convert Infinity to integer ratio",
+            F.from_decimal, Decimal("-inf"))
+        self.assertRaisesMessage(
+            ValueError, "cannot convert NaN to integer ratio",
+            F.from_decimal, Decimal("nan"))
+        self.assertRaisesMessage(
+            ValueError, "cannot convert NaN to integer ratio",
+            F.from_decimal, Decimal("snan"))
+
+    def test_as_integer_ratio(self):
+        self.assertEqual(F(4, 6).as_integer_ratio(), (2, 3))
+        self.assertEqual(F(-4, 6).as_integer_ratio(), (-2, 3))
+        self.assertEqual(F(4, -6).as_integer_ratio(), (-2, 3))
+        self.assertEqual(F(0, 6).as_integer_ratio(), (0, 1))
+
+    def testLimitDenominator(self):
+        rpi = F('3.1415926535897932')
+        self.assertEqual(rpi.limit_denominator(10000), F(355, 113))
+        self.assertEqual(-rpi.limit_denominator(10000), F(-355, 113))
+        self.assertEqual(rpi.limit_denominator(113), F(355, 113))
+        self.assertEqual(rpi.limit_denominator(112), F(333, 106))
+        self.assertEqual(F(201, 200).limit_denominator(100), F(1))
+        self.assertEqual(F(201, 200).limit_denominator(101), F(102, 101))
+        self.assertEqual(F(0).limit_denominator(10000), F(0))
+        for i in (0, -1):
+            self.assertRaisesMessage(
+                ValueError, "max_denominator should be at least 1",
+                F(1).limit_denominator, i)
+
+    def testConversions(self):
+        self.assertTypedEquals(-1, math.trunc(F(-11, 10)))
+        self.assertTypedEquals(1, math.trunc(F(11, 10)))
+        self.assertTypedEquals(-2, math.floor(F(-11, 10)))
+        self.assertTypedEquals(-1, math.ceil(F(-11, 10)))
+        self.assertTypedEquals(-1, math.ceil(F(-10, 10)))
+        self.assertTypedEquals(-1, int(F(-11, 10)))
+        self.assertTypedEquals(0, round(F(-1, 10)))
+        self.assertTypedEquals(0, round(F(-5, 10)))
+        self.assertTypedEquals(-2, round(F(-15, 10)))
+        self.assertTypedEquals(-1, round(F(-7, 10)))
+
+        self.assertEqual(False, bool(F(0, 1)))
+        self.assertEqual(True, bool(F(3, 2)))
+        self.assertTypedEquals(0.1, float(F(1, 10)))
+
+        # Check that __float__ isn't implemented by converting the
+        # numerator and denominator to float before dividing.
+        self.assertRaises(OverflowError, float, int('2'*400+'7'))
+        self.assertAlmostEqual(2.0/3,
+                               float(F(int('2'*400+'7'), int('3'*400+'1'))))
+
+        self.assertTypedEquals(0.1+0j, complex(F(1,10)))
+
+    @skip_skulpt
+    def testBoolGuarateesBoolReturn(self):
+        # Ensure that __bool__ is used on numerator which guarantees a bool
+        # return.  See also bpo-39274.
+        @functools.total_ordering
+        class CustomValue:
+            denominator = 1
+
+            def __init__(self, value):
+                self.value = value
+
+            def __bool__(self):
+                return bool(self.value)
+
+            @property
+            def numerator(self):
+                # required to preserve `self` during instantiation
+                return self
+
+            def __eq__(self, other):
+                raise AssertionError("Avoid comparisons in Fraction.__bool__")
+
+            __lt__ = __eq__
+
+        # We did not implement all abstract methods, so register:
+        numbers.Rational.register(CustomValue)
+
+        numerator = CustomValue(1)
+        r = F(numerator)
+        # ensure the numerator was not lost during instantiation:
+        self.assertIs(r.numerator, numerator)
+        self.assertIs(bool(r), True)
+
+        numerator = CustomValue(0)
+        r = F(numerator)
+        self.assertIs(bool(r), False)
+
+    def testRound(self):
+        self.assertTypedEquals(F(-200), round(F(-150), -2))
+        self.assertTypedEquals(F(-200), round(F(-250), -2))
+        self.assertTypedEquals(F(30), round(F(26), -1))
+        self.assertTypedEquals(F(-2, 10), round(F(-15, 100), 1))
+        self.assertTypedEquals(F(-2, 10), round(F(-25, 100), 1))
+
+    def testArithmetic(self):
+        self.assertEqual(F(1, 2), F(1, 10) + F(2, 5))
+        self.assertEqual(F(-3, 10), F(1, 10) - F(2, 5))
+        self.assertEqual(F(1, 25), F(1, 10) * F(2, 5))
+        self.assertEqual(F(1, 4), F(1, 10) / F(2, 5))
+        self.assertTypedEquals(2, F(9, 10) // F(2, 5))
+        self.assertTypedEquals(10**23, F(10**23, 1) // F(1))
+        self.assertEqual(F(5, 6), F(7, 3) % F(3, 2))
+        self.assertEqual(F(2, 3), F(-7, 3) % F(3, 2))
+        self.assertEqual((F(1), F(5, 6)), divmod(F(7, 3), F(3, 2)))
+        self.assertEqual((F(-2), F(2, 3)), divmod(F(-7, 3), F(3, 2)))
+        self.assertEqual(F(8, 27), F(2, 3) ** F(3))
+        self.assertEqual(F(27, 8), F(2, 3) ** F(-3))
+        self.assertTypedEquals(2.0, F(4) ** F(1, 2))
+        self.assertEqual(F(1, 1), +F(1, 1))
+        z = pow(F(-1), F(1, 2))
+        self.assertAlmostEqual(z.real, 0)
+        self.assertEqual(z.imag, 1)
+        # Regression test for #27539.
+        p = F(-1, 2) ** 0
+        self.assertEqual(p, F(1, 1))
+        self.assertEqual(p.numerator, 1)
+        self.assertEqual(p.denominator, 1)
+        p = F(-1, 2) ** -1
+        self.assertEqual(p, F(-2, 1))
+        self.assertEqual(p.numerator, -2)
+        self.assertEqual(p.denominator, 1)
+        p = F(-1, 2) ** -2
+        self.assertEqual(p, F(4, 1))
+        self.assertEqual(p.numerator, 4)
+        self.assertEqual(p.denominator, 1)
+
+    def testLargeArithmetic(self):
+        self.assertTypedEquals(
+            F(10101010100808080808080808101010101010000000000000000,
+              1010101010101010101010101011111111101010101010101010101010101),
+            F(10**35+1, 10**27+1) % F(10**27+1, 10**35-1)
+        )
+        self.assertTypedEquals(
+            F(7, 1901475900342344102245054808064),
+            F(-2**100, 3) % F(5, 2**100)
+        )
+        self.assertTypedTupleEquals(
+            (9999999999999999,
+             F(10101010100808080808080808101010101010000000000000000,
+               1010101010101010101010101011111111101010101010101010101010101)),
+            divmod(F(10**35+1, 10**27+1), F(10**27+1, 10**35-1))
+        )
+        self.assertTypedEquals(
+            -2 ** 200 // 15,
+            F(-2**100, 3) // F(5, 2**100)
+        )
+        self.assertTypedEquals(
+            1,
+            F(5, 2**100) // F(3, 2**100)
+        )
+        self.assertTypedEquals(
+            (1, F(2, 2**100)),
+            divmod(F(5, 2**100), F(3, 2**100))
+        )
+        self.assertTypedTupleEquals(
+            (-2 ** 200 // 15,
+             F(7, 1901475900342344102245054808064)),
+            divmod(F(-2**100, 3), F(5, 2**100))
+        )
+
+    def testMixedArithmetic(self):
+        self.assertTypedEquals(F(11, 10), F(1, 10) + 1)
+        self.assertTypedEquals(1.1, F(1, 10) + 1.0)
+        self.assertTypedEquals(1.1 + 0j, F(1, 10) + (1.0 + 0j))
+        self.assertTypedEquals(F(11, 10), 1 + F(1, 10))
+        self.assertTypedEquals(1.1, 1.0 + F(1, 10))
+        self.assertTypedEquals(1.1 + 0j, (1.0 + 0j) + F(1, 10))
+
+        self.assertTypedEquals(F(-9, 10), F(1, 10) - 1)
+        self.assertTypedEquals(-0.9, F(1, 10) - 1.0)
+        self.assertTypedEquals(-0.9 + 0j, F(1, 10) - (1.0 + 0j))
+        self.assertTypedEquals(F(9, 10), 1 - F(1, 10))
+        self.assertTypedEquals(0.9, 1.0 - F(1, 10))
+        self.assertTypedEquals(0.9 + 0j, (1.0 + 0j) - F(1, 10))
+
+        self.assertTypedEquals(F(1, 10), F(1, 10) * 1)
+        self.assertTypedEquals(0.1, F(1, 10) * 1.0)
+        self.assertTypedEquals(0.1 + 0j, F(1, 10) * (1.0 + 0j))
+        self.assertTypedEquals(F(1, 10), 1 * F(1, 10))
+        self.assertTypedEquals(0.1, 1.0 * F(1, 10))
+        self.assertTypedEquals(0.1 + 0j, (1.0 + 0j) * F(1, 10))
+
+        self.assertTypedEquals(F(1, 10), F(1, 10) / 1)
+        self.assertTypedEquals(0.1, F(1, 10) / 1.0)
+        self.assertTypedEquals(0.1 + 0j, F(1, 10) / (1.0 + 0j))
+        self.assertTypedEquals(F(10, 1), 1 / F(1, 10))
+        self.assertTypedEquals(10.0, 1.0 / F(1, 10))
+        self.assertTypedEquals(10.0 + 0j, (1.0 + 0j) / F(1, 10))
+
+        self.assertTypedEquals(0, F(1, 10) // 1)
+        self.assertTypedEquals(0.0, F(1, 10) // 1.0)
+        self.assertTypedEquals(10, 1 // F(1, 10))
+        self.assertTypedEquals(10**23, 10**22 // F(1, 10))
+        self.assertTypedEquals(1.0 // 0.1, 1.0 // F(1, 10))
+
+        self.assertTypedEquals(F(1, 10), F(1, 10) % 1)
+        self.assertTypedEquals(0.1, F(1, 10) % 1.0)
+        self.assertTypedEquals(F(0, 1), 1 % F(1, 10))
+        self.assertTypedEquals(1.0 % 0.1, 1.0 % F(1, 10))
+        self.assertTypedEquals(0.1, F(1, 10) % float('inf'))
+        self.assertTypedEquals(float('-inf'), F(1, 10) % float('-inf'))
+        self.assertTypedEquals(float('inf'), F(-1, 10) % float('inf'))
+        self.assertTypedEquals(-0.1, F(-1, 10) % float('-inf'))
+
+        self.assertTypedTupleEquals((0, F(1, 10)), divmod(F(1, 10), 1))
+        self.assertTypedTupleEquals(divmod(0.1, 1.0), divmod(F(1, 10), 1.0))
+        self.assertTypedTupleEquals((10, F(0)), divmod(1, F(1, 10)))
+        self.assertTypedTupleEquals(divmod(1.0, 0.1), divmod(1.0, F(1, 10)))
+        self.assertTypedTupleEquals(divmod(0.1, float('inf')), divmod(F(1, 10), float('inf')))
+        self.assertTypedTupleEquals(divmod(0.1, float('-inf')), divmod(F(1, 10), float('-inf')))
+        self.assertTypedTupleEquals(divmod(-0.1, float('inf')), divmod(F(-1, 10), float('inf')))
+        self.assertTypedTupleEquals(divmod(-0.1, float('-inf')), divmod(F(-1, 10), float('-inf')))
+
+        # ** has more interesting conversion rules.
+        self.assertTypedEquals(F(100, 1), F(1, 10) ** -2)
+        self.assertTypedEquals(F(100, 1), F(10, 1) ** 2)
+        self.assertTypedEquals(0.1, F(1, 10) ** 1.0)
+        self.assertTypedEquals(0.1 + 0j, F(1, 10) ** (1.0 + 0j))
+        self.assertTypedEquals(4 , 2 ** F(2, 1))
+        z = pow(-1, F(1, 2))
+        self.assertAlmostEqual(0, z.real)
+        self.assertEqual(1, z.imag)
+        self.assertTypedEquals(F(1, 4) , 2 ** F(-2, 1))
+        self.assertTypedEquals(2.0 , 4 ** F(1, 2))
+        self.assertTypedEquals(0.25, 2.0 ** F(-2, 1))
+        self.assertTypedEquals(1.0 + 0j, (1.0 + 0j) ** F(1, 10))
+        self.assertRaises(ZeroDivisionError, operator.pow,
+                          F(0, 1), -2)
+
+    @skip_skulpt
+    def testMixingWithDecimal(self):
+        # Decimal refuses mixed arithmetic (but not mixed comparisons)
+        self.assertRaises(TypeError, operator.add,
+                          F(3,11), Decimal('3.1415926'))
+        self.assertRaises(TypeError, operator.add,
+                          Decimal('3.1415926'), F(3,11))
+
+    def testComparisons(self):
+        self.assertTrue(F(1, 2) < F(2, 3))
+        self.assertFalse(F(1, 2) < F(1, 2))
+        self.assertTrue(F(1, 2) <= F(2, 3))
+        self.assertTrue(F(1, 2) <= F(1, 2))
+        self.assertFalse(F(2, 3) <= F(1, 2))
+        self.assertTrue(F(1, 2) == F(1, 2))
+        self.assertFalse(F(1, 2) == F(1, 3))
+        self.assertFalse(F(1, 2) != F(1, 2))
+        self.assertTrue(F(1, 2) != F(1, 3))
+
+    def testComparisonsDummyRational(self):
+        self.assertTrue(F(1, 2) == DummyRational(1, 2))
+        self.assertTrue(DummyRational(1, 2) == F(1, 2))
+        self.assertFalse(F(1, 2) == DummyRational(3, 4))
+        self.assertFalse(DummyRational(3, 4) == F(1, 2))
+
+        self.assertTrue(F(1, 2) < DummyRational(3, 4))
+        self.assertFalse(F(1, 2) < DummyRational(1, 2))
+        self.assertFalse(F(1, 2) < DummyRational(1, 7))
+        self.assertFalse(F(1, 2) > DummyRational(3, 4))
+        self.assertFalse(F(1, 2) > DummyRational(1, 2))
+        self.assertTrue(F(1, 2) > DummyRational(1, 7))
+        self.assertTrue(F(1, 2) <= DummyRational(3, 4))
+        self.assertTrue(F(1, 2) <= DummyRational(1, 2))
+        self.assertFalse(F(1, 2) <= DummyRational(1, 7))
+        self.assertFalse(F(1, 2) >= DummyRational(3, 4))
+        self.assertTrue(F(1, 2) >= DummyRational(1, 2))
+        self.assertTrue(F(1, 2) >= DummyRational(1, 7))
+
+        self.assertTrue(DummyRational(1, 2) < F(3, 4))
+        self.assertFalse(DummyRational(1, 2) < F(1, 2))
+        self.assertFalse(DummyRational(1, 2) < F(1, 7))
+        self.assertFalse(DummyRational(1, 2) > F(3, 4))
+        self.assertFalse(DummyRational(1, 2) > F(1, 2))
+        self.assertTrue(DummyRational(1, 2) > F(1, 7))
+        self.assertTrue(DummyRational(1, 2) <= F(3, 4))
+        self.assertTrue(DummyRational(1, 2) <= F(1, 2))
+        self.assertFalse(DummyRational(1, 2) <= F(1, 7))
+        self.assertFalse(DummyRational(1, 2) >= F(3, 4))
+        self.assertTrue(DummyRational(1, 2) >= F(1, 2))
+        self.assertTrue(DummyRational(1, 2) >= F(1, 7))
+
+    def testComparisonsDummyFloat(self):
+        x = DummyFloat(1./3.)
+        y = F(1, 3)
+        self.assertTrue(x != y)
+        self.assertTrue(x < y or x > y)
+        self.assertFalse(x == y)
+        self.assertFalse(x <= y and x >= y)
+        self.assertTrue(y != x)
+        self.assertTrue(y < x or y > x)
+        self.assertFalse(y == x)
+        self.assertFalse(y <= x and y >= x)
+
+    def testMixedLess(self):
+        self.assertTrue(2 < F(5, 2))
+        self.assertFalse(2 < F(4, 2))
+        self.assertTrue(F(5, 2) < 3)
+        self.assertFalse(F(4, 2) < 2)
+
+        self.assertTrue(F(1, 2) < 0.6)
+        self.assertFalse(F(1, 2) < 0.4)
+        self.assertTrue(0.4 < F(1, 2))
+        self.assertFalse(0.5 < F(1, 2))
+
+        self.assertFalse(float('inf') < F(1, 2))
+        self.assertTrue(float('-inf') < F(0, 10))
+        self.assertFalse(float('nan') < F(-3, 7))
+        self.assertTrue(F(1, 2) < float('inf'))
+        self.assertFalse(F(17, 12) < float('-inf'))
+        self.assertFalse(F(144, -89) < float('nan'))
+
+    def testMixedLessEqual(self):
+        self.assertTrue(0.5 <= F(1, 2))
+        self.assertFalse(0.6 <= F(1, 2))
+        self.assertTrue(F(1, 2) <= 0.5)
+        self.assertFalse(F(1, 2) <= 0.4)
+        self.assertTrue(2 <= F(4, 2))
+        self.assertFalse(2 <= F(3, 2))
+        self.assertTrue(F(4, 2) <= 2)
+        self.assertFalse(F(5, 2) <= 2)
+
+        self.assertFalse(float('inf') <= F(1, 2))
+        self.assertTrue(float('-inf') <= F(0, 10))
+        self.assertFalse(float('nan') <= F(-3, 7))
+        self.assertTrue(F(1, 2) <= float('inf'))
+        self.assertFalse(F(17, 12) <= float('-inf'))
+        self.assertFalse(F(144, -89) <= float('nan'))
+
+    def testBigFloatComparisons(self):
+        # Because 10**23 can't be represented exactly as a float:
+        self.assertFalse(F(10**23) == float(10**23))
+        # The first test demonstrates why these are important.
+        self.assertFalse(1e23 < float(F(math.trunc(1e23) + 1)))
+        self.assertTrue(1e23 < F(math.trunc(1e23) + 1))
+        self.assertFalse(1e23 <= F(math.trunc(1e23) - 1))
+        self.assertTrue(1e23 > F(math.trunc(1e23) - 1))
+        self.assertFalse(1e23 >= F(math.trunc(1e23) + 1))
+
+    def testBigComplexComparisons(self):
+        self.assertFalse(F(10**23) == complex(10**23))
+        self.assertRaises(TypeError, operator.gt, F(10**23), complex(10**23))
+        self.assertRaises(TypeError, operator.le, F(10**23), complex(10**23))
+
+        x = F(3, 8)
+        z = complex(0.375, 0.0)
+        w = complex(0.375, 0.2)
+        self.assertTrue(x == z)
+        self.assertFalse(x != z)
+        self.assertFalse(x == w)
+        self.assertTrue(x != w)
+        for op in operator.lt, operator.le, operator.gt, operator.ge:
+            self.assertRaises(TypeError, op, x, z)
+            self.assertRaises(TypeError, op, z, x)
+            self.assertRaises(TypeError, op, x, w)
+            self.assertRaises(TypeError, op, w, x)
+
+    def testMixedEqual(self):
+        self.assertTrue(0.5 == F(1, 2))
+        self.assertFalse(0.6 == F(1, 2))
+        self.assertTrue(F(1, 2) == 0.5)
+        self.assertFalse(F(1, 2) == 0.4)
+        self.assertTrue(2 == F(4, 2))
+        self.assertFalse(2 == F(3, 2))
+        self.assertTrue(F(4, 2) == 2)
+        self.assertFalse(F(5, 2) == 2)
+        self.assertFalse(F(5, 2) == float('nan'))
+        self.assertFalse(float('nan') == F(3, 7))
+        self.assertFalse(F(5, 2) == float('inf'))
+        self.assertFalse(float('-inf') == F(2, 5))
+
+    def testStringification(self):
+        self.assertEqual("Fraction(7, 3)", repr(F(7, 3)))
+        self.assertEqual("Fraction(6283185307, 2000000000)",
+                         repr(F('3.1415926535')))
+        self.assertEqual("Fraction(-1, 100000000000000000000)",
+                         repr(F(1, -10**20)))
+        self.assertEqual("7/3", str(F(7, 3)))
+        self.assertEqual("7", str(F(7, 1)))
+
+    def testHash(self):
+        hmod = sys.hash_info.modulus
+        hinf = sys.hash_info.inf
+        self.assertEqual(hash(2.5), hash(F(5, 2)))
+        self.assertEqual(hash(10**50), hash(F(10**50)))
+        self.assertNotEqual(hash(float(10**23)), hash(F(10**23)))
+        self.assertEqual(hinf, hash(F(1, hmod)))
+        # Check that __hash__ produces the same value as hash(), for
+        # consistency with int and Decimal.  (See issue #10356.)
+        self.assertEqual(hash(F(-1)), F(-1).__hash__())
+
+    def testApproximatePi(self):
+        # Algorithm borrowed from
+        # http://docs.python.org/lib/decimal-recipes.html
+        three = F(3)
+        lasts, t, s, n, na, d, da = 0, three, 3, 1, 0, 0, 24
+        while abs(s - lasts) > F(1, 10**9):
+            lasts = s
+            n, na = n+na, na+8
+            d, da = d+da, da+32
+            t = (t * n) / d
+            s += t
+        self.assertAlmostEqual(math.pi, s)
+
+    def testApproximateCos1(self):
+        # Algorithm borrowed from
+        # http://docs.python.org/lib/decimal-recipes.html
+        x = F(1)
+        i, lasts, s, fact, num, sign = 0, 0, F(1), 1, 1, 1
+        while abs(s - lasts) > F(1, 10**9):
+            lasts = s
+            i += 2
+            fact *= i * (i-1)
+            num *= x * x
+            sign *= -1
+            s += num / fact * sign
+        self.assertAlmostEqual(math.cos(1), s)
+
+    def test_copy_deepcopy_pickle(self):
+        r = F(13, 7)
+        dr = DummyFraction(13, 7)
+        # self.assertEqual(r, loads(dumps(r)))
+        self.assertEqual(id(r), id(copy(r)))
+        self.assertEqual(id(r), id(deepcopy(r)))
+        self.assertNotEqual(id(dr), id(copy(dr)))
+        self.assertNotEqual(id(dr), id(deepcopy(dr)))
+        self.assertTypedEquals(dr, copy(dr))
+        self.assertTypedEquals(dr, deepcopy(dr))
+
+    def test_slots(self):
+        # Issue 4998
+        r = F(13, 7)
+        self.assertRaises(AttributeError, setattr, r, 'a', 10)
+
+    def test_int_subclass(self):
+        class myint(int):
+            def __mul__(self, other):
+                return type(self)(int(self) * int(other))
+            def __floordiv__(self, other):
+                return type(self)(int(self) // int(other))
+            def __mod__(self, other):
+                x = type(self)(int(self) % int(other))
+                return x
+            @property
+            def numerator(self):
+                return type(self)(int(self))
+            @property
+            def denominator(self):
+                return type(self)(1)
+
+        f = fractions.Fraction(myint(1 * 3), myint(2 * 3))
+        self.assertEqual(f.numerator, 1)
+        self.assertEqual(f.denominator, 2)
+        self.assertEqual(type(f.numerator), myint)
+        self.assertEqual(type(f.denominator), myint)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implement fractions module in javascript with tests

required changes:
- adjust hashing of ints/floats
- sys.hash_info
- implement -float ** fractional power (comment out python 2 test that says this is not allowed)