### PR TITLE
Line numbers are invalid after a function call

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -915,10 +915,7 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
         case Sk.astnodes.Compare:
             return this.ccompare(e);
         case Sk.astnodes.Call:
-            result = this.ccall(e);
-            // After the function call, we've returned to this line
-            this.annotateSource(e);
-            return result;
+            return this.ccall(e);
         case Sk.astnodes.Num:
             if (typeof e.n === "number") {
                 return e.n;

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -92,5 +92,24 @@ class TestDict(unittest.TestCase):
         self.assertFalse(a.__dict__.called)
 
 
+
+class TestLineNoErrorBug(unittest.TestCase):
+    def test_error_after_func_call(self):
+        global err
+
+        import time
+        class Foo:
+            def __init__(self):
+                f"{time.time()} {self.bar}"
+        
+        with self.assertRaises(AttributeError) as e:
+            Foo()
+        
+        err = e.exception
+        # hack because traceback is not exposed in python yet
+        lineno = jseval("Sk.globals['err'].traceback[0].lineno")
+        self.assertNotEqual(lineno, 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This seems like an old piece of code that was superseded by other code
And doesn't cause issues generally since the line no is corrected when we visit the next expression

The test case is an edge case where a function call inside an f string exposes the incorrect line no
