### PR TITLE
Implement context management for StringIO

### DIFF
--- a/src/lib/StringIO.py
+++ b/src/lib/StringIO.py
@@ -268,3 +268,14 @@ class StringIO:
             self.buf += ''.join(self.buflist)
             self.buflist = []
         return self.buf
+
+    # The following two methods implement the PEP343 context management protocol
+    # for StringIO objects, allowing them to be used in with statements.
+    # In standard Python this is done via inheriting from IOBase
+    # Possible pure Python implementation: https://github.com/python/cpython/blob/main/Lib/_pyio.py
+    def __enter__(self):
+        _complain_ifclosed(self.closed)
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/test/unit/test_StringIO.py
+++ b/test/unit/test_StringIO.py
@@ -45,6 +45,11 @@ class TestGenericStringIO(unittest.TestCase):
         self.assertEqual(res1, "test input")
         self.assertEqual(res2, "second line")
 
+    def test_is_context_manager(self):
+        with StringIO.StringIO("test contents\nsecond line") as f:
+            self.assertEqual(f.read(), "test contents\nsecond line")
+        self.assertTrue(f.closed)
+
     def test_reads(self):
         eq = self.assertEqual
         self.assertRaises(TypeError, self._fp.seek)


### PR DESCRIPTION
This PR adds the context manager methods to StringIO, to bring it more in line with standard Python's `io.StringIO`. This would allow someone to for example overwrite the `open` method with their own simple method to return a StringIO object (e.g. for testing purposes), and then use it in a `with` context (or to be exact, running user code that used a `with` context). Right now they might be a bit surprised that while `StringIO` can act as a stand-in for a file for normal read/write operations, it cannot be used in a `with` context.

Python's StringIO inherits these methods from its class hierarchy, so one option would have been to replicate more of that hierarchy (e.g. https://github.com/python/cpython/blob/main/Lib/_pyio.py) but that felt like overkill perhaps.