### PR TITLE
decorators: add 3.10 changes to static/class methods

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ Sk.builtin.str.$imag = new Sk.builtin.str("imag");
 Sk.builtin.str.$real = new Sk.builtin.str("real");
 
 Sk.builtin.str.$abs = new Sk.builtin.str("__abs__");
+Sk.builtin.str.$ann = new Sk.builtin.str("__annotations__");
 Sk.builtin.str.$bases = new Sk.builtin.str("__bases__");
 Sk.builtin.str.$bytes = new Sk.builtin.str("__bytes__");
 Sk.builtin.str.$call = new Sk.builtin.str("__call__");

--- a/src/property_class_static.js
+++ b/src/property_class_static.js
@@ -42,8 +42,7 @@ Sk.builtin.property = Sk.abstr.buildNativeClass("property", {
                 this.tp$setattr(Sk.builtin.str.$doc, this.prop$doc);
             }
         },
-        tp$doc:
-            "Property attribute.\n\n  fget\n    function to be used for getting an attribute value\n  fset\n    function to be used for setting an attribute value\n  fdel\n    function to be used for del'ing an attribute\n  doc\n    docstring\n\nTypical use is to define a managed attribute x:\n\nclass C(object):\n    def getx(self): return self._x\n    def setx(self, value): self._x = value\n    def delx(self): del self._x\n    x = property(getx, setx, delx, 'I'm the 'x' property.')\n\nDecorators make defining new properties or modifying existing ones easy:\n\nclass C(object):\n    @property\n    def x(self):\n        'I am the 'x' property.'\n        return self._x\n    @x.setter\n    def x(self, value):\n        self._x = value\n    @x.deleter\n    def x(self):\n        del self._x",
+        tp$doc: "Property attribute.\n\n  fget\n    function to be used for getting an attribute value\n  fset\n    function to be used for setting an attribute value\n  fdel\n    function to be used for del'ing an attribute\n  doc\n    docstring\n\nTypical use is to define a managed attribute x:\n\nclass C(object):\n    def getx(self): return self._x\n    def setx(self, value): self._x = value\n    def delx(self): del self._x\n    x = property(getx, setx, delx, 'I'm the 'x' property.')\n\nDecorators make defining new properties or modifying existing ones easy:\n\nclass C(object):\n    @property\n    def x(self):\n        'I am the 'x' property.'\n        return self._x\n    @x.setter\n    def x(self, value):\n        self._x = value\n    @x.deleter\n    def x(self):\n        del self._x",
         tp$descr_get(obj, type, canSuspend) {
             if (obj === null) {
                 return this;
@@ -121,7 +120,7 @@ Sk.builtin.property = Sk.abstr.buildNativeClass("property", {
             $set(value) {
                 value = value || Sk.builtin.none.none$;
                 this.prop$doc = value;
-            }
+            },
         },
     },
     proto: {
@@ -135,15 +134,31 @@ Sk.builtin.property = Sk.abstr.buildNativeClass("property", {
             } else {
                 return type.tp$call(args);
             }
-        }
-    }
+        },
+    },
 });
+
+function copyAttr(wrapper, wrapped, name) {
+    try {
+        const v = wrapped.tp$getattr(name);
+        wrapper.tp$setattr(name, v);
+    } catch {
+        // pass
+    }
+}
+
+function functoolsWraps(wrapper, wrapped) {
+    copyAttr(wrapper, wrapped, Sk.builtin.str.$module);
+    copyAttr(wrapper, wrapped, Sk.builtin.str.$name);
+    copyAttr(wrapper, wrapped, Sk.builtin.str.$qualname);
+    copyAttr(wrapper, wrapped, Sk.builtin.str.$doc);
+    copyAttr(wrapper, wrapped, Sk.builtin.str.$ann);
+}
 
 /**
  * @constructor
  * @param {Sk.builtin.func} callable
  */
