### PR TITLE
ffi: fix re-assign list to window should be the same object

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -409,6 +409,9 @@ const unhandledPythonObject = (obj) => {
 
 const jsHooks = {
     unhandledHook: unhandledPythonObject,
+    arrayHook: (obj) => {
+        return obj[PROXY_SYMBOL] || obj.map((x) => toJs(x, jsHooks));
+    },
 };
 
 // we customize the dictHook and the funcHook here - we want to keep object literals as proxied objects when remapping to Py
@@ -884,9 +887,13 @@ const ArrayFunction = {
 
 const arrayMethods = {};
 const ArrayProto = Array.prototype;
+const PROXY_SYMBOL = Symbol("$proxy");
 
 const arrayHandler = {
     get(target, attr) {
+        if (attr === PROXY_SYMBOL) {
+            return target;
+        }
         const rv = target[attr];
         if (attr in ArrayProto) {
             // internal calls like this.v.pop(); this.v.push(x);

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -15,6 +15,8 @@ class TestProxyArray(unittest.TestCase):
 
         x = window.x
         self.assertIs(x, window.x)
+        window.x = x
+        self.assertIs(x, window.x)
 
         self.assertIsInstance(x, list)
         x.append(4)
@@ -47,6 +49,9 @@ class TestProxyArray(unittest.TestCase):
         x = [["a", 1], ["b", 2]]
         m = window.m = window.Map(x)
         self.assertIs(window.m, m)
+        window.m = m
+        self.assertIs(window.m, m)
+
         self.assertTrue(m.has, "a")
         self.assertEqual(list(m), list(m.keys()))
         self.assertEqual(x, [[k, v] for k, v in dict(x).items()])
@@ -59,6 +64,9 @@ class TestProxyArray(unittest.TestCase):
         x = ["a", "b", "c"]
         s = window.s = window.Set(x)
         self.assertIs(window.s, s)
+        window.s = s
+        self.assertIs(window.s, s)
+
         self.assertTrue(s.has("a"))
         self.assertEqual(list(s), x)
         self.assertIn("b", s)


### PR DESCRIPTION
fix for reassigning a proxied list back to a javascript api
(small change with a test)