### PR TITLE
Improve behavior of input() when using non-default sys.stdin

### DIFF
--- a/src/builtin.js
+++ b/src/builtin.js
@@ -711,7 +711,8 @@ Sk.builtin.raw_input = function (prompt) {
                     return Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdout"]["write"], [sys["$d"]["stdout"], new Sk.builtin.str(lprompt)]);
                 },
                 function () {
-                    return Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdin"]["readline"], [sys["$d"]["stdin"]]);
+                    const s = Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdin"]["readline"], [sys["$d"]["stdin"]]);
+                    return new Sk.builtin.str(s.$jsstr().replace(/[\r\n]+$/, ""));
                 }
             );
         }

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -701,19 +701,15 @@ Sk.builtin.raw_input = function (prompt) {
     var lprompt = prompt ? prompt : "";
 
     return Sk.misceval.chain(Sk.importModule("sys", false, true), function (sys) {
-        const isTrueStdin = sys["$d"]["stdin"]["fileno"] == 0;
+        const isTrueStdin = sys["$d"]["stdin"]["fileno"] === 0;
         if (Sk.inputfunTakesPrompt && isTrueStdin) {
             return Sk.builtin.file.$readline(sys["$d"]["stdin"], null, lprompt);
         } else {
             return Sk.misceval.chain(
                 undefined,
-                function () {
-                    return Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdout"]["write"], [sys["$d"]["stdout"], new Sk.builtin.str(lprompt)]);
-                },
-                function () {
-                    const s = Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdin"]["readline"], [sys["$d"]["stdin"]]);
-                    return new Sk.builtin.str(s.$jsstr().replace(/[\r\n]+$/, ""));
-                }
+                () => Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdout"]["write"], [sys["$d"]["stdout"], new Sk.builtin.str(lprompt)]),
+                () => Sk.misceval.callsimOrSuspendArray(sys["$d"]["stdin"]["readline"], [sys["$d"]["stdin"]]),
+                (s) => new Sk.builtin.str(s.$jsstr().replace(/[\r\n]+$/, ""))
             );
         }
     });

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -701,7 +701,8 @@ Sk.builtin.raw_input = function (prompt) {
     var lprompt = prompt ? prompt : "";
 
     return Sk.misceval.chain(Sk.importModule("sys", false, true), function (sys) {
-        if (Sk.inputfunTakesPrompt) {
+        const isTrueStdin = sys["$d"]["stdin"]["fileno"] == 0;
+        if (Sk.inputfunTakesPrompt && isTrueStdin) {
             return Sk.builtin.file.$readline(sys["$d"]["stdin"], null, lprompt);
         } else {
             return Sk.misceval.chain(
@@ -791,7 +792,7 @@ Sk.builtin.exec = function (code, globals, locals) {
     );
     /**@todo shouldn't have to do this - Sk.globals loses scope*/
     const tmp = Sk.globals;
-    /** 
+    /**
      * @todo this is not correct outside of __main__ i.e. exec doesn't work inside modules using the module scope
      * This is because globals don't work outside of __main__
     */

--- a/test/unit/test_StringIO.py
+++ b/test/unit/test_StringIO.py
@@ -37,6 +37,14 @@ class TestGenericStringIO(unittest.TestCase):
         sys.stdin = sys.__stdin__
         self.assertEqual(res, "test input")
 
+        #multi-line
+        sys.stdin = StringIO.StringIO("test input\nsecond line")
+        res1 = raw_input()
+        res2 = raw_input()
+        sys.stdin = sys.__stdin__
+        self.assertEqual(res1, "test input")
+        self.assertEqual(res2, "second line")
+
     def test_reads(self):
         eq = self.assertEqual
         self.assertRaises(TypeError, self._fp.seek)


### PR DESCRIPTION
Currently input() is behaving in a non-expected manner in two ways:

- If the `input` function takes a prompt, then `Sk.builtin.file.$readline` is hard-coded to be used, even if `sys.stdin` has been replaced by a `StringIO` object. This function expects the internal structure of a `file` and results in errors if the `sys.stdin` has been redirected to a `StringIO`.
- When `input` uses `readline` to read, it does not remove the possible newline character at the end of the line. This results in somewhat inaccurate behavior in multi-line input cases.

This PR addresses these issues by only using `$readline` in the case where `sys.stdin` has not been replaced, and by trimming the newline character if present on the normal `readline` call.