### PR TITLE
bytes: support decode encodings that the browser supports #noa

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16.x"
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
while encoding in the browser is only valid for utf8,
the browser's TextDecoder supports various decode encodings

https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings

This PR uses the browsers decode implementation if available
adds a couple of tests

