### PR TITLE
fix: keep annotation flags separate from symbol scopes

### DIFF
--- a/src/symtable.js
+++ b/src/symtable.js
@@ -31,9 +31,9 @@ var DEF_BOUND = (DEF_LOCAL | DEF_PARAM | DEF_IMPORT);
 
 /* GLOBAL_EXPLICIT and GLOBAL_IMPLICIT are used internally by the symbol
  table.  GLOBAL is returned from PyST_GetScope() for either of them.
- It is stored in ste_symbols at bits 12-14.
+ It is stored in ste_symbols at bits 13-15, above DEF_ANNOT at bit 12.
  */
-var SCOPE_OFF = 11;
+var SCOPE_OFF = 13;
 var SCOPE_MASK = 7;
 
 var LOCAL = 1;

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -120,6 +120,18 @@ class An:
 
 
 class TestAnnotations(unittest.TestCase):
+    def test_annotated_variables_remain_local(self):
+        def first():
+            rows: list = []
+            second()
+            return rows
+
+        def second():
+            rows: list = []
+            rows.append(7)
+
+        self.assertEqual(first(), [])
+
     def test_bug_1428(self):
         annotations = An.__annotations__
         self.assertEqual(annotations, {"name": str, "_An__foo": int})


### PR DESCRIPTION
Annotated function locals can be classified as globals because DEF_ANNOT overlaps the encoded scope bits. Move the scope offset above every definition flag and add a regression proving annotated locals remain isolated. Fixes #1590. Validation: full npm test passes.