-
 Sk.builtin.classmethod = Sk.abstr.buildNativeClass("classmethod", {
     constructor: function classmethod(callable) {
         // this can be used as an internal function
@@ -158,9 +173,12 @@ Sk.builtin.classmethod = Sk.abstr.buildNativeClass("classmethod", {
             Sk.abstr.checkNoKwargs("classmethod", kwargs);
             Sk.abstr.checkArgsLen("classmethod", args, 1, 1);
             this.cm$callable = args[0];
+            functoolsWraps(this, args[0]);
         },
-        tp$doc:
-            "classmethod(function) -> method\n\nConvert a function to be a class method.\n\nA class method receives the class as implicit first argument,\njust like an instance method receives the instance.\nTo declare a class method, use this idiom:\n\n  class C:\n      @classmethod\n      def f(cls, arg1, arg2, ...):\n          ...\n\nIt can be called either on the class (e.g. C.f()) or on an instance\n(e.g. C().f()).  The instance is ignored except for its class.\nIf a class method is called for a derived class, the derived class\nobject is passed as the implied first argument.\n\nClass methods are different than C++ or Java static methods.\nIf you want those, see the staticmethod builtin.",
+        $r() {
+            return new Sk.builtin.str(`<classmethod(${Sk.misceval.objectRepr(this.cm$callable)})>`);
+        },
+        tp$doc: "classmethod(function) -> method\n\nConvert a function to be a class method.\n\nA class method receives the class as implicit first argument,\njust like an instance method receives the instance.\nTo declare a class method, use this idiom:\n\n  class C:\n      @classmethod\n      def f(cls, arg1, arg2, ...):\n          ...\n\nIt can be called either on the class (e.g. C.f()) or on an instance\n(e.g. C().f()).  The instance is ignored except for its class.\nIf a class method is called for a derived class, the derived class\nobject is passed as the implied first argument.\n\nClass methods are different than C++ or Java static methods.\nIf you want those, see the staticmethod builtin.",
         tp$descr_get(obj, type, canSuspend) {
             const callable = this.cm$callable;
             if (callable === undefined) {
@@ -178,6 +196,11 @@ Sk.builtin.classmethod = Sk.abstr.buildNativeClass("classmethod", {
     },
     getsets: {
         __func__: {
+            $get() {
+                return this.cm$callable;
+            },
+        },
+        __wrapped__: {
             $get() {
                 return this.cm$callable;
             },
@@ -205,9 +228,15 @@ Sk.builtin.staticmethod = Sk.abstr.buildNativeClass("staticmethod", {
             Sk.abstr.checkNoKwargs("staticmethod", kwargs);
             Sk.abstr.checkArgsLen("staticmethod", args, 1, 1);
             this.sm$callable = args[0];
+            functoolsWraps(this, args[0]);
         },
-        tp$doc:
-            "staticmethod(function) -> method\n\nConvert a function to be a static method.\n\nA static method does not receive an implicit first argument.\nTo declare a static method, use this idiom:\n\n     class C:\n         @staticmethod\n         def f(arg1, arg2, ...):\n             ...\n\nIt can be called either on the class (e.g. C.f()) or on an instance\n(e.g. C().f()).  The instance is ignored except for its class.\n\nStatic methods in Python are similar to those found in Java or C++.\nFor a more advanced concept, see the classmethod builtin.",
+        $r() {
+            return new Sk.builtin.str(`<staticmethod(${Sk.misceval.objectRepr(this.sm$callable)})>`);
+        },
+        tp$call(args, kws) {
+            return Sk.misceval.callsimOrSuspendArray(this.sm$callable, args, kws);
+        },
+        tp$doc: "staticmethod(function) -> method\n\nConvert a function to be a static method.\n\nA static method does not receive an implicit first argument.\nTo declare a static method, use this idiom:\n\n     class C:\n         @staticmethod\n         def f(arg1, arg2, ...):\n             ...\n\nIt can be called either on the class (e.g. C.f()) or on an instance\n(e.g. C().f()).  The instance is ignored except for its class.\n\nStatic methods in Python are similar to those found in Java or C++.\nFor a more advanced concept, see the classmethod builtin.",
         tp$descr_get(obj, type) {
             if (this.sm$callable === undefined) {
                 throw new Sk.builtin.RuntimeError("uninitialized staticmethod object");
@@ -217,6 +246,11 @@ Sk.builtin.staticmethod = Sk.abstr.buildNativeClass("staticmethod", {
     },
     getsets: {
         __func__: {
+            $get() {
+                return this.sm$callable;
+            },
+        },
+        __wrapped__: {
             $get() {
                 return this.sm$callable;
             },

--- a/test/unit3/test_decorators.py
+++ b/test/unit3/test_decorators.py
@@ -263,6 +263,33 @@ class TestDecorators(unittest.TestCase):
         self.assertEqual(C.foo(), 42)
         self.assertEqual(C().foo(), 42)
 
+    def check_wrapper_attrs(self, method_wrapper, format_str):
+        def func(x):
+            return x
+        wrapper = method_wrapper(func)
+
+        self.assertIs(wrapper.__func__, func)
+        self.assertIs(wrapper.__wrapped__, func)
+
+        for attr in ('__module__', '__qualname__', '__name__',
+                     '__doc__', '__annotations__'):
+            self.assertIs(getattr(wrapper, attr),
+                          getattr(func, attr))
+
+        self.assertEqual(repr(wrapper), format_str.format(func))
+        return wrapper
+
+    def test_staticmethod(self):
+        wrapper = self.check_wrapper_attrs(staticmethod, '<staticmethod({!r})>')
+
+        # bpo-43682: Static methods are callable since Python 3.10
+        self.assertEqual(wrapper(1), 1)
+
+    def test_classmethod(self):
+        wrapper = self.check_wrapper_attrs(classmethod, '<classmethod({!r})>')
+
+        self.assertRaises(TypeError, wrapper, 1)
+
     def test_staticmethods(self):
         # Testing static methods...
         class C(object):

--- a/test/unit3/test_descr.py
+++ b/test/unit3/test_descr.py
@@ -1550,7 +1550,9 @@ order (MRO) for bases """
         self.assertEqual(d.foo(1), (d, 1))
         self.assertEqual(D.foo(d, 1), (d, 1))
         # Test for a specific crash (SF bug 528132)
-        def f(cls, arg): return (cls, arg)
+        def f(cls, arg):
+            "f docstring"
+            return (cls, arg)
         ff = classmethod(f)
         self.assertEqual(ff.__get__(0, int)(42), (int, 42))
         self.assertEqual(ff.__get__(0)(42), (int, 42))
@@ -1576,10 +1578,14 @@ order (MRO) for bases """
             self.fail("classmethod shouldn't accept keyword args")
 
         cm = classmethod(f)
-        self.assertEqual(cm.__dict__, {})
+        cm_dict = {'__annotations__': {},
+                   '__doc__': "f docstring",
+                   '__module__': __name__,
+                   '__name__': 'f',
+                   '__qualname__': f.__qualname__}
         cm.x = 42
         self.assertEqual(cm.x, 42)
-        self.assertEqual(cm.__dict__, {"x" : 42})
+        self.assertEqual(cm.__dict__, {"x" : 42, **cm_dict})
         del cm.x
         self.assertNotHasAttr(cm, "x")
 
@@ -1659,10 +1665,10 @@ order (MRO) for bases """
         self.assertEqual(d.foo(1), (d, 1))
         self.assertEqual(D.foo(d, 1), (d, 1))
         sm = staticmethod(None)
-        self.assertEqual(sm.__dict__, {})
+        self.assertEqual(sm.__dict__, {'__doc__': None})
         sm.x = 42
         self.assertEqual(sm.x, 42)
-        self.assertEqual(sm.__dict__, {"x" : 42})
+        self.assertEqual(sm.__dict__, {"x" : 42, '__doc__': None})
         del sm.x
         self.assertNotHasAttr(sm, "x")
 


### PR DESCRIPTION
in python 310 some enhancements were made to class/staticmethod

> Static methods ([@staticmethod](https://docs.python.org/3.10/library/functions.html#staticmethod)) and class methods ([@classmethod](https://docs.python.org/3.10/library/functions.html#classmethod)) now inherit the method attributes (__module__, __name__, __qualname__, __doc__, __annotations__) and have a new __wrapped__ attribute. Moreover, static methods are now callable as regular functions. (Contributed by Victor Stinner in [bpo-43682](https://bugs.python.org/issue?@action=redirect&bpo=43682).)

This PR adds support for this feature and copies the tests from cpython