### PR TITLE
feat: dataclasses

### DIFF
--- a/src/lib/dataclasses.py
+++ b/src/lib/dataclasses.py
@@ -53,6 +53,18 @@ def _unsupported(feature):
     raise NotImplementedError(feature + " is not supported in skulpt.dataclasses")
 
 
+def _is_classvar(typ):
+    if isinstance(typ, str):
+        return "ClassVar" in typ
+    origin = getattr(typ, "__origin__", None)
+    if origin is not None and getattr(origin, "__name__", "") == "ClassVar":
+        return True
+    typ_name = getattr(typ, "__name__", "")
+    if typ_name == "ClassVar":
+        return True
+    return "ClassVar" in repr(typ)
+
+
 class _DataclassParams:
     def __init__(
         self,
@@ -170,8 +182,6 @@ def field(
 ):
     if default is not MISSING and default_factory is not MISSING:
         raise ValueError("cannot specify both default and default_factory")
-    if kw_only is not MISSING:
-        _unsupported("field(kw_only=...)")
     return Field(
         default=default,
         default_factory=default_factory,
@@ -196,6 +206,12 @@ def _has_default(f):
     return f.default is not MISSING or f.default_factory is not MISSING
 
 
+def _field_is_kw_only(f, default_kw_only):
+    if f.kw_only is MISSING:
+        return default_kw_only
+    return bool(f.kw_only)
+
+
 def _iter_fields(cls):
     all_fields = {}
     for base in reversed(cls.__mro__[1:]):
@@ -214,15 +230,11 @@ def _process_own_fields(cls, all_fields):
             _unsupported("KW_ONLY sentinel")
         if typ is InitVar or isinstance(typ, InitVar):
             _unsupported("InitVar")
+        if _is_classvar(typ):
+            continue
         if isinstance(typ, str):
-            if "ClassVar" in typ:
-                _unsupported("ClassVar")
             if "InitVar" in typ:
                 _unsupported("InitVar")
-        else:
-            typ_name = getattr(typ, "__name__", "")
-            if typ_name == "ClassVar" or "ClassVar" in repr(typ):
-                _unsupported("ClassVar")
 
         candidate = class_dict.get(name, MISSING)
         if isinstance(candidate, Field):
@@ -239,21 +251,21 @@ def _process_own_fields(cls, all_fields):
         all_fields[name] = f
 
 
-def _build_init(cls, fields_in_init, frozen):
+def _build_init(cls, pos_fields_in_init, kwonly_fields_in_init, frozen):
     def __init__(self, *args, **kwargs):
-        if len(args) > len(fields_in_init):
+        if len(args) > len(pos_fields_in_init):
             raise TypeError(
                 "__init__() takes at most %d positional arguments (%d given)"
-                % (len(fields_in_init), len(args))
+                % (len(pos_fields_in_init), len(args))
             )
 
         seen = {}
 
         for idx, value in enumerate(args):
-            fname = fields_in_init[idx].name
+            fname = pos_fields_in_init[idx].name
             seen[fname] = value
 
-        for f in fields_in_init[len(args):]:
+        for f in pos_fields_in_init[len(args):]:
             if f.name in kwargs:
                 seen[f.name] = kwargs.pop(f.name)
             elif f.default is not MISSING:
@@ -263,11 +275,21 @@ def _build_init(cls, fields_in_init, frozen):
             else:
                 raise TypeError("missing required argument: '%s'" % (f.name,))
 
+        for f in kwonly_fields_in_init:
+            if f.name in kwargs:
+                seen[f.name] = kwargs.pop(f.name)
+            elif f.default is not MISSING:
+                seen[f.name] = f.default
+            elif f.default_factory is not MISSING:
+                seen[f.name] = f.default_factory()
+            else:
+                raise TypeError("missing required keyword-only argument: '%s'" % (f.name,))
+
         if kwargs:
             keys = ", ".join(sorted(kwargs.keys()))
             raise TypeError("got unexpected keyword argument(s): %s" % (keys,))
 
-        for f in fields_in_init:
+        for f in pos_fields_in_init + kwonly_fields_in_init:
             if frozen:
                 object.__setattr__(self, f.name, seen[f.name])
             else:
@@ -341,8 +363,6 @@ def _apply_dataclass(
     slots,
     weakref_slot,
 ):
-    if kw_only:
-        _unsupported("dataclass(kw_only=True)")
     if slots:
         _unsupported("dataclass(slots=True)")
     if weakref_slot:
@@ -355,8 +375,10 @@ def _apply_dataclass(
     _process_own_fields(cls, all_fields)
 
     init_fields = [f for f in all_fields.values() if f.init]
+    pos_init_fields = [f for f in init_fields if not _field_is_kw_only(f, kw_only)]
+    kwonly_init_fields = [f for f in init_fields if _field_is_kw_only(f, kw_only)]
     seen_default = None
-    for f in init_fields:
+    for f in pos_init_fields:
         if _has_default(f):
             if seen_default is None:
                 seen_default = f.name
@@ -367,7 +389,7 @@ def _apply_dataclass(
             )
 
     if init and "__init__" not in cls.__dict__:
-        cls.__init__ = _build_init(cls, init_fields, frozen)
+        cls.__init__ = _build_init(cls, pos_init_fields, kwonly_init_fields, frozen)
 
     if repr_ and "__repr__" not in cls.__dict__:
         cls.__repr__ = _build_repr([f for f in all_fields.values() if f.repr])
@@ -406,7 +428,7 @@ def _apply_dataclass(
         cls.__setattr__ = _frozen_setattr
         cls.__delattr__ = _frozen_delattr
 
-    cls.__match_args__ = tuple(f.name for f in init_fields) if match_args else ()
+    cls.__match_args__ = tuple(f.name for f in pos_init_fields) if match_args else ()
     setattr(cls, _FIELDS, all_fields)
     setattr(
         cls,

--- a/src/lib/dataclasses.py
+++ b/src/lib/dataclasses.py
@@ -1,0 +1,599 @@
+"""
+Minimal dataclasses support for Skulpt.
+
+This module intentionally implements a focused subset of CPython's dataclasses.
+"""
+
+__all__ = [
+    "dataclass",
+    "field",
+    "Field",
+    "FrozenInstanceError",
+    "InitVar",
+    "KW_ONLY",
+    "MISSING",
+    "fields",
+    "asdict",
+    "astuple",
+    "make_dataclass",
+    "replace",
+    "is_dataclass",
+]
+
+
+class FrozenInstanceError(AttributeError):
+    pass
+
+
+class _MISSING_TYPE:
+    def __repr__(self):
+        return "MISSING"
+
+
+MISSING = _MISSING_TYPE()
+
+
+class _KW_ONLY_TYPE:
+    def __repr__(self):
+        return "KW_ONLY"
+
+
+KW_ONLY = _KW_ONLY_TYPE()
+
+
+class InitVar:
+    def __init__(self, typ):
+        self.type = typ
+
+    def __repr__(self):
+        return "dataclasses.InitVar[%r]" % (self.type,)
+
+
+def _unsupported(feature):
+    raise NotImplementedError(feature + " is not supported in skulpt.dataclasses")
+
+
+class _DataclassParams:
+    def __init__(
+        self,
+        init,
+        repr_,
+        eq,
+        order,
+        unsafe_hash,
+        frozen,
+        match_args,
+        kw_only,
+        slots,
+        weakref_slot,
+    ):
+        self.init = init
+        self.repr = repr_
+        self.eq = eq
+        self.order = order
+        self.unsafe_hash = unsafe_hash
+        self.frozen = frozen
+        self.match_args = match_args
+        self.kw_only = kw_only
+        self.slots = slots
+        self.weakref_slot = weakref_slot
+
+    def __repr__(self):
+        return (
+            "_DataclassParams(init=%r,repr=%r,eq=%r,order=%r,unsafe_hash=%r,"
+            "frozen=%r,match_args=%r,kw_only=%r,slots=%r,weakref_slot=%r)"
+            % (
+                self.init,
+                self.repr,
+                self.eq,
+                self.order,
+                self.unsafe_hash,
+                self.frozen,
+                self.match_args,
+                self.kw_only,
+                self.slots,
+                self.weakref_slot,
+            )
+        )
+
+
+class Field:
+    def __init__(
+        self,
+        default=MISSING,
+        default_factory=MISSING,
+        init=True,
+        repr=True,
+        hash=None,
+        compare=True,
+        metadata=None,
+        kw_only=MISSING,
+        name=None,
+        type=None,
+    ):
+        self.name = name
+        self.type = type
+        self.default = default
+        self.default_factory = default_factory
+        self.init = init
+        self.repr = repr
+        self.hash = hash
+        self.compare = compare
+        self.metadata = {} if metadata is None else metadata
+        self.kw_only = kw_only
+        self._field_type = None
+
+    def _clone(self):
+        return Field(
+            default=self.default,
+            default_factory=self.default_factory,
+            init=self.init,
+            repr=self.repr,
+            hash=self.hash,
+            compare=self.compare,
+            metadata=self.metadata,
+            kw_only=self.kw_only,
+            name=self.name,
+            type=self.type,
+        )
+
+    def __repr__(self):
+        return (
+            "Field(name=%r,type=%r,default=%r,default_factory=%r,init=%r,"
+            "repr=%r,hash=%r,compare=%r,metadata=%r,kw_only=%r,_field_type=%r)"
+            % (
+                self.name,
+                self.type,
+                self.default,
+                self.default_factory,
+                self.init,
+                self.repr,
+                self.hash,
+                self.compare,
+                self.metadata,
+                self.kw_only,
+                self._field_type,
+            )
+        )
+
+
+def field(
+    *,
+    default=MISSING,
+    default_factory=MISSING,
+    init=True,
+    repr=True,
+    hash=None,
+    compare=True,
+    metadata=None,
+    kw_only=MISSING
+):
+    if default is not MISSING and default_factory is not MISSING:
+        raise ValueError("cannot specify both default and default_factory")
+    if kw_only is not MISSING:
+        _unsupported("field(kw_only=...)")
+    return Field(
+        default=default,
+        default_factory=default_factory,
+        init=init,
+        repr=repr,
+        hash=hash,
+        compare=compare,
+        metadata=metadata,
+        kw_only=kw_only,
+    )
+
+
+_FIELDS = "__dataclass_fields__"
+_PARAMS = "__dataclass_params__"
+
+
+def _is_dataclass_instance(obj):
+    return hasattr(type(obj), _FIELDS)
+
+
+def _has_default(f):
+    return f.default is not MISSING or f.default_factory is not MISSING
+
+
+def _iter_fields(cls):
+    all_fields = {}
+    for base in reversed(cls.__mro__[1:]):
+        base_fields = getattr(base, _FIELDS, None)
+        if base_fields:
+            for name, f in base_fields.items():
+                all_fields[name] = f._clone()
+    return all_fields
+
+
+def _process_own_fields(cls, all_fields):
+    annotations = getattr(cls, "__annotations__", {})
+    class_dict = cls.__dict__
+    for name, typ in annotations.items():
+        if typ is KW_ONLY or typ == "KW_ONLY":
+            _unsupported("KW_ONLY sentinel")
+        if typ is InitVar or isinstance(typ, InitVar):
+            _unsupported("InitVar")
+        if isinstance(typ, str):
+            if "ClassVar" in typ:
+                _unsupported("ClassVar")
+            if "InitVar" in typ:
+                _unsupported("InitVar")
+        else:
+            typ_name = getattr(typ, "__name__", "")
+            if typ_name == "ClassVar" or "ClassVar" in repr(typ):
+                _unsupported("ClassVar")
+
+        candidate = class_dict.get(name, MISSING)
+        if isinstance(candidate, Field):
+            f = candidate
+            f.name = name
+            f.type = typ
+            if f.default is not MISSING:
+                setattr(cls, name, f.default)
+            elif name in class_dict:
+                delattr(cls, name)
+        else:
+            default = candidate
+            f = Field(default=default, name=name, type=typ)
+        all_fields[name] = f
+
+
+def _build_init(cls, fields_in_init, frozen):
+    def __init__(self, *args, **kwargs):
+        if len(args) > len(fields_in_init):
+            raise TypeError(
+                "__init__() takes at most %d positional arguments (%d given)"
+                % (len(fields_in_init), len(args))
+            )
+
+        seen = {}
+
+        for idx, value in enumerate(args):
+            fname = fields_in_init[idx].name
+            seen[fname] = value
+
+        for f in fields_in_init[len(args):]:
+            if f.name in kwargs:
+                seen[f.name] = kwargs.pop(f.name)
+            elif f.default is not MISSING:
+                seen[f.name] = f.default
+            elif f.default_factory is not MISSING:
+                seen[f.name] = f.default_factory()
+            else:
+                raise TypeError("missing required argument: '%s'" % (f.name,))
+
+        if kwargs:
+            keys = ", ".join(sorted(kwargs.keys()))
+            raise TypeError("got unexpected keyword argument(s): %s" % (keys,))
+
+        for f in fields_in_init:
+            if frozen:
+                object.__setattr__(self, f.name, seen[f.name])
+            else:
+                setattr(self, f.name, seen[f.name])
+
+        post_init = getattr(self, "__post_init__", None)
+        if post_init is not None:
+            post_init()
+
+    return __init__
+
+
+def _build_repr(repr_fields):
+    def __repr__(self):
+        body = ", ".join(
+            "%s=%r" % (f.name, getattr(self, f.name)) for f in repr_fields
+        )
+        return "%s(%s)" % (self.__class__.__qualname__, body)
+
+    return __repr__
+
+
+def _build_eq(eq_fields):
+    def __eq__(self, other):
+        if other.__class__ is self.__class__:
+            return tuple(getattr(self, f.name) for f in eq_fields) == tuple(
+                getattr(other, f.name) for f in eq_fields
+            )
+        return NotImplemented
+
+    return __eq__
+
+
+def _build_order(name, op, order_fields):
+    def fn(self, other):
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        left = tuple(getattr(self, f.name) for f in order_fields)
+        right = tuple(getattr(other, f.name) for f in order_fields)
+        return op(left, right)
+
+    fn.__name__ = name
+    return fn
+
+
+def _build_hash(hash_fields):
+    def __hash__(self):
+        return hash(tuple(getattr(self, f.name) for f in hash_fields))
+
+    return __hash__
+
+
+def _frozen_setattr(self, name, value):
+    raise FrozenInstanceError("cannot assign to field '%s'" % (name,))
+
+
+def _frozen_delattr(self, name):
+    raise FrozenInstanceError("cannot delete field '%s'" % (name,))
+
+
+def _apply_dataclass(
+    cls,
+    init,
+    repr_,
+    eq,
+    order,
+    unsafe_hash,
+    frozen,
+    match_args,
+    kw_only,
+    slots,
+    weakref_slot,
+):
+    if kw_only:
+        _unsupported("dataclass(kw_only=True)")
+    if slots:
+        _unsupported("dataclass(slots=True)")
+    if weakref_slot:
+        _unsupported("dataclass(weakref_slot=True)")
+
+    if order and not eq:
+        raise ValueError("eq must be true if order is true")
+
+    all_fields = _iter_fields(cls)
+    _process_own_fields(cls, all_fields)
+
+    init_fields = [f for f in all_fields.values() if f.init]
+    seen_default = None
+    for f in init_fields:
+        if _has_default(f):
+            if seen_default is None:
+                seen_default = f.name
+        elif seen_default is not None:
+            raise TypeError(
+                "non-default argument '%s' follows default argument '%s'"
+                % (f.name, seen_default)
+            )
+
+    if init and "__init__" not in cls.__dict__:
+        cls.__init__ = _build_init(cls, init_fields, frozen)
+
+    if repr_ and "__repr__" not in cls.__dict__:
+        cls.__repr__ = _build_repr([f for f in all_fields.values() if f.repr])
+
+    if eq and "__eq__" not in cls.__dict__:
+        cls.__eq__ = _build_eq([f for f in all_fields.values() if f.compare])
+
+    if order:
+        for n in ("__lt__", "__le__", "__gt__", "__ge__"):
+            if n in cls.__dict__:
+                raise TypeError("Cannot overwrite attribute %s in class %s" % (n, cls.__name__))
+        order_fields = [f for f in all_fields.values() if f.compare]
+        cls.__lt__ = _build_order("__lt__", lambda a, b: a < b, order_fields)
+        cls.__le__ = _build_order("__le__", lambda a, b: a <= b, order_fields)
+        cls.__gt__ = _build_order("__gt__", lambda a, b: a > b, order_fields)
+        cls.__ge__ = _build_order("__ge__", lambda a, b: a >= b, order_fields)
+
+    if unsafe_hash:
+        if "__hash__" in cls.__dict__ and cls.__dict__["__hash__"] is not None:
+            raise TypeError("Cannot overwrite attribute __hash__ in class %s" % (cls.__name__,))
+        cls.__hash__ = _build_hash(
+            [f for f in all_fields.values() if (f.hash is True or (f.hash is None and f.compare))]
+        )
+    elif eq and frozen:
+        if "__hash__" not in cls.__dict__ or cls.__dict__["__hash__"] is None:
+            cls.__hash__ = _build_hash(
+                [f for f in all_fields.values() if (f.hash is True or (f.hash is None and f.compare))]
+            )
+    elif eq and not frozen:
+        if "__hash__" not in cls.__dict__:
+            cls.__hash__ = None
+
+    if frozen:
+        if "__setattr__" in cls.__dict__ or "__delattr__" in cls.__dict__:
+            raise TypeError("Cannot overwrite attribute __setattr__ or __delattr__ in class %s" % (cls.__name__,))
+        cls.__setattr__ = _frozen_setattr
+        cls.__delattr__ = _frozen_delattr
+
+    cls.__match_args__ = tuple(f.name for f in init_fields) if match_args else ()
+    setattr(cls, _FIELDS, all_fields)
+    setattr(
+        cls,
+        _PARAMS,
+        _DataclassParams(
+            init,
+            repr_,
+            eq,
+            order,
+            unsafe_hash,
+            frozen,
+            match_args,
+            kw_only,
+            slots,
+            weakref_slot,
+        ),
+    )
+    return cls
+
+
+def dataclass(
+    cls=None,
+    *,
+    init=True,
+    repr_=True,
+    eq=True,
+    order=False,
+    unsafe_hash=False,
+    frozen=False,
+    match_args=True,
+    kw_only=False,
+    slots=False,
+    weakref_slot=False
+):
+    def wrap(c):
+        return _apply_dataclass(
+            c,
+            init,
+            repr_,
+            eq,
+            order,
+            unsafe_hash,
+            frozen,
+            match_args,
+            kw_only,
+            slots,
+            weakref_slot,
+        )
+
+    if cls is None:
+        return wrap
+    return wrap(cls)
+
+
+def fields(class_or_instance):
+    cls = class_or_instance if isinstance(class_or_instance, type) else type(class_or_instance)
+    f = getattr(cls, _FIELDS, None)
+    if f is None:
+        raise TypeError("must be called with a dataclass type or instance")
+    return tuple(f.values())
+
+
+def is_dataclass(obj):
+    if isinstance(obj, type):
+        return hasattr(obj, _FIELDS)
+    return _is_dataclass_instance(obj)
+
+
+def _convert_asdict(obj, dict_factory):
+    if _is_dataclass_instance(obj):
+        items = []
+        for f in fields(obj):
+            items.append((f.name, _convert_asdict(getattr(obj, f.name), dict_factory)))
+        return dict_factory(items)
+    if isinstance(obj, list):
+        return [_convert_asdict(x, dict_factory) for x in obj]
+    if isinstance(obj, tuple):
+        return tuple(_convert_asdict(x, dict_factory) for x in obj)
+    if isinstance(obj, dict):
+        return type(obj)(
+            (_convert_asdict(k, dict_factory), _convert_asdict(v, dict_factory))
+            for k, v in obj.items()
+        )
+    return obj
+
+
+def asdict(obj, *, dict_factory=dict):
+    if not _is_dataclass_instance(obj):
+        raise TypeError("asdict() should be called on dataclass instances")
+    return _convert_asdict(obj, dict_factory)
+
+
+def _convert_astuple(obj, tuple_factory):
+    if _is_dataclass_instance(obj):
+        return tuple_factory([_convert_astuple(getattr(obj, f.name), tuple_factory) for f in fields(obj)])
+    if isinstance(obj, list):
+        return [_convert_astuple(x, tuple_factory) for x in obj]
+    if isinstance(obj, tuple):
+        return tuple_factory([_convert_astuple(x, tuple_factory) for x in obj])
+    if isinstance(obj, dict):
+        return type(obj)((_convert_astuple(k, tuple_factory), _convert_astuple(v, tuple_factory)) for k, v in obj.items())
+    return obj
+
+
+def astuple(obj, *, tuple_factory=tuple):
+    if not _is_dataclass_instance(obj):
+        raise TypeError("astuple() should be called on dataclass instances")
+    return _convert_astuple(obj, tuple_factory)
+
+
+def replace(obj, **changes):
+    if not _is_dataclass_instance(obj):
+        raise TypeError("replace() should be called on dataclass instances")
+    kwargs = {}
+    for f in fields(obj):
+        if not f.init:
+            if f.name in changes:
+                raise ValueError(
+                    "field %s is declared with init=False, it cannot be specified with replace()"
+                    % (f.name,)
+                )
+            continue
+        if f.name in changes:
+            kwargs[f.name] = changes.pop(f.name)
+        else:
+            kwargs[f.name] = getattr(obj, f.name)
+    if changes:
+        bad = ", ".join(sorted(changes.keys()))
+        raise TypeError("got unexpected field name(s): %s" % (bad,))
+    return type(obj)(**kwargs)
+
+
+def make_dataclass(
+    cls_name,
+    field_defs,
+    *,
+    bases=(),
+    namespace=None,
+    init=True,
+    repr=True,
+    eq=True,
+    order=False,
+    unsafe_hash=False,
+    frozen=False,
+    match_args=True,
+    kw_only=False,
+    slots=False,
+    weakref_slot=False
+):
+    if namespace is None:
+        namespace = {}
+    else:
+        namespace = dict(namespace)
+    annotations = {}
+
+    for item in field_defs:
+        if isinstance(item, str):
+            fname = item
+            ftype = object
+            fdefault = MISSING
+        elif isinstance(item, tuple):
+            if len(item) == 2:
+                fname, ftype = item
+                fdefault = MISSING
+            elif len(item) == 3:
+                fname, ftype, fdefault = item
+            else:
+                raise TypeError("Invalid field definition: %r" % (item,))
+        else:
+            raise TypeError("Invalid field definition: %r" % (item,))
+
+        annotations[fname] = ftype
+        if fdefault is not MISSING:
+            namespace[fname] = fdefault
+
+    namespace["__annotations__"] = annotations
+    cls = type(cls_name, bases, namespace)
+    return dataclass(
+        cls,
+        init=init,
+        repr_=repr,
+        eq=eq,
+        order=order,
+        unsafe_hash=unsafe_hash,
+        frozen=frozen,
+        match_args=match_args,
+        kw_only=kw_only,
+        slots=slots,
+        weakref_slot=weakref_slot,
+    )

--- a/src/lib/dataclasses.py
+++ b/src/lib/dataclasses.py
@@ -48,6 +48,9 @@ class InitVar:
     def __repr__(self):
         return "dataclasses.InitVar[%r]" % (self.type,)
 
+    def __class_getitem__(cls, typ):
+        return cls(typ)
+
 
 def _unsupported(feature):
     raise NotImplementedError(feature + " is not supported in skulpt.dataclasses")
@@ -63,6 +66,16 @@ def _is_classvar(typ):
     if typ_name == "ClassVar":
         return True
     return "ClassVar" in repr(typ)
+
+
+def _is_initvar(typ):
+    if typ is InitVar:
+        return True
+    if isinstance(typ, InitVar):
+        return True
+    if isinstance(typ, str):
+        return "InitVar" in typ
+    return False
 
 
 class _DataclassParams:
@@ -196,6 +209,7 @@ def field(
 
 _FIELDS = "__dataclass_fields__"
 _PARAMS = "__dataclass_params__"
+_INITVARS = "__dataclass_initvars__"
 
 
 def _is_dataclass_instance(obj):
@@ -212,6 +226,16 @@ def _field_is_kw_only(f, default_kw_only):
     return bool(f.kw_only)
 
 
+def _value_from_default(default, default_factory, name, kwonly):
+    if default is not MISSING:
+        return default
+    if default_factory is not MISSING:
+        return default_factory()
+    if kwonly:
+        raise TypeError("missing required keyword-only argument: '%s'" % (name,))
+    raise TypeError("missing required argument: '%s'" % (name,))
+
+
 def _iter_fields(cls):
     all_fields = {}
     for base in reversed(cls.__mro__[1:]):
@@ -222,82 +246,151 @@ def _iter_fields(cls):
     return all_fields
 
 
-def _process_own_fields(cls, all_fields):
+def _process_own_fields(cls, all_fields, default_kw_only):
     annotations = getattr(cls, "__annotations__", {})
     class_dict = cls.__dict__
+    initvars = []
+    own_pos_entries = []
+    own_kw_entries = []
+    own_field_names = set()
+    seen_kw_only = False
     for name, typ in annotations.items():
         if typ is KW_ONLY or typ == "KW_ONLY":
-            _unsupported("KW_ONLY sentinel")
-        if typ is InitVar or isinstance(typ, InitVar):
-            _unsupported("InitVar")
+            if seen_kw_only:
+                raise TypeError("KW_ONLY can only be used once per class")
+            seen_kw_only = True
+            default_kw_only = True
+            continue
+        if _is_initvar(typ):
+            candidate = class_dict.get(name, MISSING)
+            if isinstance(candidate, Field):
+                if not candidate.init:
+                    _unsupported("InitVar with init=False")
+                initvars.append(
+                    {
+                        "name": name,
+                        "default": candidate.default,
+                        "default_factory": candidate.default_factory,
+                        "kw_only": _field_is_kw_only(candidate, default_kw_only),
+                    }
+                )
+                if initvars[-1]["kw_only"]:
+                    own_kw_entries.append(("initvar", initvars[-1]))
+                else:
+                    own_pos_entries.append(("initvar", initvars[-1]))
+                if candidate.default is not MISSING:
+                    setattr(cls, name, candidate.default)
+                elif name in class_dict:
+                    delattr(cls, name)
+            else:
+                initvars.append(
+                    {
+                        "name": name,
+                        "default": candidate,
+                        "default_factory": MISSING,
+                        "kw_only": default_kw_only,
+                    }
+                )
+                if initvars[-1]["kw_only"]:
+                    own_kw_entries.append(("initvar", initvars[-1]))
+                else:
+                    own_pos_entries.append(("initvar", initvars[-1]))
+            continue
         if _is_classvar(typ):
             continue
-        if isinstance(typ, str):
-            if "InitVar" in typ:
-                _unsupported("InitVar")
 
         candidate = class_dict.get(name, MISSING)
         if isinstance(candidate, Field):
             f = candidate
             f.name = name
             f.type = typ
+            if f.kw_only is MISSING:
+                f.kw_only = default_kw_only
             if f.default is not MISSING:
                 setattr(cls, name, f.default)
             elif name in class_dict:
                 delattr(cls, name)
         else:
-            default = candidate
-            f = Field(default=default, name=name, type=typ)
+            f = Field(default=candidate, name=name, type=typ, kw_only=default_kw_only)
         all_fields[name] = f
+        own_field_names.add(name)
+        if f.init:
+            if _field_is_kw_only(f, default_kw_only):
+                own_kw_entries.append(("field", name))
+            else:
+                own_pos_entries.append(("field", name))
+    return initvars, own_pos_entries, own_kw_entries, own_field_names
 
 
-def _build_init(cls, pos_fields_in_init, kwonly_fields_in_init, frozen):
+def _build_init(cls, pos_entries, kwonly_entries, frozen):
     def __init__(self, *args, **kwargs):
-        if len(args) > len(pos_fields_in_init):
+        if len(args) > len(pos_entries):
             raise TypeError(
                 "__init__() takes at most %d positional arguments (%d given)"
-                % (len(pos_fields_in_init), len(args))
+                % (len(pos_entries), len(args))
             )
 
         seen = {}
+        initvar_seen = {}
 
         for idx, value in enumerate(args):
-            fname = pos_fields_in_init[idx].name
-            seen[fname] = value
-
-        for f in pos_fields_in_init[len(args):]:
-            if f.name in kwargs:
-                seen[f.name] = kwargs.pop(f.name)
-            elif f.default is not MISSING:
-                seen[f.name] = f.default
-            elif f.default_factory is not MISSING:
-                seen[f.name] = f.default_factory()
+            kind, item = pos_entries[idx]
+            if kind == "field":
+                seen[item.name] = value
             else:
-                raise TypeError("missing required argument: '%s'" % (f.name,))
+                initvar_seen[item["name"]] = value
 
-        for f in kwonly_fields_in_init:
-            if f.name in kwargs:
-                seen[f.name] = kwargs.pop(f.name)
-            elif f.default is not MISSING:
-                seen[f.name] = f.default
-            elif f.default_factory is not MISSING:
-                seen[f.name] = f.default_factory()
+        for kind, item in pos_entries[len(args):]:
+            if kind == "field":
+                if item.name in kwargs:
+                    seen[item.name] = kwargs.pop(item.name)
+                else:
+                    seen[item.name] = _value_from_default(
+                        item.default, item.default_factory, item.name, False
+                    )
             else:
-                raise TypeError("missing required keyword-only argument: '%s'" % (f.name,))
+                if item["name"] in kwargs:
+                    initvar_seen[item["name"]] = kwargs.pop(item["name"])
+                else:
+                    initvar_seen[item["name"]] = _value_from_default(
+                        item["default"], item["default_factory"], item["name"], False
+                    )
+
+        for kind, item in kwonly_entries:
+            if kind == "field":
+                if item.name in kwargs:
+                    seen[item.name] = kwargs.pop(item.name)
+                else:
+                    seen[item.name] = _value_from_default(
+                        item.default, item.default_factory, item.name, True
+                    )
+            else:
+                if item["name"] in kwargs:
+                    initvar_seen[item["name"]] = kwargs.pop(item["name"])
+                else:
+                    initvar_seen[item["name"]] = _value_from_default(
+                        item["default"], item["default_factory"], item["name"], True
+                    )
 
         if kwargs:
             keys = ", ".join(sorted(kwargs.keys()))
             raise TypeError("got unexpected keyword argument(s): %s" % (keys,))
 
-        for f in pos_fields_in_init + kwonly_fields_in_init:
+        for kind, item in pos_entries + kwonly_entries:
+            if kind != "field":
+                continue
             if frozen:
-                object.__setattr__(self, f.name, seen[f.name])
+                object.__setattr__(self, item.name, seen[item.name])
             else:
-                setattr(self, f.name, seen[f.name])
+                setattr(self, item.name, seen[item.name])
 
         post_init = getattr(self, "__post_init__", None)
         if post_init is not None:
-            post_init()
+            ordered_initvars = [item for kind, item in (pos_entries + kwonly_entries) if kind == "initvar"]
+            if ordered_initvars:
+                post_init(*(initvar_seen[iv["name"]] for iv in ordered_initvars))
+            else:
+                post_init()
 
     return __init__
 
@@ -372,24 +465,43 @@ def _apply_dataclass(
         raise ValueError("eq must be true if order is true")
 
     all_fields = _iter_fields(cls)
-    _process_own_fields(cls, all_fields)
+    initvars, own_pos_entries, own_kw_entries, own_field_names = _process_own_fields(
+        cls, all_fields, kw_only
+    )
 
     init_fields = [f for f in all_fields.values() if f.init]
     pos_init_fields = [f for f in init_fields if not _field_is_kw_only(f, kw_only)]
     kwonly_init_fields = [f for f in init_fields if _field_is_kw_only(f, kw_only)]
+    inherited_pos_entries = [("field", f) for f in pos_init_fields if f.name not in own_field_names]
+    inherited_kw_entries = [("field", f) for f in kwonly_init_fields if f.name not in own_field_names]
+    field_map = {f.name: f for f in init_fields}
+    pos_entries = inherited_pos_entries + [
+        ("field", field_map[item]) if kind == "field" else ("initvar", item)
+        for kind, item in own_pos_entries
+    ]
+    kwonly_entries = inherited_kw_entries + [
+        ("field", field_map[item]) if kind == "field" else ("initvar", item)
+        for kind, item in own_kw_entries
+    ]
     seen_default = None
-    for f in pos_init_fields:
-        if _has_default(f):
+    for kind, item in pos_entries:
+        if kind == "field":
+            has_default = _has_default(item)
+            name = item.name
+        else:
+            has_default = item["default"] is not MISSING or item["default_factory"] is not MISSING
+            name = item["name"]
+        if has_default:
             if seen_default is None:
-                seen_default = f.name
+                seen_default = name
         elif seen_default is not None:
             raise TypeError(
                 "non-default argument '%s' follows default argument '%s'"
-                % (f.name, seen_default)
+                % (name, seen_default)
             )
 
     if init and "__init__" not in cls.__dict__:
-        cls.__init__ = _build_init(cls, pos_init_fields, kwonly_init_fields, frozen)
+        cls.__init__ = _build_init(cls, pos_entries, kwonly_entries, frozen)
 
     if repr_ and "__repr__" not in cls.__dict__:
         cls.__repr__ = _build_repr([f for f in all_fields.values() if f.repr])
@@ -428,8 +540,11 @@ def _apply_dataclass(
         cls.__setattr__ = _frozen_setattr
         cls.__delattr__ = _frozen_delattr
 
-    cls.__match_args__ = tuple(f.name for f in pos_init_fields) if match_args else ()
+    initvar_entries = [item for kind, item in (pos_entries + kwonly_entries) if kind == "initvar"]
+
+    cls.__match_args__ = tuple(item.name for kind, item in pos_entries if kind == "field") if match_args else ()
     setattr(cls, _FIELDS, all_fields)
+    setattr(cls, _INITVARS, tuple(initvar_entries))
     setattr(
         cls,
         _PARAMS,
@@ -497,52 +612,109 @@ def is_dataclass(obj):
     return _is_dataclass_instance(obj)
 
 
-def _convert_asdict(obj, dict_factory):
+def _convert_asdict(obj, dict_factory, active):
     if _is_dataclass_instance(obj):
-        items = []
-        for f in fields(obj):
-            items.append((f.name, _convert_asdict(getattr(obj, f.name), dict_factory)))
-        return dict_factory(items)
+        oid = id(obj)
+        if oid in active:
+            raise RecursionError("cannot convert recursive dataclass structure")
+        active.add(oid)
+        try:
+            items = []
+            for f in fields(obj):
+                items.append((f.name, _convert_asdict(getattr(obj, f.name), dict_factory, active)))
+            return dict_factory(items)
+        finally:
+            active.remove(oid)
     if isinstance(obj, list):
-        return [_convert_asdict(x, dict_factory) for x in obj]
+        oid = id(obj)
+        if oid in active:
+            raise RecursionError("cannot convert recursive dataclass structure")
+        active.add(oid)
+        try:
+            return [_convert_asdict(x, dict_factory, active) for x in obj]
+        finally:
+            active.remove(oid)
     if isinstance(obj, tuple):
-        return tuple(_convert_asdict(x, dict_factory) for x in obj)
+        oid = id(obj)
+        if oid in active:
+            raise RecursionError("cannot convert recursive dataclass structure")
+        active.add(oid)
+        try:
+            return tuple(_convert_asdict(x, dict_factory, active) for x in obj)
+        finally:
+            active.remove(oid)
     if isinstance(obj, dict):
-        return type(obj)(
-            (_convert_asdict(k, dict_factory), _convert_asdict(v, dict_factory))
-            for k, v in obj.items()
-        )
+        oid = id(obj)
+        if oid in active:
+            raise RecursionError("cannot convert recursive dataclass structure")
+        active.add(oid)
+        try:
+            return type(obj)(
+                (_convert_asdict(k, dict_factory, active), _convert_asdict(v, dict_factory, active))
+                for k, v in obj.items()
+            )
+        finally:
+            active.remove(oid)
     return obj
 
 
 def asdict(obj, *, dict_factory=dict):
     if not _is_dataclass_instance(obj):
         raise TypeError("asdict() should be called on dataclass instances")
-    return _convert_asdict(obj, dict_factory)
+    return _convert_asdict(obj, dict_factory, set())
 
 
-def _convert_astuple(obj, tuple_factory):
+def _convert_astuple(obj, tuple_factory, active):
     if _is_dataclass_instance(obj):
-        return tuple_factory([_convert_astuple(getattr(obj, f.name), tuple_factory) for f in fields(obj)])
+        oid = id(obj)
+        if oid in active:
+            raise RecursionError("cannot convert recursive dataclass structure")
+        active.add(oid)
+        try:
+            return tuple_factory([_convert_astuple(getattr(obj, f.name), tuple_factory, active) for f in fields(obj)])
+        finally:
+            active.remove(oid)
     if isinstance(obj, list):
-        return [_convert_astuple(x, tuple_factory) for x in obj]
+        oid = id(obj)
+        if oid in active:
+            raise RecursionError("cannot convert recursive dataclass structure")
+        active.add(oid)
+        try:
+            return [_convert_astuple(x, tuple_factory, active) for x in obj]
+        finally:
+            active.remove(oid)
     if isinstance(obj, tuple):
-        return tuple_factory([_convert_astuple(x, tuple_factory) for x in obj])
+        oid = id(obj)
+        if oid in active:
+            raise RecursionError("cannot convert recursive dataclass structure")
+        active.add(oid)
+        try:
+            return tuple_factory([_convert_astuple(x, tuple_factory, active) for x in obj])
+        finally:
+            active.remove(oid)
     if isinstance(obj, dict):
-        return type(obj)((_convert_astuple(k, tuple_factory), _convert_astuple(v, tuple_factory)) for k, v in obj.items())
+        oid = id(obj)
+        if oid in active:
+            raise RecursionError("cannot convert recursive dataclass structure")
+        active.add(oid)
+        try:
+            return type(obj)((_convert_astuple(k, tuple_factory, active), _convert_astuple(v, tuple_factory, active)) for k, v in obj.items())
+        finally:
+            active.remove(oid)
     return obj
 
 
 def astuple(obj, *, tuple_factory=tuple):
     if not _is_dataclass_instance(obj):
         raise TypeError("astuple() should be called on dataclass instances")
-    return _convert_astuple(obj, tuple_factory)
+    return _convert_astuple(obj, tuple_factory, set())
 
 
 def replace(obj, **changes):
     if not _is_dataclass_instance(obj):
         raise TypeError("replace() should be called on dataclass instances")
     kwargs = {}
+    initvars = getattr(type(obj), _INITVARS, ())
     for f in fields(obj):
         if not f.init:
             if f.name in changes:
@@ -555,6 +727,11 @@ def replace(obj, **changes):
             kwargs[f.name] = changes.pop(f.name)
         else:
             kwargs[f.name] = getattr(obj, f.name)
+    for iv in initvars:
+        if iv["name"] in changes:
+            kwargs[iv["name"]] = changes.pop(iv["name"])
+        elif iv["default"] is MISSING and iv["default_factory"] is MISSING:
+            raise TypeError("InitVar %r must be specified with replace()" % (iv["name"],))
     if changes:
         bad = ", ".join(sorted(changes.keys()))
         raise TypeError("got unexpected field name(s): %s" % (bad,))

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -520,6 +520,9 @@ SymbolTable.prototype.visitStmt = function (s) {
             if (s.args.defaults) {
                 this.SEQExpr(s.args.defaults);
             }
+            if (s.args.kw_defaults) {
+                this.SEQExpr(s.args.kw_defaults);
+            }
             if (s.decorator_list) {
                 this.SEQExpr(s.decorator_list);
             }
@@ -751,6 +754,9 @@ SymbolTable.prototype.visitExpr = function (e) {
             this.addDef(new Sk.builtin.str("lambda"), DEF_LOCAL, e.lineno);
             if (e.args.defaults) {
                 this.SEQExpr(e.args.defaults);
+            }
+            if (e.args.kw_defaults) {
+                this.SEQExpr(e.args.kw_defaults);
             }
             this.enterBlock("lambda", FunctionBlock, e, e.lineno);
             this.visitArguments(e.args, e.lineno);

--- a/test/unit3/test_dataclasses.py
+++ b/test/unit3/test_dataclasses.py
@@ -263,11 +263,17 @@ class TestDataclasses(unittest.TestCase):
         c = C(10)
         self.assertEqual((c.x, c.y), (10, 11))
 
-    def test_guard_kw_only_decorator(self):
-        with self.assertRaisesRegex(NotImplementedError, "kw_only"):
-            @dataclass(kw_only=True)
-            class C:
-                x: int
+    def test_kw_only_decorator(self):
+        @dataclass(kw_only=True)
+        class C:
+            x: int
+            y: int = 0
+
+        c = C(x=10)
+        self.assertEqual((c.x, c.y), (10, 0))
+        with self.assertRaises(TypeError):
+            C(10)
+        self.assertEqual(C.__match_args__, ())
 
     def test_guard_slots(self):
         with self.assertRaisesRegex(NotImplementedError, "slots"):
@@ -281,11 +287,26 @@ class TestDataclasses(unittest.TestCase):
             class C:
                 x: int
 
-    def test_guard_field_kw_only(self):
-        with self.assertRaisesRegex(NotImplementedError, "field\\(kw_only"):
-            @dataclass
-            class C:
-                x: int = field(default=1, kw_only=True)
+    def test_field_kw_only(self):
+        @dataclass
+        class C:
+            x: int
+            y: int = field(default=1, kw_only=True)
+
+        c = C(7, y=9)
+        self.assertEqual((c.x, c.y), (7, 9))
+        with self.assertRaises(TypeError):
+            C(7, 9)
+        self.assertEqual(C.__match_args__, ("x",))
+
+    def test_kw_only_does_not_trigger_default_order_error(self):
+        @dataclass
+        class C:
+            x: int = 0
+            y: int = field(kw_only=True)
+
+        c = C(y=3)
+        self.assertEqual((c.x, c.y), (0, 3))
 
     def test_guard_initvar(self):
         with self.assertRaisesRegex(NotImplementedError, "InitVar"):
@@ -293,11 +314,16 @@ class TestDataclasses(unittest.TestCase):
             class C:
                 x: InitVar(int)
 
-    def test_guard_classvar(self):
-        with self.assertRaisesRegex(NotImplementedError, "ClassVar"):
-            @dataclass
-            class C:
-                x: "ClassVar[int]" = 1
+    def test_classvar_ignored(self):
+        @dataclass
+        class C:
+            x: "ClassVar[int]" = 1
+            y: int
+
+        o = C(5)
+        self.assertEqual(o.y, 5)
+        self.assertEqual(C.x, 1)
+        self.assertEqual([f.name for f in fields(C)], ["y"])
 
     def test_guard_kw_only_sentinel(self):
         with self.assertRaisesRegex(NotImplementedError, "KW_ONLY"):
@@ -307,9 +333,8 @@ class TestDataclasses(unittest.TestCase):
                 x: int
 
     # Intentionally omitted/skipped for minimal implementation:
-    # - full ClassVar/InitVar/KW_ONLY semantics (guarded with explicit errors)
+    # - full InitVar/KW_ONLY semantics (guarded with explicit errors)
     # - slots / weakref_slot implementation (guarded with explicit errors)
-    # - kw_only implementation (guarded with explicit errors)
     # - recursive protection / deepcopy semantics in asdict/astuple
     # - metadata mappingproxy details
     # - full error text parity with CPython

--- a/test/unit3/test_dataclasses.py
+++ b/test/unit3/test_dataclasses.py
@@ -201,6 +201,19 @@ class TestDataclasses(unittest.TestCase):
         self.assertEqual(asdict(p), {"x": 3, "y": {"z": 7}})
         self.assertEqual(astuple(p), (3, (7,)))
 
+    def test_asdict_astuple_recursive_raises(self):
+        @dataclass
+        class Node:
+            x: int
+            nxt: object = None
+
+        n = Node(1)
+        n.nxt = n
+        with self.assertRaises(RecursionError):
+            asdict(n)
+        with self.assertRaises(RecursionError):
+            astuple(n)
+
     def test_replace(self):
         @dataclass
         class C:
@@ -210,6 +223,36 @@ class TestDataclasses(unittest.TestCase):
         o = C(1, 2)
         o2 = replace(o, x=9)
         self.assertEqual((o2.x, o2.y), (9, 2))
+
+    def test_replace_requires_initvar(self):
+        @dataclass
+        class C:
+            x: int
+            y: InitVar[int]
+            z: int = 0
+
+            def __post_init__(self, y):
+                self.z = y
+
+        o = C(1, 2)
+        with self.assertRaisesRegex(TypeError, "InitVar 'y' must be specified with replace\\(\\)"):
+            replace(o, x=9)
+        o2 = replace(o, x=9, y=7)
+        self.assertEqual((o2.x, o2.z), (9, 7))
+
+    def test_replace_initvar_with_default_not_required(self):
+        @dataclass
+        class C:
+            x: int
+            y: InitVar[int] = 4
+            z: int = 0
+
+            def __post_init__(self, y):
+                self.z = y
+
+        o = C(1, 6)
+        o2 = replace(o, x=9)
+        self.assertEqual((o2.x, o2.z), (9, 4))
 
     def test_replace_with_init_false_rejected(self):
         @dataclass
@@ -309,10 +352,33 @@ class TestDataclasses(unittest.TestCase):
         self.assertEqual((c.x, c.y), (0, 3))
 
     def test_guard_initvar(self):
-        with self.assertRaisesRegex(NotImplementedError, "InitVar"):
-            @dataclass
-            class C:
-                x: InitVar(int)
+        @dataclass
+        class C:
+            x: int
+            y: InitVar(int)
+            z: int = 0
+
+            def __post_init__(self, y):
+                self.z = self.x + y
+
+        c = C(2, 3)
+        self.assertEqual((c.x, c.z), (2, 5))
+        self.assertFalse(hasattr(c, "y"))
+
+    def test_initvar_kw_only_and_default(self):
+        @dataclass
+        class C:
+            x: int
+            y: InitVar(int) = field(default=4, kw_only=True)
+            z: int = 0
+
+            def __post_init__(self, y):
+                self.z = y
+
+        c = C(2, y=7)
+        self.assertEqual((c.x, c.z), (2, 7))
+        c2 = C(2)
+        self.assertEqual((c2.x, c2.z), (2, 4))
 
     def test_classvar_ignored(self):
         @dataclass
@@ -326,14 +392,28 @@ class TestDataclasses(unittest.TestCase):
         self.assertEqual([f.name for f in fields(C)], ["y"])
 
     def test_guard_kw_only_sentinel(self):
-        with self.assertRaisesRegex(NotImplementedError, "KW_ONLY"):
+        @dataclass
+        class C:
+            x: int
+            _: KW_ONLY
+            y: int
+
+        c = C(1, y=2)
+        self.assertEqual((c.x, c.y), (1, 2))
+        with self.assertRaises(TypeError):
+            C(1, 2)
+        self.assertEqual(C.__match_args__, ("x",))
+
+    def test_kw_only_sentinel_once(self):
+        with self.assertRaisesRegex(TypeError, "KW_ONLY can only be used once"):
             @dataclass
             class C:
                 _: KW_ONLY
+                __: KW_ONLY
                 x: int
 
     # Intentionally omitted/skipped for minimal implementation:
-    # - full InitVar/KW_ONLY semantics (guarded with explicit errors)
+    # - full InitVar/KW_ONLY parity with CPython
     # - slots / weakref_slot implementation (guarded with explicit errors)
     # - recursive protection / deepcopy semantics in asdict/astuple
     # - metadata mappingproxy details

--- a/test/unit3/test_dataclasses.py
+++ b/test/unit3/test_dataclasses.py
@@ -1,0 +1,319 @@
+import unittest
+import dataclasses
+from dataclasses import (
+    dataclass,
+    field,
+    fields,
+    asdict,
+    astuple,
+    make_dataclass,
+    replace,
+    is_dataclass,
+    FrozenInstanceError,
+    InitVar,
+    KW_ONLY,
+)
+
+
+class TestDataclasses(unittest.TestCase):
+    def test_no_fields(self):
+        @dataclass
+        class C:
+            pass
+
+        o = C()
+        self.assertEqual(len(fields(C)), 0)
+        self.assertEqual(len(fields(o)), 0)
+
+    def test_no_fields_but_member_variable(self):
+        @dataclass
+        class C:
+            i = 0
+
+        o = C()
+        self.assertEqual(len(fields(C)), 0)
+        self.assertEqual(o.i, 0)
+
+    def test_one_field_no_default(self):
+        @dataclass
+        class C:
+            x: int
+
+        o = C(42)
+        self.assertEqual(o.x, 42)
+
+    def test_named_init_params(self):
+        @dataclass
+        class C:
+            x: int
+
+        o = C(x=32)
+        self.assertEqual(o.x, 32)
+
+    def test_two_fields_one_default(self):
+        @dataclass
+        class C:
+            x: int
+            y: int = 0
+
+        o = C(3)
+        self.assertEqual((o.x, o.y), (3, 0))
+
+    def test_non_default_follows_default(self):
+        with self.assertRaisesRegex(TypeError, "non-default argument 'y' follows default argument 'x'"):
+            @dataclass
+            class C:
+                x: int = 0
+                y: int
+
+        with self.assertRaisesRegex(TypeError, "non-default argument 'y' follows default argument 'x'"):
+            @dataclass
+            class B:
+                x: int = 0
+
+            @dataclass
+            class C(B):
+                y: int
+
+    def test_field_default_default_factory_error(self):
+        with self.assertRaisesRegex(ValueError, "cannot specify both default and default_factory"):
+            @dataclass
+            class C:
+                x: int = field(default=1, default_factory=int)
+
+    def test_dataclass_params_repr(self):
+        @dataclass(frozen=True)
+        class Some:
+            pass
+
+        expected = (
+            "_DataclassParams(init=True,repr=True,eq=True,order=False,unsafe_hash=False,"
+            "frozen=True,match_args=True,kw_only=False,slots=False,weakref_slot=False)"
+        )
+        self.assertEqual(repr(Some.__dataclass_params__), expected)
+
+    def test_field_repr_contains_expected_parts(self):
+        int_field = field(default=1, init=True, repr=False)
+        int_field.name = "id"
+        out = repr(int_field)
+        self.assertIn("Field(name='id'", out)
+        self.assertIn("default=1", out)
+        self.assertIn("default_factory=MISSING", out)
+        self.assertIn("repr=False", out)
+
+    def test_overwrite_hash(self):
+        @dataclass(frozen=True)
+        class C:
+            x: int
+
+            def __hash__(self):
+                return 301
+
+        self.assertEqual(hash(C(100)), 301)
+
+        @dataclass(frozen=True)
+        class D:
+            x: int
+
+            def __eq__(self, other):
+                return False
+
+        self.assertEqual(hash(D(100)), hash((100,)))
+
+        with self.assertRaisesRegex(TypeError, "Cannot overwrite attribute __hash__"):
+            @dataclass(unsafe_hash=True)
+            class E:
+                def __hash__(self):
+                    pass
+
+    def test_overwrite_fields_in_derived_class(self):
+        @dataclass
+        class Base:
+            x: float = 15.0
+            y: int = 0
+
+        @dataclass
+        class C1(Base):
+            z: int = 10
+            x: int = 15
+
+        o = C1(x=5)
+        self.assertEqual((o.x, o.y, o.z), (5, 0, 10))
+        self.assertIn("x=5", repr(o))
+        self.assertIn("y=0", repr(o))
+        self.assertIn("z=10", repr(o))
+
+    def test_field_named_self(self):
+        @dataclass
+        class C:
+            self: str
+
+        c = C("foo")
+        self.assertEqual(c.self, "foo")
+
+    def test_field_named_object(self):
+        @dataclass
+        class C:
+            object: str
+
+        c = C("foo")
+        self.assertEqual(c.object, "foo")
+
+    def test_frozen(self):
+        @dataclass(frozen=True)
+        class C:
+            x: int
+
+        c = C(10)
+        self.assertEqual(c.x, 10)
+        with self.assertRaises(FrozenInstanceError):
+            c.x = 11
+
+    def test_is_dataclass(self):
+        @dataclass
+        class C:
+            x: int
+
+        self.assertTrue(is_dataclass(C))
+        self.assertTrue(is_dataclass(C(1)))
+        self.assertFalse(is_dataclass(123))
+
+    def test_fields(self):
+        @dataclass
+        class C:
+            x: int
+            y: int = 5
+
+        f = fields(C)
+        self.assertEqual([i.name for i in f], ["x", "y"])
+
+    def test_asdict_astuple(self):
+        @dataclass
+        class Child:
+            z: int
+
+        @dataclass
+        class Parent:
+            x: int
+            y: Child
+
+        p = Parent(3, Child(7))
+        self.assertEqual(asdict(p), {"x": 3, "y": {"z": 7}})
+        self.assertEqual(astuple(p), (3, (7,)))
+
+    def test_replace(self):
+        @dataclass
+        class C:
+            x: int
+            y: int = 0
+
+        o = C(1, 2)
+        o2 = replace(o, x=9)
+        self.assertEqual((o2.x, o2.y), (9, 2))
+
+    def test_replace_with_init_false_rejected(self):
+        @dataclass
+        class C:
+            x: int
+            y: int = field(default=0, init=False)
+
+        o = C(1)
+        with self.assertRaisesRegex(ValueError, "field y is declared with init=False"):
+            replace(o, y=10)
+
+    def test_make_dataclass(self):
+        C = make_dataclass("C", [("x", int), ("y", int, 7)])
+        o = C(1)
+        self.assertEqual((o.x, o.y), (1, 7))
+
+    def test_order(self):
+        @dataclass(order=True)
+        class C:
+            x: int
+            y: int
+
+        self.assertTrue(C(1, 2) < C(2, 0))
+        self.assertTrue(C(1, 2) <= C(1, 2))
+        self.assertTrue(C(3, 0) > C(2, 9))
+        self.assertTrue(C(3, 0) >= C(3, 0))
+
+    def test_order_requires_eq(self):
+        with self.assertRaisesRegex(ValueError, "eq must be true if order is true"):
+            @dataclass(order=True, eq=False)
+            class C:
+                x: int
+
+    def test_match_args(self):
+        @dataclass
+        class C:
+            x: int
+            y: int = 0
+
+        self.assertEqual(C.__match_args__, ("x", "y"))
+
+    def test_post_init_called(self):
+        @dataclass
+        class C:
+            x: int
+            y: int = 0
+
+            def __post_init__(self):
+                self.y = self.x + 1
+
+        c = C(10)
+        self.assertEqual((c.x, c.y), (10, 11))
+
+    def test_guard_kw_only_decorator(self):
+        with self.assertRaisesRegex(NotImplementedError, "kw_only"):
+            @dataclass(kw_only=True)
+            class C:
+                x: int
+
+    def test_guard_slots(self):
+        with self.assertRaisesRegex(NotImplementedError, "slots"):
+            @dataclass(slots=True)
+            class C:
+                x: int
+
+    def test_guard_weakref_slot(self):
+        with self.assertRaisesRegex(NotImplementedError, "weakref_slot"):
+            @dataclass(weakref_slot=True)
+            class C:
+                x: int
+
+    def test_guard_field_kw_only(self):
+        with self.assertRaisesRegex(NotImplementedError, "field\\(kw_only"):
+            @dataclass
+            class C:
+                x: int = field(default=1, kw_only=True)
+
+    def test_guard_initvar(self):
+        with self.assertRaisesRegex(NotImplementedError, "InitVar"):
+            @dataclass
+            class C:
+                x: InitVar(int)
+
+    def test_guard_classvar(self):
+        with self.assertRaisesRegex(NotImplementedError, "ClassVar"):
+            @dataclass
+            class C:
+                x: "ClassVar[int]" = 1
+
+    def test_guard_kw_only_sentinel(self):
+        with self.assertRaisesRegex(NotImplementedError, "KW_ONLY"):
+            @dataclass
+            class C:
+                _: KW_ONLY
+                x: int
+
+    # Intentionally omitted/skipped for minimal implementation:
+    # - full ClassVar/InitVar/KW_ONLY semantics (guarded with explicit errors)
+    # - slots / weakref_slot implementation (guarded with explicit errors)
+    # - kw_only implementation (guarded with explicit errors)
+    # - recursive protection / deepcopy semantics in asdict/astuple
+    # - metadata mappingproxy details
+    # - full error text parity with CPython
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -370,5 +370,28 @@ class TestClassCell(unittest.TestCase):
         self.assertEqual(calls, ['Middle', 'Leaf'])
 
 
+class TestCompilerRegressions(unittest.TestCase):
+    def test_kwonly_default_builtin_name_resolution(self):
+        """kw-only defaults should resolve names without compiler assertion failures."""
+        def f(*, x=dict):
+            return x
+
+        self.assertIs(f(), dict)
+
+    def test_nested_class_annotation_resolves_outer_name(self):
+        """Class annotations in nested scopes should resolve closure names correctly."""
+        def outer():
+            class Child:
+                pass
+
+            class Parent:
+                y: Child
+
+            return Parent, Child
+
+        Parent, Child = outer()
+        self.assertIs(Parent.__annotations__["y"], Child)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a practical `dataclasses` stdlib module for Skulpt with an incremental, CPython-guided implementation strategy.

Note this is on top of #1591 (so ignore first commit for this PR)

Implemented in:
- `/Users/scork/Desktop/Projects/skulpt/src/lib/dataclasses.py`
- `/Users/scork/Desktop/Projects/skulpt/test/unit3/test_dataclasses.py`

## Why This Stacks On `feat/nonlocal` #1591

This work is intentionally based on `feat/nonlocal` because `dataclasses` depends on correct compiler scoping behavior for:
- class/free-variable resolution,
- nested class closure behavior,
- keyword-only default expression name resolution.

Without those baseline fixes, dataclasses paths hit compiler assertions and incorrect name binding.

## Approach

1. Implement common, high-value dataclass behavior first.
2. Port and adapt CPython tests into a focused Skulpt module test.
3. Add explicit guardrails for unsupported features to avoid silent misbehavior.
4. Expand support in phases only when the complexity/benefit tradeoff is good.

## Implemented Behavior

- Core decorator and field machinery:
  - `@dataclass`
  - `field(...)`
  - generated `__init__`, `__repr__`, `__eq__`, ordering subset, hashing subset, frozen subset
- Helper APIs:
  - `fields`, `is_dataclass`, `asdict`, `astuple`, `replace`, `make_dataclass`
- Sentinels/types exported:
  - `MISSING`, `KW_ONLY`, `InitVar`, `FrozenInstanceError`

### Added in follow-up phases

- `ClassVar` support (excluded from dataclass fields/init)
- keyword-only support:
  - `dataclass(kw_only=True)`
  - `field(..., kw_only=True)`
- `KW_ONLY` sentinel support (single-use per class)
- `InitVar` support with `__post_init__` argument passing
- recursion protection in `asdict`/`astuple` (raises `RecursionError` on cycles)
- `replace()` parity improvement for required `InitVar`s

## Limitations

Not full CPython parity yet. Notable remaining gaps:
- `slots=True` and `weakref_slot=True` (explicitly guarded)
- full metadata parity (`mappingproxy` behavior and exact repr parity)
- complete edge-case parity across all inheritance/signature/error-text combinations
- deeper `make_dataclass` parity for all advanced interactions


## Full disclosure

Most code written by GPT-5.3-Codex