### PR TITLE
property fixes

### DIFF
--- a/src/property_class_static.js
+++ b/src/property_class_static.js
@@ -12,6 +12,7 @@ Sk.builtin.property = Sk.abstr.buildNativeClass("property", {
         this.prop$get = fget || Sk.builtin.none.none$;
         this.prop$set = fset || Sk.builtin.none.none$;
         this.prop$del = fdel || Sk.builtin.none.none$;
+        this.getter$doc = fget && !doc;
         this.prop$doc = doc || (fget && fget.$doc) || Sk.builtin.none.none$;
     },
     slots: {
@@ -30,11 +31,15 @@ Sk.builtin.property = Sk.abstr.buildNativeClass("property", {
             this.prop$set = args[1];
             this.prop$del = args[2];
             if (Sk.builtin.checkNone(args[3])) {
+                this.getter$doc = true;
                 if (!Sk.builtin.checkNone(args[0])) {
                     this.prop$doc = args[0].$doc || args[3];
                 }
             } else {
                 this.prop$doc = args[3];
+            }
+            if (this.ob$type !== Sk.builtin.property) {
+                this.tp$setattr(Sk.builtin.str.$doc, this.prop$doc);
             }
         },
         tp$doc:
@@ -76,19 +81,19 @@ Sk.builtin.property = Sk.abstr.buildNativeClass("property", {
     methods: {
         getter: {
             $meth(fget) {
-                return new Sk.builtin.property(fget, this.prop$set, this.prop$del, this.prop$doc);
+                return this.$copy([fget, this.prop$set, this.prop$del]);
             },
             $flags: { OneArg: true },
         },
         setter: {
             $meth(fset) {
-                return new Sk.builtin.property(this.prop$get, fset, this.prop$del, this.prop$doc);
+                return this.$copy([this.prop$get, fset, this.prop$del]);
             },
             $flags: { OneArg: true },
         },
         deleter: {
             $meth(fdel) {
-                return new Sk.builtin.property(this.prop$get, this.prop$set, fdel, this.prop$doc);
+                return this.$copy([this.prop$get, this.prop$set, fdel]);
             },
             $flags: { OneArg: true },
         },
@@ -119,6 +124,19 @@ Sk.builtin.property = Sk.abstr.buildNativeClass("property", {
             }
         },
     },
+    proto: {
+        $copy(args) {
+            const type = this.ob$type;
+            if (!this.getter$doc) {
+                args.push(this.prop$doc);
+            }
+            if (type === Sk.builtin.property) {
+                return new type(...args);
+            } else {
+                return type.tp$call(args);
+            }
+        }
+    }
 });
 
 /**

--- a/test/unit3/test_decorators.py
+++ b/test/unit3/test_decorators.py
@@ -100,27 +100,27 @@ class PropertyTests(unittest.TestCase):
         self.assertRaises(PropertySet, setattr, sub, "spam", None)
         # self.assertRaises(PropertyDel, delattr, sub, "spam")
 
-    # def test_property_decorator_subclass_doc(self):
-    #     sub = SubClass()
-    #     self.assertEqual(sub.__class__.spam.__doc__, "SubClass.getter")
-    #
-    # def test_property_decorator_baseclass_doc(self):
-    #     base = BaseClass()
-    #     self.assertEqual(base.__class__.spam.__doc__, "BaseClass.getter")
+    def test_property_decorator_subclass_doc(self):
+        sub = SubClass()
+        self.assertEqual(sub.__class__.spam.__doc__, "SubClass.getter")
+    
+    def test_property_decorator_baseclass_doc(self):
+        base = BaseClass()
+        self.assertEqual(base.__class__.spam.__doc__, "BaseClass.getter")
 
-    # def test_property_decorator_doc(self):
-    #     base = PropertyDocBase()
-    #     sub = PropertyDocSub()
-    #     self.assertEqual(base.__class__.spam.__doc__, "spam spam spam")
-    #     self.assertEqual(sub.__class__.spam.__doc__, "spam spam spam")
+    def test_property_decorator_doc(self):
+        base = PropertyDocBase()
+        sub = PropertyDocSub()
+        self.assertEqual(base.__class__.spam.__doc__, "spam spam spam")
+        self.assertEqual(sub.__class__.spam.__doc__, "spam spam spam")
 
-    # def test_property_getter_doc_override(self):
-    #     newgettersub = PropertySubNewGetter()
-    #     self.assertEqual(newgettersub.spam, 5)
-    #     self.assertEqual(newgettersub.__class__.spam.__doc__, "new docstring")
-    #     newgetter = PropertyNewGetter()
-    #     self.assertEqual(newgetter.spam, 8)
-    #     self.assertEqual(newgetter.__class__.spam.__doc__, "new docstring")
+    def test_property_getter_doc_override(self):
+        newgettersub = PropertySubNewGetter()
+        self.assertEqual(newgettersub.spam, 5)
+        self.assertEqual(newgettersub.__class__.spam.__doc__, "new docstring")
+        newgetter = PropertyNewGetter()
+        self.assertEqual(newgetter.spam, 8)
+        self.assertEqual(newgetter.__class__.spam.__doc__, "new docstring")
 
     # def test_property___isabstractmethod__descriptor(self):
     #     for val in (True, False, [], [1], '', '1'):
@@ -145,24 +145,24 @@ class PropertyTests(unittest.TestCase):
     #             foo = property(foo)
     #         C.foo.__isabstractmethod__
 
-    # def test_property_builtin_doc_writable(self):
-    #     p = property(doc='basic')
-    #     self.assertEqual(p.__doc__, 'basic')
-    #     p.__doc__= 'extended'
-    #     self.assertEqual(p.__doc__, 'extended')
+    def test_property_builtin_doc_writable(self):
+        p = property(doc='basic')
+        self.assertEqual(p.__doc__, 'basic')
+        p.__doc__= 'extended'
+        self.assertEqual(p.__doc__, 'extended')
 
-    # def test_property_decorator_doc_writable(self):
-    #     class PropertyWritableDoc(object):
-    #
-    #         @property
-    #         def spam(self):
-    #             """Eggs"""
-    #             return "eggs"
-    #
-    #     sub = PropertyWritableDoc()
-    #     self.assertEqual(sub.__class__.spam.__doc__, 'Eggs')
-    #     sub.__class__.spam.__doc__ = 'Spam'
-    #     self.assertEqual(sub.__class__.spam.__doc__, 'Spam')
+    def test_property_decorator_doc_writable(self):
+        class PropertyWritableDoc(object):
+    
+            @property
+            def spam(self):
+                """Eggs"""
+                return "eggs"
+    
+        sub = PropertyWritableDoc()
+        self.assertEqual(sub.__class__.spam.__doc__, 'Eggs')
+        sub.__class__.spam.__doc__ = 'Spam'
+        self.assertEqual(sub.__class__.spam.__doc__, 'Spam')
 
 # Issue 5890: subclasses of property do not preserve method __doc__ strings
 class PropertySub(property):
@@ -191,68 +191,68 @@ class FooSub(Foo):
 
 class PropertySubclassTests(unittest.TestCase):
 
-    # def test_slots_docstring_copy_exception(self):
-    #     try:
-    #         class Foo(object):
-    #             @PropertySubSlots
-    #             def spam(self):
-    #                 """Trying to copy this docstring will raise an exception"""
-    #                 return 1
-    #     except AttributeError:
-    #         pass
-    #     else:
-    #         raise Exception("AttributeError not raised")
-    #
-    # def test_docstring_copy(self):
-    #     class Foo(object):
-    #         @PropertySub
-    #         def spam(self):
-    #             """spam wrapped in property subclass"""
-    #             return 1
-    #     self.assertEqual(
-    #         Foo.spam.__doc__,
-    #         "spam wrapped in property subclass")
+    def test_slots_docstring_copy_exception(self):
+        try:
+            class Foo(object):
+                @PropertySubSlots
+                def spam(self):
+                    """Trying to copy this docstring will raise an exception"""
+                    return 1
+        except AttributeError:
+            pass
+        else:
+            raise Exception("AttributeError not raised")
+    
+    def test_docstring_copy(self):
+        class Foo(object):
+            @PropertySub
+            def spam(self):
+                """spam wrapped in property subclass"""
+                return 1
+        self.assertEqual(
+            Foo.spam.__doc__,
+            "spam wrapped in property subclass")
 
     def test_property_setter_copies_getter_docstring(self):
         foo = Foo()
         self.assertEqual(foo.spam, 1)
         foo.spam = 2
         self.assertEqual(foo.spam, 2)
-        # self.assertEqual(
-        #     Foo.spam.__doc__,
-        #     "spam wrapped in property subclass")
+        self.assertEqual(
+            Foo.spam.__doc__,
+            "spam wrapped in property subclass")
 
         foosub = FooSub()
         self.assertEqual(foosub.spam, 1)
         foosub.spam = 7
         self.assertEqual(foosub.spam, 'eggs')
-        # self.assertEqual(
-        #     FooSub.spam.__doc__,
-        #     "spam wrapped in property subclass")
+        self.assertEqual(
+            FooSub.spam.__doc__,
+            "spam wrapped in property subclass")
 
-    # def test_property_new_getter_new_docstring(self):
-    #
-    #     class Foo(object):
-    #         @PropertySub
-    #         def spam(self):
-    #             """a docstring"""
-    #             return 1
-    #         @spam.getter
-    #         def spam(self):
-    #             """a new docstring"""
-    #             return 2
-    #     self.assertEqual(Foo.spam.__doc__, "a new docstring")
-    #     class FooBase(object):
-    #         @PropertySub
-    #         def spam(self):
-    #             """a docstring"""
-    #             return 1
-    #     class Foo2(FooBase):
-    #         @FooBase.spam.getter
-    #         def spam(self):
-    #             """a new docstring"""
-    #             return 2
-    #     self.assertEqual(Foo.spam.__doc__, "a new docstring")
+    def test_property_new_getter_new_docstring(self):
+    
+        class Foo(object):
+            @PropertySub
+            def spam(self):
+                """a docstring"""
+                return 1
+            @spam.getter
+            def spam(self):
+                """a new docstring"""
+                return 2
+        self.assertEqual(Foo.spam.__doc__, "a new docstring")
+        # class FooBase(object):
+        #     @PropertySub
+        #     def spam(self):
+        #         """a docstring"""
+        #         return 1
+        # class Foo2(FooBase):
+        #     @FooBase.spam.getter
+        #     def spam(self):
+        #         """a new docstring"""
+        #         return 2
+        # self.assertEqual(Foo.spam.__doc__, "a new docstring")
 
 class TestDecorators(unittest.TestCase):
 


### PR DESCRIPTION
allows property to be subclassed correctly
and fixes doc issues from the test, uncommenting out some tests from the test suite