### PR TITLE
ffi: wrap Symbols

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -57,6 +57,8 @@ function toPy(obj, hooks) {
 
     if (type === "string") {
         return new Sk.builtin.str(obj);
+    } else if (type === "symbol") {
+        return new WrappedSymbol(obj);
     } else if (type === "number") {
         return numberToPy(obj);
     } else if (type === "boolean") {
@@ -156,6 +158,8 @@ function toJs(obj, hooks) {
 
     if (type === "string") {
         return hooks.stringHook ? hooks.stringHook(val) : val;
+    } else if (type === "symbol") {
+        return val;
     } else if (type === "boolean") {
         return val;
     } else if (type === "number") {
@@ -739,3 +743,23 @@ function checkBodyIsMaybeConstructor(obj) {
         return !noNewNeeded.has(obj);
     }
 }
+
+
+const WrappedSymbol = Sk.abstr.buildNativeClass("ProxySymbol", {
+    constructor: function WrappedSymbol(symbol) {
+        this.v = symbol;
+    },
+    slots: {
+        $r() {
+            return new Sk.builtin.str(this.toString());
+        }
+    },
+    proto: {
+        toString() {
+            return this.v.toString();
+        },
+        valueOf() {
+            return this.v;
+        }
+    }
+});


### PR DESCRIPTION
At the moment symbols get lost in the ffi toPy/toJs conversion
And if you're doing something crazy like getting a ReactComponent inside Skulpt
then you get:

```python
{'$$typeof': Symbol(react.element), ...}
```

So it helps if you can handle Symbols

(Small change)