### PR TITLE
Fix lookbehind assertion browser test.

### DIFF
--- a/src/lib/re.js
+++ b/src/lib/re.js
@@ -279,7 +279,7 @@ function $builtinmodule(name) {
     let neg_lookbehind_A = "(?<!\\\\n)";
     (function checkLookBehindSupport() {
         try {
-            new RegExp("(?<!foo)");
+            eval("/(?<!foo)/");
         } catch {
             neg_lookbehind_A = "";
         }


### PR DESCRIPTION
In a minified build we use this got minified to inline regex
which is pretty useless if the point is to test whether the browser supports the syntax or not