### PR TITLE
fix class for super in python2

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2144,7 +2144,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     this.u.varDeclsCode += "}";
 
     // inject __class__ cell when running python3
-    if (Sk.__future__.python3 && class_for_super) {
+    if (Sk.__future__.super_args && class_for_super) {
         this.u.varDeclsCode += "$gbl.__class__=$gbl." + class_for_super.v + ";";
     }
 


### PR DESCRIPTION
currently super_args as an argument to __future__ is broken
this PR fixes this issue
minor change
only affects python2 