### PR TITLE
ffi: preserve identity of methods into javascript

### DIFF
--- a/src/method.js
+++ b/src/method.js
@@ -51,7 +51,7 @@ Sk.builtin.method = Sk.abstr.buildNativeClass("method", {
             }
             let eq;
             try {
-                eq = Sk.misceval.richCompareBool(this.im_self, other.im_self, "Eq", false) && this.im_func == other.im_func;
+                eq = Sk.misceval.richCompareBool(this.im_self, other.im_self, "Eq", false) && this.im_func === other.im_func;
             } catch (x) {
                 eq = false;
             }

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -60,7 +60,6 @@ class TestProxyArray(unittest.TestCase):
         self.assertIn("b", m)
         self.assertIn("has", dir(m))
 
-
         x = ["a", "b", "c"]
         s = window.s = window.Set(x)
         self.assertIs(window.s, s)
@@ -77,6 +76,19 @@ class TestProxyArray(unittest.TestCase):
     def test_frozen_array(self):
         jseval("Sk.global.foo = Object.freeze([1, 2, 3])")
         self.assertEqual(window.foo[0], 1)
+
+    def test_preserve_method_identity(self):
+        class Foo:
+            def bar(self):
+                pass
+
+        foo = Foo()
+        method_1 = foo.bar
+        method_2 = foo.bar
+        window.method_1 = method_1
+        window.method_2 = method_2
+        self.assertIsNot(method_1, method_2)
+        self.assertIs(window.method_1, window.method_2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use case

```python
import document
from time import sleep

class Foo:
    def on_mount(self):
        document.addEventListener("click", self.on_click)

    def on_cleanup(self):
        document.removeEventListener("click", self.on_click)

    def on_click(self, event):
        print("document was clicked")

foo = Foo()
foo.on_mount()
sleep(3)
foo.on_cleanup()
```

We would expect that the above code to successfully clean up the click event handler
But currently this doesn't work

the equivalent code would work in javascript because bound methods are identical
whereas in python two methods are not identical

```python
>>> foo.on_click is foo.on_click
False
>>> foo.on_click == foo.on_click
True
```
```javascript
>>> class Foo { bar() {}}
>>> var foo = new Foo()
>>> foo.bar === foo.bar
true
```
This is a big gotcha for event handlers in the interop between python and javascript
This PR uses a weak cache to always send the same method into javascript

