### PR TITLE
Remove dead link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ There is plenty of work still to do in making improvements to Skulpt.  If you wo
 
 1. Create a Github account if you don't already have one
 2. Create a Fork of the Skulpt repository -- This will make a clone of the repository in your account.  **DO NOT** clone this one.  Once you've made the fork you will clone the forked version in your account to your local machine for development.
-3. Read the HACKING.md file to get the "lay of the land".  If you plan to work on creating  a module then you may also find this [blog post](http://reputablejournal.com/adding-a-module-to-skulpt.html) helpful.
+3. Read the HACKING.md file to get the "lay of the land".
 3. Check the issues list for something to do.
 4. Follow the instructions above to get skulpt building
 5. Fix or add your own features.  Commit and push to your forked version of the repository.  When everything is tested and ready to be incorporated into the master version...

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ There is plenty of work still to do in making improvements to Skulpt.  If you wo
 
 1. Create a Github account if you don't already have one
 2. Create a Fork of the Skulpt repository -- This will make a clone of the repository in your account.  **DO NOT** clone this one.  Once you've made the fork you will clone the forked version in your account to your local machine for development.
-3. Read the HACKING.md file to get the "lay of the land".
-3. Check the issues list for something to do.
-4. Follow the instructions above to get skulpt building
-5. Fix or add your own features.  Commit and push to your forked version of the repository.  When everything is tested and ready to be incorporated into the master version...
-6. Make a Pull Request to get your feature(s) added to the main repository.
+3. Read the HACKING.md file to get the "lay of the land".  If you plan to work on creating  a module then you may also find this [blog post](https://reputablejournal.com/2011/03/18/adding-a-module.html) helpful.
+4. Check the issues list for something to do.
+5. Follow the instructions above to get skulpt building
+6. Fix or add your own features.  Commit and push to your forked version of the repository.  When everything is tested and ready to be incorporated into the master version...
+7. Make a Pull Request to get your feature(s) added to the main repository.
 
 
 ## Community


### PR DESCRIPTION
The [blog post link](http://reputablejournal.com/adding-a-module-to-skulpt.html) seems to be dead. This commit merely removes it from the readme.