### PR TITLE
fix: support explicit exception causes and context protocol errors

### DIFF
--- a/src/builtindict.js
+++ b/src/builtindict.js
@@ -40,6 +40,7 @@ Sk.builtins = {
     "AttributeError"     : Sk.builtin.AttributeError,
     "ArithmeticError"    : Sk.builtin.ArithmeticError,
     "ValueError"         : Sk.builtin.ValueError,
+    "GeneratorExit"      : Sk.builtin.GeneratorExit,
     "Exception"          : Sk.builtin.Exception,
     "ZeroDivisionError"  : Sk.builtin.ZeroDivisionError,
     "AssertionError"     : Sk.builtin.AssertionError,

--- a/src/compile.js
+++ b/src/compile.js
@@ -1539,7 +1539,7 @@ Compiler.prototype.craise = function (s) {
 
         if (s.cause) {
             cause = this._gr("cause", this.vexpr(s.cause));
-            out("if (", cause, ".prototype instanceof Sk.builtin.BaseException) {");
+            out("if (", cause, " === Sk.builtin.BaseException || ", cause, ".prototype instanceof Sk.builtin.BaseException) {");
             out(    "$ret = Sk.misceval.callsimOrSuspend(", cause, ");");
             out("} else {");
             out(    "$ret = ", cause, ";");
@@ -1728,11 +1728,11 @@ Compiler.prototype.cwith = function (s, itemIdx) {
 
     // value = mgr.__enter__()
     out("$ret = Sk.abstr.lookupSpecial(",mgr,",Sk.builtin.str.$enter);");
-    
+
     // check we actually have a context manager and throw nicely
     out("if ($ret === undefined) {throw new Sk.builtin.AttributeError('__enter__');} ");
     out(`else if (${exit} === undefined) {throw new Sk.builtin.AttributeError('__exit__');}`);
-    
+
     // lookupspecial can't suspend
     out("$ret = Sk.misceval.callsimOrSuspendArray($ret);");
     this._checkSuspension(s);

--- a/src/compile.js
+++ b/src/compile.js
@@ -1508,6 +1508,7 @@ Compiler.prototype.cfor = function (s) {
 Compiler.prototype.craise = function (s) {
     if (s.exc) {
         var exc = this._gr("exc", this.vexpr(s.exc));
+        var cause;
         // This is tricky - we're supporting both the weird-ass semantics
         // of the Python 2 "raise (exc), (inst), (tback)" version,
         // plus the sensible Python "raise (exc) from (cause)".
@@ -1536,8 +1537,20 @@ Compiler.prototype.craise = function (s) {
 
         this.setBlock(instantiatedException);
 
-        // TODO TODO TODO set cause appropriately
-        // (and perhaps traceback for py2 if we care before it gets fully deprecated)
+        if (s.cause) {
+            cause = this._gr("cause", this.vexpr(s.cause));
+            out("if (", cause, ".prototype instanceof Sk.builtin.BaseException) {");
+            out(    "$ret = Sk.misceval.callsimOrSuspend(", cause, ");");
+            out("} else {");
+            out(    "$ret = ", cause, ";");
+            out("}");
+            this._checkSuspension(s);
+            out(cause, "=$ret;");
+            out("if (", cause, " !== Sk.builtin.none.none$ && !(", cause, " instanceof Sk.builtin.BaseException)) {");
+            out(    "throw new Sk.builtin.TypeError('exception causes must derive from BaseException');");
+            out("}");
+            out(exc, ".$cause = ", cause, ";");
+        }
 
         out("if (", exc, " instanceof Sk.builtin.BaseException) {throw ",exc,";} else {throw new Sk.builtin.TypeError('exceptions must derive from BaseException');};");
     } else {
@@ -1710,14 +1723,17 @@ Compiler.prototype.cwith = function (s, itemIdx) {
     mgr = this._gr("mgr", this.vexpr(s.items[itemIdx].context_expr));
 
     // exit = mgr.__exit__
-    out("$ret = Sk.abstr.lookupSpecial(",mgr,",Sk.builtin.str.$exit);");
-    this._checkSuspension(s);
-    exit = this._gr("exit", "$ret");
+    exit = this._gr("exit", "Sk.abstr.lookupSpecial(",mgr,",Sk.builtin.str.$exit);");
     this.u.tempsToSave.push(exit);
 
     // value = mgr.__enter__()
     out("$ret = Sk.abstr.lookupSpecial(",mgr,",Sk.builtin.str.$enter);");
-    this._checkSuspension(s);
+    
+    // check we actually have a context manager and throw nicely
+    out("if ($ret === undefined) {throw new Sk.builtin.AttributeError('__enter__');} ");
+    out(`else if (${exit} === undefined) {throw new Sk.builtin.AttributeError('__exit__');}`);
+    
+    // lookupspecial can't suspend
     out("$ret = Sk.misceval.callsimOrSuspendArray($ret);");
     this._checkSuspension(s);
     value = this._gr("value", "$ret");

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -206,6 +206,41 @@ class TestBugs(unittest.TestCase):
         self.assertTrue(a != a)
 
 
+class TestExceptionProtocols(unittest.TestCase):
+    def test_explicit_cause(self):
+        for cause in (ValueError, ValueError("cause"), None):
+            try:
+                raise RuntimeError("outer") from cause
+            except RuntimeError as error:
+                if cause is ValueError:
+                    self.assertIsInstance(error.__cause__, ValueError)
+                else:
+                    self.assertIs(error.__cause__, cause)
+        with self.assertRaises(TypeError):
+            raise RuntimeError from 42
+
+    def test_missing_context_methods(self):
+        entered = []
+        class EnterOnly:
+            def __enter__(self):
+                entered.append(True)
+        class ExitOnly:
+            def __exit__(self, *args):
+                pass
+        for manager in (EnterOnly(), ExitOnly()):
+            with self.assertRaises(AttributeError):
+                with manager:
+                    self.fail("body must not run")
+        self.assertEqual(entered, [])
+
+    def test_exception_values(self):
+        self.assertIsNone(StopIteration().value)
+        self.assertIsNone(StopIteration(None).value)
+        self.assertEqual(StopIteration(42).value, 42)
+        self.assertTrue(issubclass(GeneratorExit, BaseException))
+        self.assertFalse(issubclass(GeneratorExit, Exception))
+
+
 class TestClassCell(unittest.TestCase):
     """Tests for __class__ cell and super() handling - Issues #1171, #1340"""
 

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -208,12 +208,12 @@ class TestBugs(unittest.TestCase):
 
 class TestExceptionProtocols(unittest.TestCase):
     def test_explicit_cause(self):
-        for cause in (ValueError, ValueError("cause"), None):
+        for cause in (BaseException, ValueError, ValueError("cause"), None):
             try:
                 raise RuntimeError("outer") from cause
             except RuntimeError as error:
-                if cause is ValueError:
-                    self.assertIsInstance(error.__cause__, ValueError)
+                if cause in (BaseException, ValueError):
+                    self.assertIsInstance(error.__cause__, cause)
                 else:
                     self.assertIs(error.__cause__, cause)
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Explicit `raise ... from ...` now stores the supplied cause, instantiates exception classes including `BaseException`, and rejects invalid causes. `GeneratorExit` becomes available in builtins. A `with` statement with missing context-manager methods raises a Python error before entering the manager.

This is layer 2 of the work split from #1306, based on #1603. Generator execution and contextlib are reviewed separately. Python-visible `StopIteration.value` remains unchanged.

Validation: focused compiler regressions pass under Skulpt and CPython 3.7.17. Full development and optimized suites pass on the completed stack. Merge after the cleanup layer; retarget to master and rerun CI first.

Stack and merge order: #1602 → #1603 → #1604 → #1605 → #1306.
