### PR TITLE
ffi - map and set behaviour

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -330,7 +330,7 @@ function proxy(obj, flags) {
         rv = new JsProxy(obj, flags);
     } else if (Array.isArray(obj)) {
         rv = new JsProxyList(obj);
-    } else  {
+    } else {
         const constructor = obj.constructor;
         if (constructor === Map) {
             rv = new JsProxyMap(obj);
@@ -339,7 +339,7 @@ function proxy(obj, flags) {
         } else {
             rv = new JsProxy(obj, flags);
         }
-    } 
+    }
     _proxied.set(obj, rv);
     return rv;
 }
@@ -462,9 +462,7 @@ const JsProxy = Sk.abstr.buildNativeClass("Proxy", {
         tp$getattr(pyName) {
             return this.$lookup(pyName) || Sk.generic.getAttr.call(this, pyName);
         },
-        tp$setattr(pyName, pyValue) {
-            return setJsProxyAttr.call(this, pyName, pyValue);
-        },
+        tp$setattr: setJsProxyAttr,
         $r() {
             if (this.is$callable) {
                 if (this.is$type || !this.$bound) {
@@ -560,10 +558,6 @@ const JsProxy = Sk.abstr.buildNativeClass("Proxy", {
         },
         keys: {
             $meth() {
-                // dict calls this method rather than self.keys()
-                if ("keys" in this.js$wrapped) {
-                    return toPy(this.js$wrapped.keys(), pyHooks);
-                }
                 return new Sk.builtin.list(Object.keys(this.js$wrapped).map((x) => new Sk.builtin.str(x)));
             },
             $flags: { NoArgs: true },
@@ -800,7 +794,7 @@ function pop$item(k) {
         this.js$wrapped.delete(jsKey);
         return rv;
     }
-};
+}
 
 const JsProxyMap = Sk.abstr.buildNativeClass("ProxyMap", {
     base: Sk.builtin.dict,
@@ -812,7 +806,7 @@ const JsProxyMap = Sk.abstr.buildNativeClass("ProxyMap", {
         tp$getattr: proxyGetAttr,
         $r() {
             return new Sk.builtin.str(`ProxyMap(${Sk.builtin.dict.prototype.$r.call(this)})`);
-        }
+        },
     },
     proto: {
         $lookup: JsProxy.prototype.$lookup,
@@ -834,9 +828,8 @@ const JsProxyMap = Sk.abstr.buildNativeClass("ProxyMap", {
     },
     $flags: {
         sk$acceptable_as_base_class: false,
-    }
+    },
 });
-
 
 const InternalProxySet = Sk.abstr.buildNativeClass("InternalProxySet", {
     base: Sk.builtin.dict,
@@ -845,7 +838,6 @@ const InternalProxySet = Sk.abstr.buildNativeClass("InternalProxySet", {
         this.js$wrapped = obj;
     },
     proto: {
-        $lookup: JsProxy.prototype.$lookup,
         proxy$getItem(k) {
             return true;
         },
@@ -863,7 +855,6 @@ const InternalProxySet = Sk.abstr.buildNativeClass("InternalProxySet", {
     },
 });
 
-
 const JsProxySet = Sk.abstr.buildNativeClass("ProxySet", {
     base: Sk.builtin.set,
     constructor: function (obj) {
@@ -879,10 +870,8 @@ const JsProxySet = Sk.abstr.buildNativeClass("ProxySet", {
     },
     $flags: {
         sk$acceptable_as_base_class: false,
-    }
+    },
 });
-
-
 
 const ArrayFunction = {
     apply(target, thisArg, argumentsList) {

--- a/src/set.js
+++ b/src/set.js
@@ -353,7 +353,7 @@ Sk.builtin.set = Sk.abstr.buildNativeClass("set", {
             return this.v.pop$item(entry);
         },
         set$clear() {
-            this.v = new Sk.builtin.dict([]);
+            this.v.dict$clear();
         },
         set$copy() {
             const setCopy = new this.sk$builtinBase();

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -45,7 +45,7 @@ class TestProxyArray(unittest.TestCase):
         x = [["a", 1], ["b", 2]]
         m = window.Map(x)
         self.assertTrue(m.has, "a")
-        self.assertEqual(list(m), x)
+        self.assertEqual(list(m), list(m.keys()))
         self.assertEqual(x, [[k, v] for k, v in dict(x).items()])
         m["b"] = 3
         self.assertEqual(m.get("b"), 3)
@@ -56,6 +56,8 @@ class TestProxyArray(unittest.TestCase):
         self.assertTrue(s.has("a"))
         self.assertEqual(list(s), x)
         self.assertIn("b", s)
+        s.add("d")
+        self.assertIn("d", s)
 
         # Don't convert a python set to a javascript set
         s = {"a", "b", "c"}

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -39,6 +39,18 @@ class TestProxyArray(unittest.TestCase):
         i = x.pop(0) # use python method over js method here
         self.assertEqual(i, 1)
 
+    def test_set_map(self):
+        # these should remain as js Sets/Maps when coming from javascript
+        x = [["a", 1], ["b", 2]]
+        m = window.Map(x)
+        self.assertTrue(m.has, "a")
+        self.assertEqual(list(m), x)
+
+        x = ["a", "b", "c"]
+        s = window.Set(x)
+        self.assertTrue(s.has("a"))
+        self.assertEqual(list(s), x)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -51,6 +51,11 @@ class TestProxyArray(unittest.TestCase):
         self.assertTrue(s.has("a"))
         self.assertEqual(list(s), x)
 
+        # Don't convert a python set to a javascript set
+        s = {'a', 'b', 'c'}
+        window.s = s
+        self.assertIs(s, window.s)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -5,6 +5,7 @@ import unittest
 
 window = jseval("Sk.global")
 
+
 class TestProxyArray(unittest.TestCase):
     def test_basic(self):
         x = [1, 2, 3]
@@ -32,11 +33,11 @@ class TestProxyArray(unittest.TestCase):
         self.assertEqual(r, [4, 5])
 
         r = x.map(lambda v, *args: v + 1)
-        self.assertEqual(r, [v + 1 for v in x]) 
+        self.assertEqual(r, [v + 1 for v in x])
 
         i = x.pop()
         self.assertEqual(i, 3)
-        i = x.pop(0) # use python method over js method here
+        i = x.pop(0)  # use python method over js method here
         self.assertEqual(i, 1)
 
     def test_set_map(self):
@@ -45,14 +46,19 @@ class TestProxyArray(unittest.TestCase):
         m = window.Map(x)
         self.assertTrue(m.has, "a")
         self.assertEqual(list(m), x)
+        self.assertEqual(x, [[k, v] for k, v in dict(x).items()])
+        m["b"] = 3
+        self.assertEqual(m.get("b"), 3)
+        self.assertIn("b", m)
 
         x = ["a", "b", "c"]
         s = window.Set(x)
         self.assertTrue(s.has("a"))
         self.assertEqual(list(s), x)
+        self.assertIn("b", s)
 
         # Don't convert a python set to a javascript set
-        s = {'a', 'b', 'c'}
+        s = {"a", "b", "c"}
         window.s = s
         self.assertIs(s, window.s)
 


### PR DESCRIPTION
This PR changes how we proxy Maps and Sets from javascript to python

previously if a javascript library returned a Map or a Set we would receive a python dict/set respectively
This is problematic since the objects lose mutability

In this PR we create ProxyMap and ProxySet that are subclasses of dict/set
These proxy versions mean we maintain mutability
And it's also backwards compatible

