### PR TITLE
dict: fix setattr should not call mp$ass_subscript on the `__dict__`

### DIFF
--- a/src/generic.js
+++ b/src/generic.js
@@ -83,21 +83,18 @@ Sk.generic.setAttr = function __setattr__(pyName, value, canSuspend) {
     }
 
     const dict = this.$d;
-    if (dict !== undefined) {
-        if (dict.mp$ass_subscript) {
+    if (dict !== undefined && dict !== null) {
+        if (dict.dict$setItem) {
             if (value !== undefined) {
-                return dict.mp$ass_subscript(pyName, value);
+                return dict.dict$setItem(pyName, value);
             } else {
-                try {
-                    return dict.mp$ass_subscript(pyName);
-                } catch (e) {
-                    if (e instanceof Sk.builtin.KeyError) {
-                        throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(this) + "' object has no attribute '" + pyName.$jsstr() + "'");
-                    }
-                    throw e;
+                const err = dict.dict$delItem(pyName);
+                if (err) {
+                    throw new Sk.builtin.AttributeError("'" + Sk.abstr.typeName(this) + "' object has no attribute '" + pyName.$jsstr() + "'");
                 }
+                return;
             }
-        } else if (typeof dict === "object") {
+        } else if (typeof dict === "object" && !dict.sk$object) {
             const jsMangled = pyName.$mangled;
             if (value !== undefined) {
                 dict[jsMangled] = value;

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -50,5 +50,30 @@ class TestAnnotations(unittest.TestCase):
         annotations = An.__annotations__
         self.assertEqual(annotations, {"name": str, "_An__foo": int})
 
+
+class TestDict(unittest.TestCase):
+    def test_override_dunder_dict(self):
+        class D(dict):
+            called = False
+            def __getitem__(self, key):
+                self.called = True
+                return dict.__getitem__(self, key)
+
+            def __setitem__(self, key, value):
+                self.called = True
+                return dict.__setitem__(self, key, value)
+
+        class A:
+            def __init__(self):
+                self.__dict__ = D()
+        
+        a = A()
+
+        self.assertFalse(a.__dict__.called)
+        a.foo = "bar"
+        self.assertFalse(a.__dict__.called)
+        self.assertEqual(a.foo, "bar")
+        self.assertFalse(a.__dict__.called)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`mp$ass_subscript` is overridden by `__setitem__`
And if strangely if you override the `__dict__` of an object with a dict subclass, this method is never called.

Minor change
Just for correctness
I couldn't find any CPython tests for this, so I added a custom test and ran it against Cpython

I changed the name of `set$item` to `dict$setItem` to better match cPython's `_pyObjectDict_SetItem`
