### PR TITLE
Fix object type checks in FFI for obscure objects in python

### DIFF
--- a/src/ffi.js
+++ b/src/ffi.js
@@ -48,14 +48,20 @@ function toPy(obj, hooks) {
         return Sk.builtin.none.none$;
     }
 
-    if (obj.sk$object) {
-        return obj;
-    } else if (obj.$isPyWrapped && obj.unwrap) {
-        // wrap protocol
-        return obj.unwrap();
+    const type = typeof obj;
+
+    if (type === "object" || type === "function") {
+        // test for python object or wrapped object
+        // we use the in operator because some proxy objects e.g. objects wrapped by comlink.js
+        // will always return proxy functions when asked e.g. obj.sk$object => ProxyFunction
+        if ("sk$object" in obj) {
+            return obj;
+        } else if ("$isPyWrapped" in obj && "unwrap" in obj) {
+            // wrap protocol
+            return obj.unwrap();
+        }
     }
 
-    const type = typeof obj;
     hooks = hooks || {};
 
     if (type === "string") {


### PR DESCRIPTION
We've had users wrapping javascript libraries built using comlink js objects

and this small change means that these libraries are usable in skulpt

---

**how the current code fails:**
whenever a `comlink` object does attribute look up, it returns a proxy function
so we were asking a `comlink` object for it's `sk$object` attribute, and it was happily providing us with something.

**how this change fixes this edge case**
`comlink` objects are proxies and don't override the `.has` method trap, and so if we ask for `"sk$object" in obj` we get `false`.
And then everything works.

proxies are notoriously difficult to introspect
there will probably be more edge cases in the future
this change helps with an edge case we've seen a couple of times now
and it won't change semantics for existing success cases.

 