### PR TITLE
fix: run suspension cleanup after completion

### DIFF
--- a/src/misceval.js
+++ b/src/misceval.js
@@ -1087,10 +1087,27 @@ Sk.exportSymbol("Sk.misceval.chain", Sk.misceval.chain);
  *       console.log(err);
  *     });
  *
- * Because exceptions are returned asynchronously aswell you can't catch them
- * with a try/catch. That's what this function is for.
+ * Optional cleanUp runs once after tryFn or catchFn finishes, including all
+ * suspensions. Cleanup may suspend; its exception replaces any pending result
+ * or exception, as with a Python finally clause.
  */
-Sk.misceval.tryCatch = function (tryFn, catchFn) {
+Sk.misceval.tryCatch = function (tryFn, catchFn, cleanUp) {
+    if (cleanUp !== undefined) {
+        var failed = false;
+        var error;
+        var result = Sk.misceval.tryCatch(
+            function () { return Sk.misceval.tryCatch(tryFn, catchFn); },
+            function (e) { failed = true; error = e; }
+        );
+        return Sk.misceval.chain(result, function (value) {
+            return Sk.misceval.chain(cleanUp(), function () {
+                if (failed) {
+                    throw error;
+                }
+                return value;
+            });
+        });
+    }
     var r;
 
     try {

--- a/test/suspension_cleanup.js
+++ b/test/suspension_cleanup.js
@@ -1,0 +1,51 @@
+const assert = require("assert");
+
+function pause(resume) {
+    const suspension = new Sk.misceval.Suspension();
+    suspension.resume = resume;
+    return suspension;
+}
+
+// Cleanup follows the complete operation, even when the catch handler and
+// cleanup themselves suspend. The catch handler's result survives cleanup.
+const events = [];
+const failure = new Error("body");
+let result = Sk.misceval.tryCatch(
+    () => pause(() => pause(() => { events.push("body"); throw failure; })),
+    (error) => {
+        assert.strictEqual(error, failure);
+        return pause(() => { events.push("catch"); return 42; });
+    },
+    () => { events.push("cleanup"); return pause(() => events.push("cleanup done")); }
+);
+assert.deepStrictEqual(events, []);
+while (result instanceof Sk.misceval.Suspension) {
+    result = result.resume();
+}
+assert.strictEqual(result, 42);
+assert.deepStrictEqual(events, ["body", "catch", "cleanup", "cleanup done"]);
+
+for (const suspended of [false, true]) {
+    for (const cleanupFails of [false, true]) {
+        let cleanups = 0;
+        const cleanupError = new Error("cleanup");
+        assert.throws(() => {
+            let pending = Sk.misceval.tryCatch(
+                () => { throw failure; },
+                (error) => { throw error; },
+                () => {
+                    cleanups++;
+                    const finish = () => { if (cleanupFails) { throw cleanupError; } };
+                    return suspended ? pause(finish) : finish();
+                }
+            );
+            while (pending instanceof Sk.misceval.Suspension) {
+                pending = pending.resume();
+            }
+        }, (error) => error === (cleanupFails ? cleanupError : failure));
+        assert.strictEqual(cleanups, 1);
+    }
+}
+
+assert.strictEqual(Sk.misceval.tryCatch(() => 7, () => 0, () => 99), 7);
+console.log("Suspension cleanup tests passed");

--- a/test/testwrapper.js
+++ b/test/testwrapper.js
@@ -7,4 +7,5 @@ if (skulpt === null) {
 }
 
 // Run tests
+require('./suspension_cleanup.js');
 require('./test.js');


### PR DESCRIPTION
Suspension-aware cleanup must run after the operation finishes, including any suspended catch handler. Running it at each suspension boundary clears generator state and exits context managers too early.

Adds optional cleanup to `Sk.misceval.tryCatch`. Cleanup runs once, may itself suspend, and preserves the result or pending exception unless cleanup raises. Existing two-argument callers retain their behavior.

Depends on #1602. This is layer 1 of the generator/contextlib work split from #1306. The following layers cover exception semantics, generator execution, and contextlib.

Validation: focused JavaScript tests cover repeated suspension, suspended catch handlers, suspended cleanup, result preservation and exception precedence. Full development and optimized suites pass on the completed stack. Merge after #1602; retarget to master and rerun CI first.

Stack and merge order: #1602 → #1603 → #1604 → #1605 → #1306.
