### PR TITLE
Feat: add lineno, col_offset support for alias

### DIFF
--- a/gen/astnodes.js
+++ b/gen/astnodes.js
@@ -1049,10 +1049,12 @@ Sk.astnodes.keyword = function keyword(/* {identifier} */ arg, /* {expr_ty} */
 
 /** @constructor */
 Sk.astnodes.alias = function alias(/* {identifier} */ name, /* {identifier} */
-                                        asname)
+                                        asname, lineno, col_offset)
 {
     this.name = name;
     this.asname = asname;
+    this.lineno = lineno;
+    this.col_offset = col_offset;
     return this;
 }
 

--- a/src/ast.js
+++ b/src/ast.js
@@ -735,7 +735,7 @@ function aliasForImportName (c, n) {
                 if (NCH(n) === 3) {
                     str = CHILD(n, 2).value;
                 }
-                return new Sk.astnodes.alias(name, str == null ? null : strobj(str));
+                return new Sk.astnodes.alias(name, str == null ? null : strobj(str), n.lineno, n.col_offset);
             case SYM.dotted_as_name:
                 if (NCH(n) === 1) {
                     n = CHILD(n, 0);
@@ -750,7 +750,7 @@ function aliasForImportName (c, n) {
                 break;
             case SYM.dotted_name:
                 if (NCH(n) === 1) {
-                    return new Sk.astnodes.alias(strobj(CHILD(n, 0).value), null);
+                    return new Sk.astnodes.alias(strobj(CHILD(n, 0).value), null, n.lineno, n.col_offset);
                 }
                 else {
                     // create a string of the form a.b.c
@@ -758,11 +758,11 @@ function aliasForImportName (c, n) {
                     for (i = 0; i < NCH(n); i += 2) {
                         str += CHILD(n, i).value + ".";
                     }
-                    return new Sk.astnodes.alias(strobj(str.substr(0, str.length - 1)), null);
+                    return new Sk.astnodes.alias(strobj(str.substr(0, str.length - 1)), null, n.lineno, n.col_offset);
                 }
                 break;
             case TOK.T_STAR:
-                return new Sk.astnodes.alias(strobj("*"), null);
+                return new Sk.astnodes.alias(strobj("*"), null, n.lineno, n.col_offset);
             default:
                 throw new Sk.builtin.SyntaxError("unexpected import name", c.c_filename, n.lineno);
         }


### PR DESCRIPTION
This was added in python 3.10
I overrode the astnodes.js file manually
I think that's fine for now

Reason for the change, if we know the alias position then it makes a jump to definition implementation easier from the ast.