### PR TITLE
Fix can't use a proxy list on a frozen array

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -346,9 +346,15 @@ function proxy(obj, flags) {
 
 const proxyHook = (obj) => proxy(obj);
 const dictHook = proxyHook,
-    arrayHook = proxyHook,
     mapHook = proxyHook,
     setHook = proxyHook;
+
+const arrayHook = (obj) => {
+    if (Object.isFrozen(obj)) {
+        return toPyList(obj, pyHooks);
+    }
+    return proxy(obj);
+};
 
 const unhandledHook = (obj) => String(obj);
 

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -74,6 +74,9 @@ class TestProxyArray(unittest.TestCase):
         self.assertIn("d", s)
         self.assertIn("has", dir(s))
 
+    def test_frozen_array(self):
+        jseval("Sk.global.foo = Object.freeze([1, 2, 3])")
+        self.assertEqual(window.foo[0], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The failing test would give you

```

TypeError: 'get' on proxy: property '0' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected '1' but got '[object Object]')

```

So if we encounter a frozen list, then don't use a proxylist, just use a standard python list
