### PR TITLE
Add debug suspension logic to ffi python callbacks

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -17,6 +17,7 @@
  * nonreadopen: Boolean - set to true to allow non-read file operations
  * fileopen: Optional function to call any time a file is opened
  * filewrite: Optional function to call when writing to a file
+ * suspensionHandlers: Optional object map of suspension types to their handlers
  *
  * Any variables that aren't set will be left alone.
  */
@@ -205,6 +206,8 @@ Sk.configure = function (options) {
     }
 
     Sk.misceval.softspace_ = false;
+
+    Sk.misceval.defaultHandlers = options.suspensionHandlers || {};
 
     Sk.switch_version(Sk.__future__.python3);
 


### PR DESCRIPTION
This PR builds on #1496 and you only need to look at the final commit
This PR changes the semantics of how python Callables sent to javascript work

Example when we would trigger this logic
```python
import document
btn = document.getElementById("my-button")

def button_click(event):
    ...

btn.addEventListener("click", button_click)

```

The current implementation:
- if a Python function is called from JavaScript (as would happen above when a button is clicked)
- then if the function suspends and the suspension is optional, we skip it
- if the function suspends and is not optional, we return a Promise (e.g. a `sleep(4)`)

The problem:
- If you are using Skulpt's breakpoints
- then you want the python function to suspend
- even when it is used as a callback in javascript

This PR adds some logic (on top of #1496) to address this

A problem with this PR
- if JavaScript uses the return value of the Python callable
- and we use a breakpoint inside this callable
- then when debugging
- the JavaScript will receive a Promise, rather than the expected return value
- I think this compromise is worth it
