### PR TITLE
ffi: fix converting cross origin windows to python

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -312,7 +312,7 @@ function toPyDict(obj, hooks) {
 
 function isCrossOriginWindow(obj) {
     // based on https://github.com/weizman/is-cross-origin
-    return typeof obj === "object" && obj.window === obj && Object.getPrototypeOf(obj) === null;
+    return obj !== null && typeof obj === "object" && obj.window === obj && Object.getPrototypeOf(obj) === null;
 }
 
 // cache the proxied objects in a weakmap

--- a/src/ffi.js
+++ b/src/ffi.js
@@ -32,6 +32,8 @@ Sk.ffi = {
 
 const OBJECT_PROTO = Object.prototype;
 const FUNC_PROTO = Function.prototype;
+const MAP_PROTO = Map.prototype;
+const SET_PROTO = Set.prototype;
 
 /**
  * maps from Javascript Object/Array/string to Python dict/list/str.
@@ -308,6 +310,11 @@ function toPyDict(obj, hooks) {
     return ret;
 }
 
+function isCrossOriginWindow(obj) {
+    // based on https://github.com/weizman/is-cross-origin
+    return typeof obj === "object" && obj.window === obj && Object.getPrototypeOf(obj) === null;
+}
+
 // cache the proxied objects in a weakmap
 const _proxied = new WeakMap();
 const methodSelfCache = new WeakMap();
@@ -338,10 +345,10 @@ function proxy(obj, flags) {
     } else if (Array.isArray(obj)) {
         rv = new JsProxyList(obj);
     } else {
-        const constructor = obj.constructor;
-        if (constructor === Map) {
+        const proto = Object.getPrototypeOf(obj);
+        if (proto === MAP_PROTO) {
             rv = new JsProxyMap(obj);
-        } else if (constructor === Set) {
+        } else if (proto === SET_PROTO) {
             rv = new JsProxySet(obj);
         } else {
             rv = new JsProxy(obj, flags);
@@ -667,6 +674,10 @@ const JsProxy = Sk.abstr.buildNativeClass("Proxy", {
             const jsName = pyName.toString();
             const attr = this.js$wrapped[jsName];
             if (attr !== undefined) {
+                if (isCrossOriginWindow(attr)) {
+                    // we can't do the usual toPy dance, since accessing attributes breaks the same-origin policy
+                    return proxy(attr, { name: "CrossOriginWindow" });
+                }
                 // here we override the funcHook to pass the bound object
                 return toPy(attr, boundHook(this.js$wrapped, jsName));
             } else if (jsName in this.js$wrapped) {

--- a/test/unit3/test_skulpt_interop.py
+++ b/test/unit3/test_skulpt_interop.py
@@ -91,6 +91,9 @@ class TestProxyArray(unittest.TestCase):
         self.assertIs(window.method_1, window.method_2)
     
     def test_cross_origin_window(self):
+        window.x = {"foo": None}
+        self.assertIsNone(window.x.foo)
+
         if "window" not in window:
             # can't test this in a node environment
             return


### PR DESCRIPTION
Advanced use case of the ffi module is to have an iframe in python and post messages to the iframe's `contentWindow`

When we access the `contentWindow` we try to convert this object to a python object.
But we break the browser's same origin policy when we access properties like `sk$object` or `$isPyWrapped` when determining what type of object we are converting to python.
https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#window

This PR adds a check in the Proxy object lookup to determine if the attribute is a cross origin window object
If it is, we shortcut the code and return a Proxy object rather than going through `toPy`.

I added tests that can be run in the browser
But these tests won't run in a node environment



