### PR TITLE
fix: support tuple unpacking in with statement context manager

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -1728,7 +1728,7 @@ Compiler.prototype.cwith = function (s, itemIdx) {
 
     //    VAR = value
     if (s.items[itemIdx].optional_vars) {
-        this.nameop(s.items[itemIdx].optional_vars.id, Sk.astnodes.Store, value);
+        this.vexpr(s.items[itemIdx].optional_vars, value);
     }
 
     //    (try body)

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -112,6 +112,17 @@ class TestBugs(unittest.TestCase):
         self.assertEqual(A.foo(), 42)
         # shouldn't fail
 
+    def test_with_statement(self):
+        class W:
+            def __enter__(self):
+                return "a", "b"
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+        with W() as (x, y):
+            self.assertEqual(x, "a")
+            self.assertEqual(y, "b")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
added failing test case to highlight the issue

mirrors cpython compile code at the same line
https://github.com/python/cpython/blob/1793b7291f4c360ccbbf13a110abbcdf89c65aec/Python/compile.c#L5933

