### PR TITLE
ffi: preserve arrays on javascript objects

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -761,8 +761,6 @@ const arrayHandler = {
         if (rv === undefined && !(attr in target)) {
             return rv;
         }
-        console.log(attr, target);
-        debugger;
         // attributes on the list instance;
         return toPy(rv, pyHooks);
     },

--- a/src/ffi.js
+++ b/src/ffi.js
@@ -303,7 +303,7 @@ function toPyDict(obj, hooks) {
 // cache the proxied objects in a weakmap
 const _proxied = new WeakMap();
 
-// use proxy if you want to proxy an arbirtrary js object
+// use proxy if you want to proxy an arbitrary js object
 // the only flags currently used is {bound: some_js_object}
 function proxy(obj, flags) {
     if (obj === null || obj === undefined) {
@@ -324,7 +324,7 @@ function proxy(obj, flags) {
         }
     }
     let rv;
-    if (Array.isArray(obj)) {
+    if (type !== "function" && Array.isArray(obj)) {
         rv = new JsProxyList(obj);
     } else {
         rv = new JsProxy(obj, flags);

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -1,0 +1,44 @@
+"""Unit tests for zero-argument super() & related machinery."""
+
+import unittest
+
+
+window = jseval("self")
+
+class TestProxyArray(unittest.TestCase):
+    def test_basic(self):
+        x = [1, 2, 3]
+        window.x = x
+        self.assertIsNot(x, window.x)
+        self.assertEqual(x, window.x)
+
+        x = window.x
+        self.assertIs(x, window.x)
+
+        self.assertIsInstance(x, list)
+        x.append(4)
+        x.push(5)
+        self.assertEqual(x, [1, 2, 3, 4, 5])
+        self.assertEqual(len(x), 5)
+
+        c = x.copy()
+        self.assertIs(type(c), list)
+        self.assertEqual(c, x)
+
+        x.foo = "bar"
+        self.assertEqual(x.foo, "bar")
+
+        r = x.splice(3, 2)
+        self.assertEqual(r, [4, 5])
+
+        r = x.map(lambda v, *args: v + 1)
+        self.assertEqual(r, [v + 1 for v in x]) 
+
+        i = x.pop()
+        self.assertEqual(i, 3)
+        i = x.pop(0) # use python method over js method here
+        self.assertEqual(i, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -3,7 +3,7 @@
 import unittest
 
 
-window = jseval("self")
+window = jseval("Sk.global")
 
 class TestProxyArray(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
Currently when we interop with javascript objects on window,
if we get an array, we return a python copy of this array

I've found this to be problematic since,
- we lose mutability
- some javascript libraries do crazy things with arrays
  (See below)

When returning an Array from a proxied javascript object
This PR instead returns a ProxyList
Which is very similar to a python list (it's even a subclass)
But, the internal Array is a Proxy of the original Javascript Array
Now we essentially have the same reference and mutating the ProxyList mutates the original list

I've added tests to demonstrate this interopability

---

Example in an app we had failing:

```javascript
// initial page script
function(){var analytics=window.analytics=window.analytics||[];//...}

```
The script used an array as a placeholder while the real `window.analytics` object was loaded.
It then preceded to do things like analytics.track=()=>{...}
But interop converted `window.analytics` to a pure python list so it wasn't possible to use the placeholder in python.
With this PR the `window.analytics` would be a `proxylist` and so accessing the `track` method in python would work.

---

Considerations

Why not two way?
i.e. sending a python list to a proxied javascript object should hold a reference to the original python list.
I'm happy to add support for this
But I felt it was less of a concern

