### PR TITLE
fix: bind __class__ cells during type creation

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -693,7 +693,8 @@ Compiler.prototype.ccall = function (e) {
         // TODO: feel free to ignore the above
         this.u.tempsToSave.push("$sup");
         out("if (typeof $sup === \"undefined\") { throw new Sk.builtin.RuntimeError(\"super(): no arguments\") };");
-        positionalArgs = "[$gbl.__class__,$sup]";
+        out("if (typeof $free === 'undefined' || $free.__class__ === undefined) { throw new Sk.builtin.RuntimeError('super(): __class__ cell not found') };");
+        positionalArgs = "[$free.__class__,$sup]";
     }
     out ("$ret = (",func,".tp$call)?",func,".tp$call(",positionalArgs,",",keywordArgs,") : Sk.misceval.applyOrSuspend(",func,",undefined,undefined,",keywordArgs,",",positionalArgs,");");
 
@@ -2147,10 +2148,6 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     //
     this.u.varDeclsCode += "}";
 
-    // inject __class__ cell when running python3
-    if (Sk.__future__.super_args && class_for_super) {
-        this.u.varDeclsCode += "$gbl.__class__=$gbl." + class_for_super.v + ";";
-    }
 
     // finally, set up the block switch that the jump code expects
     //
@@ -2254,7 +2251,9 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     //
     frees = "";
     if (hasFree) {
-        if (this.u.ste.hasCells) {
+        if (this.u.ste.needsClassClosure) {
+            frees = ",$classcell";
+        } else if (this.u.ste.hasCells) {
             frees = ",$cell";
         }
         containingHasFree = this.u.ste.hasFree || this.u.ste.blockType === Sk.SYMTAB_CONSTS.ClassBlock;
@@ -2523,6 +2522,10 @@ Compiler.prototype.cclass = function (s) {
     entryBlock = this.newBlock("class entry");
 
     this.u.prefixCode = "var " + scopename + "=(function $" + s.name.v + "$class_outer($globals,$locals,$cell){var $gbl=$globals,$loc=$locals,$free=$cell;";
+    const needsClassClosure = this.u.ste.needsClassClosure;
+    if (needsClassClosure) {
+        this.u.prefixCode += "var $classcell={__class__:undefined};";
+    }
     this.u.switchCode += "(function $" + s.name.v + "$_closure($cell){";
     this.u.switchCode += "var $blk=" + entryBlock + ",$exc=[],$ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;";
 
@@ -2542,6 +2545,9 @@ Compiler.prototype.cclass = function (s) {
     this.u.private_ = s.name;
 
     this.cbody(s.body, s.name);
+    if (needsClassClosure) {
+        out("$loc.__classcell__=new Sk.builtin.cell($classcell);");
+    }
     out("return;");
 
     // build class

--- a/src/function.js
+++ b/src/function.js
@@ -200,6 +200,28 @@ Sk.builtin.func = Sk.abstr.buildNativeClass("function", {
     },
 });
 
+// Expose the class closure cell to Python metaclasses through __classcell__.
+Sk.builtin.cell = Sk.abstr.buildNativeClass("cell", {
+    constructor: function cell(closure) {
+        this.$closure = closure;
+    },
+    getsets: {
+        cell_contents: {
+            $get() {
+                const value = this.$closure.__class__;
+                if (value === undefined) {
+                    throw new Sk.builtin.ValueError("Cell is empty");
+                }
+                return value;
+            },
+            $set(value) {
+                this.$closure.__class__ = value;
+            },
+        },
+    },
+});
+Sk.exportSymbol("Sk.builtin.cell", Sk.builtin.cell);
+
 function $resolveArgs(posargs, kw) {
     // The rest of this function is a logical Javascript port of
     // _PyEval_EvalCodeWithName, and follows its logic,
@@ -346,4 +368,3 @@ function $resolveArgs(posargs, kw) {
 
     return args;
 };
-

--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1410,6 +1410,8 @@ Sk.misceval.buildClass = function (globals, func, name, bases, cell, kws, closur
     // pass the locals to the code object which populates the namespace of the class
     func(globals, locals, l_cell);
 
+    const classcell = locals.__classcell__ instanceof Sk.builtin.cell ? locals.__classcell__ : undefined;
+
     if (!localsIsProxy) {
         // put locals object inside the ns dict
         Object.keys(locals).forEach((key) => {
@@ -1419,7 +1421,19 @@ Sk.misceval.buildClass = function (globals, func, name, bases, cell, kws, closur
 
     const klass = Sk.misceval.callsimOrSuspendArray(meta, [_name, _bases, ns], kws);
 
-    return klass;
+    // type.__new__ must populate the cell, including when called by a metaclass.
+    return Sk.misceval.chain(klass, (resolvedKlass) => {
+        if (classcell !== undefined && Sk.builtin.checkClass(resolvedKlass)) {
+            const value = classcell.$closure.__class__;
+            if (value === undefined) {
+                throw new Sk.builtin.RuntimeError("__class__ not set defining '" + name + "'. Was __classcell__ propagated to type.__new__?");
+            }
+            if (value !== resolvedKlass) {
+                throw new Sk.builtin.TypeError("__class__ set to a different class defining '" + name + "'");
+            }
+        }
+        return resolvedKlass;
+    });
 };
 Sk.exportSymbol("Sk.misceval.buildClass", Sk.misceval.buildClass);
 

--- a/src/symtable.js
+++ b/src/symtable.js
@@ -833,6 +833,9 @@ SymbolTable.prototype.visitExpr = function (e) {
             break;
         case Sk.astnodes.Name:
             this.addDef(e.id, e.ctx === Sk.astnodes.Load ? USE : DEF_LOCAL, e.lineno);
+            if (e.ctx === Sk.astnodes.Load && this.cur.blockType === FunctionBlock && e.id.v === "super") {
+                this.addDef(new Sk.builtin.str("__class__"), USE, e.lineno);
+            }
             break;
         case Sk.astnodes.NameConstant:
             break;
@@ -944,6 +947,7 @@ SymbolTable.prototype.analyzeBlock = function (ste, bound, free, global) {
         if (bound) {
             _dictUpdate(newbound, bound);
         }
+        newbound.__class__ = null;
     }
 
     for (name in ste.symFlags) {
@@ -974,6 +978,10 @@ SymbolTable.prototype.analyzeBlock = function (ste, bound, free, global) {
     _dictUpdate(newfree, allfree);
     if (ste.blockType === FunctionBlock) {
         this.analyzeCells(ste, scope, newfree);
+    }
+    if (ste.blockType === ClassBlock && newfree.__class__ !== undefined) {
+        delete newfree.__class__;
+        ste.needsClassClosure = true;
     }
     this.updateSymbols(ste, ste.symFlags, scope, bound, newfree, ste.blockType === ClassBlock);
 

--- a/src/type.js
+++ b/src/type.js
@@ -200,7 +200,7 @@ function tp$new(args, kwargs) {
 
 
     dict.$items().forEach(([key, val]) => {
-        if (!Sk.builtin.checkString(key)) {
+        if (!Sk.builtin.checkString(key) || key.v === "__classcell__") {
             return;
         }
         if (slotSet && slotSet.has(key.v)) {
@@ -229,6 +229,14 @@ function tp$new(args, kwargs) {
     overrideImplied(proto, "__class_getitem__", "classmethod");
 
     klass.$allocateSlots();
+
+    const classcell = dict.quick$lookup(new Sk.builtin.str("__classcell__"));
+    if (classcell !== undefined) {
+        if (!(classcell instanceof Sk.builtin.cell)) {
+            throw new Sk.builtin.TypeError("__classcell__ must be a nonlocal cell, not " + Sk.abstr.typeName(classcell));
+        }
+        classcell.$closure.__class__ = klass;
+    }
 
     set_names(klass);
     init_subclass(klass, kwargs);

--- a/test/unit3/test_descr.py
+++ b/test/unit3/test_descr.py
@@ -478,8 +478,6 @@ class ClassPropertiesAndMethods(unittest.TestCase):
 
     def test_metaclass(self):
         # Testing metaclasses...
-        global A, B, C, D, E, M1, M2, T, autosuper, autoproperty, multimetaclass, _instance, AMeta, BMeta, C2 #1178
-        global ANotMeta, BNotMeta, func
         class C(metaclass=type):
             def __init__(self):
                 self.__state = 0
@@ -856,7 +854,6 @@ class ClassPropertiesAndMethods(unittest.TestCase):
 
     def test_multiple_inheritance(self):
         # Testing multiple inheritance...
-        global C_Multi #1178
         class C_Multi(object):
             def __init__(self):
                 self.__state = 0
@@ -1104,7 +1101,6 @@ order (MRO) for bases """
 
     def test_slots(self):
         # Testing __slots__...
-        global C, slots #1178
         class C0(object):
             __slots__ = []
         x = C0()
@@ -1307,7 +1303,6 @@ order (MRO) for bases """
 
     def test_slots_special(self):
         # Testing __dict__ and __weakref__ in __slots__...
-        global D, C, C2
         class D(object):
             __slots__ = ["__dict__"]
         a = D()
@@ -1465,7 +1460,6 @@ order (MRO) for bases """
         self.assertEqual(I(3)*I(2), 6)
 
         # Test comparison of classes with dynamic metaclasses
-        global dynamicmetaclass #1178
         class dynamicmetaclass(type):
             pass
         class someclass(metaclass=dynamicmetaclass):
@@ -1516,7 +1510,6 @@ order (MRO) for bases """
         else:
             self.fail("__slots__ = [1] should be illegal")
 
-        global M1, M2, A1, A2, B #1178
         class M1(type):
             pass
         class M2(type):
@@ -1712,11 +1705,10 @@ order (MRO) for bases """
         self.assertEqual(d.goo(1), (D, 1))
         self.assertEqual(d.foo(1), (d, 1))
         self.assertEqual(D.foo(d, 1), (d, 1))
-        # see skulpt issue 1178
-        # class E: # *not* subclassing from C
-        #     foo = C.foo
-        # self.assertEqual(E().foo.__func__, C.foo) # i.e., unbound
-        # self.assertTrue(repr(C.foo.__get__(C())).startswith("<bound method "))
+        class E: # *not* subclassing from C
+            foo = C.foo
+        self.assertEqual(E().foo.__func__, C.foo) # i.e., unbound
+        self.assertTrue(repr(C.foo.__get__(C())).startswith("<bound method "))
 
     def test_compattr(self):
         # Testing computed attributes...
@@ -1914,7 +1906,6 @@ order (MRO) for bases """
 
     def test_overloading(self):
         # Testing operator overloading...
-        global B, C
 
         class B(object):
             "Intermediate class because object doesn't have a __setattr__"
@@ -1964,7 +1955,6 @@ order (MRO) for bases """
 
     def test_methods(self):
         # Testing methods...
-        global C_methods, c1_methods #1178 moving this to global scope
         class C_methods(object):
             def __init__(self, x):
                 self.x = x
@@ -2070,15 +2060,10 @@ order (MRO) for bases """
             ("__round__", round, zero, set(), {}),
             ]
 
-        # Skulpt #1178 moved to global scope
-        global Checker, SpecialDescr, MyException, ErrDescr, X
-        global _self
         _self = self
         class Checker(object):
             def __init__(self, test, ok=set()):
                 self.test = test
-                global _ok
-                _ok = ok
             def __getattr__(self, attr, test=_self):
                 test.fail("__getattr__ called with {0}".format(attr))
             def __getattribute__(self, attr, test=_self):
@@ -2341,7 +2326,6 @@ order (MRO) for bases """
     #             p = property(_testcapi.test_with_docstring)
 
     def test_properties_plus(self):
-        global C, D, E, F
         class C(object):
             foo = property(doc="hello")
             @foo.getter
@@ -2586,7 +2570,6 @@ order (MRO) for bases """
 
     def test_supers(self):
         # Testing super...
-        global A, B, C, D, E, F # 1178
 
         class A(object):
             def meth(self, a):
@@ -3250,8 +3233,6 @@ order (MRO) for bases """
     def test_doc_descriptor(self):
         # Testing __doc__ descriptor...
         # SF bug 542984
-        # Skulpt BUG #1178 move this to global scope
-        global DocDescr
         class DocDescr(object):
             def __get__(self, object, otype):
                 if object:
@@ -3365,7 +3346,6 @@ order (MRO) for bases """
 
     def test_set_dict(self):
         # Testing __dict__ assignment...
-        global Base, Meta1, Meta2, D, E, C, Module1, Module2, Exception1, Exception2 #1178
         class C(object): pass
         a = C()
         a.__dict__ = {'b': 1}
@@ -4632,8 +4612,6 @@ order (MRO) for bases """
     def test_set_and_no_get(self):
         # See
         # http://mail.python.org/pipermail/python-dev/2010-January/095637.html
-        global Descr, X, Meta, descr
-        #moved to global scope see skulpt #1178
         class Descr(object):
 
             def __init__(self, name):
@@ -4663,8 +4641,6 @@ order (MRO) for bases """
     def test_getattr_hooks(self):
         # issue 4230
 
-        # moved to global scope # skulpt #1178
-        global getattr_descr, GetattrDescriptor
         class GetattrDescriptor(object):
             counter = 0
             def __get__(self, obj, objtype=None):
@@ -4982,7 +4958,6 @@ class DictProxyTests(unittest.TestCase):
 
     def test_dict_type_with_metaclass(self):
         # Testing type of __dict__ when metaclass set...
-        global M
         class B(object):
             pass
         class M(type):

--- a/test/unit3/test_init_subclass.py
+++ b/test/unit3/test_init_subclass.py
@@ -2,13 +2,10 @@ import types
 import unittest
 
 
-# argh bug #1178 is very annoying for these tests!!
-# when #1178 is fixed can remove all the global 
 
 
 class Test(unittest.TestCase):
     def test_init_subclass(self):
-        global A,B
         class A:
             initialized = False
 
@@ -22,7 +19,6 @@ class Test(unittest.TestCase):
         self.assertTrue(B.initialized)
 
     def test_init_subclass_dict(self):
-        global A,B
         class A(dict):
             initialized = False
 
@@ -36,7 +32,6 @@ class Test(unittest.TestCase):
         self.assertTrue(B.initialized)
 
     def test_init_subclass_kwargs(self):
-        global A,B
         class A:
             def __init_subclass__(cls, **kwargs):
                 cls.kwargs = kwargs
@@ -47,7 +42,6 @@ class Test(unittest.TestCase):
         self.assertEqual(B.kwargs, dict(x=3))
 
     def test_init_subclass_error(self):
-        global A,B
         class A:
             def __init_subclass__(cls):
                 raise RuntimeError
@@ -57,7 +51,6 @@ class Test(unittest.TestCase):
                 pass
 
     def test_init_subclass_wrong(self):
-        global A,B
         class A:
             def __init_subclass__(cls, whatever):
                 pass
@@ -67,7 +60,6 @@ class Test(unittest.TestCase):
                 pass
 
     def test_init_subclass_skipped(self):
-        global BaseWithInit, BaseWithoutInit, A
         class BaseWithInit:
             def __init_subclass__(cls, **kwargs):
                 super().__init_subclass__(**kwargs)
@@ -83,7 +75,6 @@ class Test(unittest.TestCase):
         self.assertIs(BaseWithoutInit.initialized, BaseWithoutInit)
 
     def test_init_subclass_diamond(self):
-        global Base, Left, Middle, Right, A
         class Base:
             def __init_subclass__(cls, **kwargs):
                 super().__init_subclass__(**kwargs)
@@ -110,7 +101,6 @@ class Test(unittest.TestCase):
         self.assertEqual(Right.calls, [])
 
     def test_set_name(self):
-        global Descriptor
         class Descriptor:
             def __set_name__(self, owner, name):
                 self.owner = owner
@@ -123,7 +113,6 @@ class Test(unittest.TestCase):
         self.assertIs(A.d.owner, A)
 
     def test_set_name_metaclass(self):
-        global Meta, Descriptor
         class Meta(type):
             def __new__(cls, name, bases, ns):
                 ret = super().__new__(cls, name, bases, ns)
@@ -141,7 +130,6 @@ class Test(unittest.TestCase):
         self.assertEqual(A, 0)
 
     def test_set_name_error(self):
-        global Descriptor, NotGoingToWork
         class Descriptor:
             def __set_name__(self, owner, name):
                 1/0
@@ -157,7 +145,6 @@ class Test(unittest.TestCase):
         self.assertIsInstance(exc.__cause__, ZeroDivisionError)
 
     def test_set_name_wrong(self):
-        global Descriptor, NotGoingToWork
         class Descriptor:
             def __set_name__(self):
                 pass
@@ -173,7 +160,6 @@ class Test(unittest.TestCase):
         self.assertIsInstance(exc.__cause__, TypeError)
 
     def test_set_name_lookup(self):
-        global resolved, NonDescriptor, A
         resolved = []
         class NonDescriptor:
             def __getattr__(self, name):
@@ -186,7 +172,6 @@ class Test(unittest.TestCase):
                          '__set_name__ is looked up in instance dict')
 
     def test_set_name_init_subclass(self):
-        global Descriptor, Meta, A
         class Descriptor:
             def __set_name__(self, owner, name):
                 self.owner = owner
@@ -213,7 +198,6 @@ class Test(unittest.TestCase):
         self.assertEqual(B.name, 'd')
 
     def test_set_name_modifying_dict(self):
-        global notified, Descriptor
         notified = []
         class Descriptor:
             def __set_name__(self, owner, name):
@@ -230,7 +214,6 @@ class Test(unittest.TestCase):
         self.assertEqual(notified, ['a', 'b', 'c', 'd', 'e'])
 
     def test_errors(self):
-        global MyMeta, MyClass
         class MyMeta(type):
             pass
 
@@ -266,7 +249,6 @@ class Test(unittest.TestCase):
         self.assertEqual(MyClass.otherarg, 1)
 
     def test_errors_changed_pep487(self):
-        global MyMeta, MyClass
         # These tests failed before Python 3.6, PEP 487
         class MyMeta(type):
             def __new__(cls, name, bases, namespace):

--- a/test/unit3/test_module.py
+++ b/test/unit3/test_module.py
@@ -7,9 +7,6 @@ import unittest
 import sys
 ModuleType = type(sys)
 
-class Descr:
-    def __get__(self, o, t):
-        raise RuntimeError
 class FullLoader:
     @classmethod
     def module_repr(cls, m):
@@ -284,10 +281,9 @@ class ModuleTests(unittest.TestCase):
     #         b"shutil.rmtree = rmtree"})
 
     def test_descriptor_errors_propagate(self):
-        # moved to global scope skulpt issue #1178
-        # class Descr:
-        #     def __get__(self, o, t):
-        #         raise RuntimeError
+        class Descr:
+            def __get__(self, o, t):
+                raise RuntimeError
         class M(ModuleType):
             melon = Descr()
         self.assertRaises(RuntimeError, getattr, M("mymod"), "melon")

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -206,5 +206,169 @@ class TestBugs(unittest.TestCase):
         self.assertTrue(a != a)
 
 
+class TestClassCell(unittest.TestCase):
+    """Tests for __class__ cell and super() handling - Issues #1171, #1340"""
+
+    def test_class_cell_available_after_type_new(self):
+        seen = []
+        class Meta(type):
+            def __new__(meta, name, bases, namespace):
+                result = super().__new__(meta, name, bases, namespace)
+                seen.append(result.get_class())
+                return result
+        class C(metaclass=Meta):
+            @staticmethod
+            def get_class():
+                return __class__
+        self.assertEqual(seen, [C])
+
+    def test_class_cell_available_in_creation_hooks(self):
+        seen = []
+        class Descriptor:
+            def __set_name__(self, owner, name):
+                seen.append(owner.get_class())
+        class Base:
+            def __init_subclass__(cls):
+                seen.append(cls.get_class())
+        class C(Base):
+            descriptor = Descriptor()
+            @staticmethod
+            def get_class():
+                return __class__
+        self.assertEqual(seen, [C, C])
+        self.assertNotIn("__classcell__", C.__dict__)
+
+    def test_class_cell_must_be_forwarded_by_metaclass(self):
+        class Meta(type):
+            def __new__(meta, name, bases, namespace):
+                namespace.pop("__classcell__")
+                return super().__new__(meta, name, bases, namespace)
+        with self.assertRaises(RuntimeError):
+            class C(metaclass=Meta):
+                def get_class(self):
+                    return __class__
+
+    def test_invalid_class_cell_rejected(self):
+        with self.assertRaises(TypeError):
+            type("C", (), {"__classcell__": 42})
+
+    def test_class_cell_and_nonlocal_share_outer_binding(self):
+        def outer():
+            count = 0
+            class C:
+                def increment(self):
+                    nonlocal count
+                    count += 1
+                    return __class__
+            self.assertIs(C().increment(), C)
+            return count
+        self.assertEqual(outer(), 1)
+
+    def test_issue_1171_super_in_nested_class_in_function(self):
+        """super() in __init_subclass__ of class defined inside a function"""
+        def bar():
+            class A:
+                def __init_subclass__(cls):
+                    super().__init_subclass__()
+
+            class B(A):
+                pass
+            return A, B
+
+        A, B = bar()
+        self.assertEqual(A.__name__, 'A')
+        self.assertEqual(B.__name__, 'B')
+
+    def test_super_with_closure_in_method(self):
+        """super() in method that also has a closure (Issue #4360 in CPython)"""
+        class A:
+            def f(self):
+                return 'A'
+
+        class E(A):
+            def f(self):
+                def nested():
+                    self  # creates closure
+                return super().f() + 'E'
+
+        self.assertEqual(E().f(), 'AE')
+
+    def test___class___in_instancemethod(self):
+        """__class__ should be available in instance methods"""
+        class X:
+            def f(self):
+                return __class__
+
+        self.assertIs(X().f(), X)
+
+    def test___class___in_classmethod(self):
+        """__class__ should be available in classmethods"""
+        class Y:
+            @classmethod
+            def f(cls):
+                return __class__
+
+        self.assertIs(Y.f(), Y)
+
+    def test___class___in_staticmethod(self):
+        """__class__ should be available in staticmethods"""
+        class Z:
+            @staticmethod
+            def f():
+                return __class__
+
+        self.assertIs(Z.f(), Z)
+
+    def test_super_in_nested_classes(self):
+        """super() works correctly in nested class hierarchies"""
+        class Outer:
+            class Inner:
+                def greet(self):
+                    return "Inner"
+
+            class InnerChild(Inner):
+                def greet(self):
+                    return super().greet() + "Child"
+
+        self.assertEqual(Outer.InnerChild().greet(), "InnerChild")
+
+    def test_multiple_levels_of_super(self):
+        """super() works through multiple inheritance levels"""
+        class A:
+            def f(self):
+                return 'A'
+
+        class B(A):
+            def f(self):
+                return super().f() + 'B'
+
+        class C(B):
+            def f(self):
+                return super().f() + 'C'
+
+        class D(C):
+            def f(self):
+                return super().f() + 'D'
+
+        self.assertEqual(D().f(), 'ABCD')
+
+    def test_super_in_init_subclass_chain(self):
+        """super().__init_subclass__() works through inheritance chain"""
+        calls = []
+
+        class Base:
+            def __init_subclass__(cls, **kwargs):
+                super().__init_subclass__(**kwargs)
+                calls.append(cls.__name__)
+
+        class Middle(Base):
+            pass
+
+        class Leaf(Middle):
+            pass
+
+        self.assertEqual(calls, ['Middle', 'Leaf'])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Uses a lexical `__class__` cell for methods and zero-argument `super()`, avoiding the module-global class value that could be overwritten by another method call. Fixes #1171 and #1340.

The class namespace carries a Python cell object through the metaclass to `type.__new__`. Type creation fills the cell before `__set_name__` and `__init_subclass__`, so methods can read `__class__` during creation hooks and after a metaclass calls `super().__new__`. Missing propagation and invalid cells raise Python exceptions.

Depends on #1591. This PR contains the class-cell changes and corresponding tests; annotation handling and nonlocal semantics have separate PRs.

Validation: targeted compiler/class-cell regressions pass under CPython and Skulpt, including metaclass timing, creation hooks, dropped and invalid cells, and nonlocal writes from methods using `__class__`. Development and optimized builds both pass the full suite.

Merge #1601, then #1591. Retarget this PR to master and rerun CI before merging it.