### PR TITLE
Fix: Free variables in class bodies

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -2832,6 +2832,22 @@ Compiler.prototype.nameop = function (name, ctx, dataToStore) {
         case OP_DEREF:
             switch (ctx) {
                 case Sk.astnodes.Load:
+                    // The cell may exist but hold no value yet (e.g. a free variable
+                    // read before the enclosing binding has executed). A bound Python
+                    // value is never JS undefined (None is Sk.builtin.none.none$), so
+                    // an undefined slot means the name is unbound. Match CPython: a free
+                    // variable raises NameError, a local cell raises UnboundLocalError.
+                    out("if (", dict, ".", mangledNoPre, "===undefined) {");
+                    if (scope === Sk.SYMTAB_CONSTS.FREE) {
+                        out("throw new Sk.builtin.NameError(\"cannot access free variable '",
+                            mangledNoPre,
+                            "' where it is not associated with a value in enclosing scope\");");
+                    } else {
+                        out("throw new Sk.builtin.UnboundLocalError(\"cannot access local variable '",
+                            mangledNoPre,
+                            "' where it is not associated with a value\");");
+                    }
+                    out("}\n");
                     return dict + "." + mangledNoPre;
                 case Sk.astnodes.Store:
                     out(dict, ".", mangledNoPre, "=", dataToStore, ";");

--- a/src/compile.js
+++ b/src/compile.js
@@ -2541,7 +2541,11 @@ Compiler.prototype.cclass = function (s) {
 
     this.exitScope();
 
-    out("$ret = Sk.misceval.buildClass($gbl,", scopename, ",", s.name["$r"]().v, ",[", bases, "], $cell, ", keywordArgs, ");");
+    // If the enclosing scope has free variables of its own, they are held in
+    // $free (not $cell) and must be threaded into the class so its body and
+    // methods can close over names bound more than one level out.
+    const enclosingFree = this.u.ste.hasFree ? ", $free" : "";
+    out("$ret = Sk.misceval.buildClass($gbl,", scopename, ",", s.name["$r"]().v, ",[", bases, "], $cell, ", keywordArgs, enclosingFree, ");");
     this._checkSuspension();
 
     // apply decorators

--- a/src/compile.js
+++ b/src/compile.js
@@ -2515,7 +2515,7 @@ Compiler.prototype.cclass = function (s) {
     scopename = this.enterScope(s.name, s, s.lineno);
     entryBlock = this.newBlock("class entry");
 
-    this.u.prefixCode = "var " + scopename + "=(function $" + s.name.v + "$class_outer($globals,$locals,$cell){var $gbl=$globals,$loc=$locals,$free=$globals;";
+    this.u.prefixCode = "var " + scopename + "=(function $" + s.name.v + "$class_outer($globals,$locals,$cell){var $gbl=$globals,$loc=$locals,$free=$cell;";
     this.u.switchCode += "(function $" + s.name.v + "$_closure($cell){";
     this.u.switchCode += "var $blk=" + entryBlock + ",$exc=[],$ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;";
 

--- a/src/function.js
+++ b/src/function.js
@@ -14,7 +14,7 @@
  * that ok?)
  * @param {Object=} closure dict of free variables
  * @param {Object=} closure2 another dict of free variables that will be
- * merged into 'closure'. there's 2 to simplify generated code (one is $free,
+ * used as the prototype of 'closure'. there's 2 to simplify generated code (one is $free,
  * the other is $cell)
  *
  * closure is the cell variables from the parent scope that we need to close
@@ -39,11 +39,10 @@ Sk.builtin.func = Sk.abstr.buildNativeClass("function", {
         this.$module = (Sk.globals && Sk.globals["__name__"]) || Sk.builtin.none.none$;
         this.$qualname = code.co_qualname || this.$name;
 
-        if (closure2 !== undefined) {
-            // todo; confirm that modification here can't cause problems
-            for (let k in closure2) {
-                closure[k] = closure2[k];
-            }
+        // Preserve local cells and observe later assignments in enclosing scopes.
+        // Class bodies can pass the same dictionary for both closures.
+        if (closure2 !== undefined && closure2 !== closure) {
+            Object.setPrototypeOf(closure, closure2);
         }
         this.func_closure = closure;
         this.func_annotations = null;

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1322,7 +1322,7 @@ function _isIE() {
  * should return a newly constructed class object.
  *
  */
-Sk.misceval.buildClass = function (globals, func, name, bases, cell, kws) {
+Sk.misceval.buildClass = function (globals, func, name, bases, cell, kws, closure2) {
     const _name = new Sk.builtin.str(name);
     const _bases = update_bases(bases); // todo this function should go through the bases and check for __mro_entries__
 
@@ -1391,6 +1391,18 @@ Sk.misceval.buildClass = function (globals, func, name, bases, cell, kws) {
     // @todo add qualname here to pass to the code object
 
     const l_cell = cell === undefined ? {} : cell;
+
+    // The class's enclosing scope's free variables (names bound further out and
+    // merely relayed through the class's enclosing scope) live in closure2
+    // rather than in cell.  The class body and its methods may close over them
+    // too, so merge them in alongside the cells, mirroring the closure handling
+    // in the function ctor.
+    if (closure2 !== undefined) {
+        for (let k in closure2) {
+            l_cell[k] = closure2[k];
+        }
+    }
+
     // pass the locals to the code object which populates the namespace of the class
     func(globals, locals, l_cell);
 

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1392,15 +1392,10 @@ Sk.misceval.buildClass = function (globals, func, name, bases, cell, kws, closur
 
     const l_cell = cell === undefined ? {} : cell;
 
-    // The class's enclosing scope's free variables (names bound further out and
-    // merely relayed through the class's enclosing scope) live in closure2
-    // rather than in cell.  The class body and its methods may close over them
-    // too, so merge them in alongside the cells, mirroring the closure handling
-    // in the function ctor.
-    if (closure2 !== undefined) {
-        for (let k in closure2) {
-            l_cell[k] = closure2[k];
-        }
+    // Look up enclosing free variables without overwriting local cells or
+    // copying their current values. Nested classes can share both dictionaries.
+    if (closure2 !== undefined && closure2 !== l_cell) {
+        Object.setPrototypeOf(l_cell, closure2);
     }
 
     // pass the locals to the code object which populates the namespace of the class

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -39,6 +39,65 @@ class TestSuper(unittest.TestCase):
 
 
 class TestRegressions(unittest.TestCase):
+    def test_function_preserves_shadowed_closure_cell(self):
+        def outer():
+            x = 1
+            y = 2
+
+            def capture():  # Keep outer x in the closure passed to inner.
+                return x
+
+            def inner():
+                x = 3
+                y  # Give inner a free variable as well as its own cell.
+
+                def get():
+                    return x
+
+                return x, get()
+
+            return inner()
+
+        self.assertEqual(outer(), (3, 3))
+
+    def test_function_observes_rebound_outer_cell(self):
+        def outer():
+            x = 1
+
+            def middle():
+                def get():
+                    return x
+                return get
+
+            get = middle()
+            before = get()
+            x = 2
+            return before, get()
+
+        self.assertEqual(outer(), (1, 2))
+
+    def test_class_preserves_shadowed_closure_cell(self):
+        def outer():
+            x = 1
+            y = 2
+
+            def capture():  # Keep outer x in the closure passed to inner.
+                return x
+
+            def inner():
+                def get():
+                    return x
+
+                x = 3
+                y  # Give inner a free variable as well as its own cell.
+                class C:
+                    pass
+                return get()
+
+            return inner()
+
+        self.assertEqual(outer(), 3)
+
     def test_bug_1470(self):
         global i
         i = 0

--- a/test/unit3/test_unbound_free.py
+++ b/test/unit3/test_unbound_free.py
@@ -26,6 +26,17 @@ class UnboundFreeTests(unittest.TestCase):
             return Inner.val
         self.assertEqual(f(), 42)
 
+    def test_class_method_captures_function_local(self):
+        # A class method may read a local of an enclosing FUNCTION: x is a cell
+        # in f and a free variable in the body of Inner.g().
+        def f():
+            x = 42
+            class Inner:
+                def g(self):
+                    return x
+            return Inner()
+        self.assertEqual(f().g(), 42)
+
     def test_deep_class_captures_function_locals(self):
         # A class body may read a local of any enclosing FUNCTION.
         def f():
@@ -40,6 +51,22 @@ class UnboundFreeTests(unittest.TestCase):
                 return h()
             return g()
         self.assertEqual(f(), 42042042)
+
+    def test_deep_class_method_captures_function_locals(self):
+        # A class method may read a local of any enclosing FUNCTION.
+        def f():
+            x = 42
+            def g():
+                y = 42000
+                def h():
+                    z = 42000000
+                    class Inner:
+                        def k(self):
+                            return x + y + z
+                    return Inner()
+                return h()
+            return g()
+        self.assertEqual(f().k(), 42042042)
 
     def test_class_body_binding_not_visible_to_nested_class(self):
         # A name bound in an enclosing CLASS body is invisible to nested code:

--- a/test/unit3/test_unbound_free.py
+++ b/test/unit3/test_unbound_free.py
@@ -1,0 +1,115 @@
+import unittest
+
+
+class UnboundFreeTests(unittest.TestCase):
+    """Name resolution across nested function and class scopes.
+
+    Python uses the LEGB rule, where the "Enclosing" tier is the chain of
+    enclosing *function* scopes only; class bodies never participate in that
+    chain.  When a name is bound in an enclosing function and read by a nested
+    scope, its value lives in a shared "cell": the binding scope sees it as a
+    cell variable, and the nested scope that reads it sees it as a free
+    variable.  A cell starts out empty on each call and is filled only when the
+    binding executes, so reading it beforehand raises an error rather than
+    silently treating the empty cell as a value -- NameError for a free-variable
+    read in the nested scope, UnboundLocalError for a cell-variable read in the
+    binding scope itself.
+    """
+
+    def test_class_captures_function_local(self):
+        # A class body may read a local of an enclosing FUNCTION: x is a cell
+        # in f and a free variable in the body of Inner.
+        def f():
+            x = 42
+            class Inner:
+                val = x
+            return Inner.val
+        self.assertEqual(f(), 42)
+
+    def test_deep_class_captures_function_locals(self):
+        # A class body may read a local of any enclosing FUNCTION.
+        def f():
+            x = 42
+            def g():
+                y = 42000
+                def h():
+                    z = 42000000
+                    class Inner:
+                        val = x + y + z
+                    return Inner.val
+                return h()
+            return g()
+        self.assertEqual(f(), 42042042)
+
+    def test_class_body_binding_not_visible_to_nested_class(self):
+        # A name bound in an enclosing CLASS body is invisible to nested code:
+        # class scopes are not enclosing scopes, so x falls through to a global
+        # lookup and is not found.
+        def f():
+            class Level1:
+                x = 42
+                class Level2:
+                    class Level3:
+                        got = x
+        self.assertRaises(NameError, f)
+
+    def test_free_var_read_during_class_construction(self):
+        # Level1 is bound in the enclosing function, so it is a cell variable
+        # there and a free variable in the nested class that reads it.  Its cell
+        # is still empty while Level1's own body is executing -> NameError for
+        # reading an unbound free variable.
+        def f():
+            class Level1:
+                x = 42
+                class Level2:
+                    got = Level1.x
+        self.assertRaises(NameError, f)
+
+    def test_cell_relayed_through_intermediate_functions(self):
+        # The cell for x is threaded through g and h, which never mention x
+        # themselves, down to k which reads it.
+        def f():
+            x = 42
+            def g():
+                def h():
+                    def k():
+                        return x
+                    return k()
+                return h()
+            return g()
+        self.assertEqual(f(), 42)
+
+    def test_no_binding_falls_through_to_global(self):
+        # With no binding in any enclosing function, x is neither local nor
+        # free; it is a global/builtin lookup and is not found.
+        def f():
+            def g():
+                return x
+            return g()
+        self.assertRaises(NameError, f)
+
+    def test_free_var_read_before_binding(self):
+        # g reads x (a free variable whose cell lives in f) before f has bound
+        # it -> NameError, even though f does bind x later.  The later x = 42 is
+        # what makes x a cell of f rather than a global.
+        def f():
+            def g():
+                return x
+            g()
+            x = 42
+        self.assertRaises(NameError, f)
+
+    def test_local_cell_read_before_binding(self):
+        # x is a local of f that is also captured by g, so it lives in a cell.
+        # Reading that cell in f before x is assigned is an UnboundLocalError
+        # (the local-variable counterpart of the free-variable case above).
+        def f():
+            def g():
+                return x
+            got = x
+            x = 1
+        self.assertRaises(UnboundLocalError, f)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
While working on something involving descriptors, I came across a problem which I boiled down to the behaviour of this code:

```python
def f():
    s = "hello"
    class _inner:
        print(s.upper())

f()
```

In CPython this prints `HELLO` as expected.  In Skulpt it generates a JavaScript error:

```test
ExternalError: TypeError: Cannot read properties of undefined (reading 'tp$getattr') on line 4
```

I used Claude to help investigate, and refined what it produced into this PR.  The root cause was that cell variables weren't being made available to the `class` body evaluation.

With the PR, all tests pass, including some new ones (`test/unit3/test_unbound_free.py`) which fail under current `master` Skulpt.  The comments are mostly Claude's and seem reasonable to me, but let me know if they should be made briefer.

Thanks!

Close #1178