### PR TITLE
Intern compiled strings

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -951,7 +951,7 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
             }
             // else fall through and make a string instead
         case Sk.astnodes.Str:
-            return this.makeConstant("new Sk.builtin.str(", getJsLiteralForString(e.s.$jsstr()), ")");
+            return this.makeConstant("new Sk.builtin.str(", getJsLiteralForString(e.s.$jsstr()), ",true)");
         case Sk.astnodes.Attribute:
             if (e.ctx !== Sk.astnodes.AugLoad && e.ctx !== Sk.astnodes.AugStore) {
                 val = this.vexpr(e.value);

--- a/src/str.js
+++ b/src/str.js
@@ -3,6 +3,7 @@ var keyhash_regex = /^[0-9!#_]/;
 // These will be initialized after Sk.builtin.str is defined
 var EMPTY_STRING;
 var INTERNED_ASCII_CHARS = new Array(256);
+var STRING_LITERALS = new Map();
 
 function internString(str) {
     const len = str.length;
@@ -25,7 +26,7 @@ function internString(str) {
  * @extends Sk.builtin.object
  */
 Sk.builtin.str = Sk.abstr.buildNativeClass("str", {
-    constructor: function str(x) {
+    constructor: function str(x, stringLiteral) {
         // new Sk.builtin.str is an internal function called with a JS value x
         // occasionally called with a python object and returns tp$str() or $r();
         Sk.asserts.assert(this instanceof Sk.builtin.str, "bad call to str - use 'new'");
@@ -48,6 +49,13 @@ Sk.builtin.str = Sk.abstr.buildNativeClass("str", {
         let interned = internString(ret);
         if (interned !== undefined) {
             return interned;
+        }
+        if (stringLiteral) {
+            interned = STRING_LITERALS.get(ret);
+            if (interned !== undefined) {
+                return interned;
+            }
+            STRING_LITERALS.set(ret, this);
         }
 
         this.$mangled = fixReserved(ret);


### PR DESCRIPTION
builds on top of #1571 

(see last commit)

I mistakenly thought that compiled strings were already interned
but actually this happens on a per scope basis
I think it's probably worth including this PR so that something like this works

```python
def check(x):
    for x in ("123", "abc"):
        print(x is y)

check("123") # True, False
check("abc") # False, True
```

In Skulpt, after #1481  we get False values because constants in different scopes are not identical
But in CPython we get True values for str literals interned at compile time

