### PR TITLE
feat: preserve generator frames and complete delegation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "devbuild": "webpack --mode development",
     "postdevbuild": "node support/build/wrapmodules.js builtin",
     "watch": "webpack --watch --mode development",
-    "test": "node test/testwrapper.js && node test/testunit.js && node test/testunit.js --python3",
+    "test": "node test/generator_suspensions.js && node test/testwrapper.js && node test/testunit.js && node test/testunit.js --python3",
     "start": "node support/run/runfile.js",
     "profile": "node --prof --no-logfile-per-isolate --log-internal-timer-events support/run/runfile.js -o",
     "postprofile": "node --prof-process v8.log"

--- a/src/compile.js
+++ b/src/compile.js
@@ -1965,10 +1965,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     if (vararg) {
         funcArgs.push(this.nameop(args.vararg.arg, Sk.astnodes.Param));
     }
-    // Are we using the new fast-call mechanism, where the
-    // function we define implements the tp$call interface?
     // Generators share normal function argument binding.
-    let fastCall = true;
 
     if (hasFree) {
         this.u.tempsToSave.push("$free");
@@ -1988,9 +1985,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         this.u.prefixCode += "\n// has cell\n";
     }
 
-    if (fastCall) {
-        this.u.prefixCode += "\n// fast call\n";
-    }
+    this.u.prefixCode += "\n// fast call\n";
 
     //
     // set up standard dicts/variables
@@ -2013,24 +2008,23 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     //
     this.u.varDeclsCode += "var $waking=false; if ("+scopename+".$wakingSuspension!==undefined) { $wakeFromSuspension(); $waking=true; } else {";
 
-    if (fastCall) {
-        // Resolve our arguments from $posargs+$kwargs.
-        // If we're posargs-only, we can handle the fast path
-        // without even calling out
-        if (!kwarg && !vararg && (!args || !args.kwonlyargs || args.kwonlyargs.length === 0)) {
-            this.u.varDeclsCode += "var $args = ((!$kwargs || $kwargs.length===0) && $posargs.length===" + funcArgs.length + ") ? $posargs : this.$resolveArgs($posargs,$kwargs)";
-        } else {
-            this.u.varDeclsCode += "\nvar $args = this.$resolveArgs($posargs,$kwargs)\n";
-        }
-        for (let i = 0; i < funcArgs.length; i++) {
-            this.u.varDeclsCode += "," + funcArgs[i] + "=$args[" + i + "]";
-        }
-        const instanceForSuper = funcArgs[kwarg ? 1 : 0];
-        if (instanceForSuper) {
-            this.u.varDeclsCode += `,$sup=${instanceForSuper}`;
-        }
-        this.u.varDeclsCode += ";\n";
+    // Resolve our arguments from $posargs+$kwargs.
+    // If we're posargs-only, we can handle the fast path
+    // without even calling out
+    if (!kwarg && !vararg && (!args || !args.kwonlyargs || args.kwonlyargs.length === 0)) {
+        this.u.varDeclsCode += "var $args = ((!$kwargs || $kwargs.length===0) && $posargs.length===" + funcArgs.length + ") ? $posargs : this.$resolveArgs($posargs,$kwargs)";
+    } else {
+        this.u.varDeclsCode += "\nvar $args = this.$resolveArgs($posargs,$kwargs)\n";
     }
+    for (let i = 0; i < funcArgs.length; i++) {
+        this.u.varDeclsCode += "," + funcArgs[i] + "=$args[" + i + "]";
+    }
+    const instanceForSuper = funcArgs[kwarg ? 1 : 0];
+    if (instanceForSuper) {
+        this.u.varDeclsCode += `,$sup=${instanceForSuper}`;
+    }
+    this.u.varDeclsCode += ";\n";
+
 
 
     //

--- a/src/compile.js
+++ b/src/compile.js
@@ -582,61 +582,35 @@ Compiler.prototype.cyield = function(e) {
         val = this.vexpr(e.value);
     }
     nextBlock = this.newBlock("after yield");
-    // return a pair: resume target block and yielded value
-    out("return [/*resume*/", nextBlock, ",/*ret*/", val, "];");
+    this.u.tempsToSave = this.u.tempsToSave.concat(this.u.localtemps);
+    out(`$blk=${nextBlock};`);
+    out(`return $gen.gi$yield((susp) => $saveSuspension(susp, '${this.filename}', $currLineNo, $currColNo), ${val});`);
+
     this.setBlock(nextBlock);
-    return "$gen.gi$sentvalue"; // will either be none if none sent, or the value from gen.send(value)
+    return this._gr("yield", "$ret");
 };
 
 Compiler.prototype.cyieldfrom = function (e) {
     if (this.u.ste.blockType !== Sk.SYMTAB_CONSTS.FunctionBlock) {
         throw new Sk.builtin.SyntaxError("'yield' outside function", this.filename, e.lineno);
     }
-    var iterable = this.vexpr(e.value);
-    // get the iterator we are yielding from and store it
-    iterable = this._gr("iter", "Sk.abstr.iter(", iterable, ")");
-    out("$gen." + iterable + "=", iterable, ";");
     var afterIter = this.newBlock("after iter");
     var afterBlock = this.newBlock("after yield from");
+    // get the iterator we are yielding from and store it
+    var iterable = this.vexpr(e.value);
+    out("$gen.gi$startYieldFrom(", iterable, ");");
     this._jump(afterIter);
     this.setBlock(afterIter);
-    var retval = this.gensym("retval");
-    // We may have entered this block resuming from a yield
-    // So get the iterable stored on $gen.
-    out(iterable, "=$gen.", iterable, ";");
-    out("var ", retval, ";");
-    // fast path -> we're sending None (not sending a value) 
-    // or we use gen.tp$iternext(true, val) (see generator.js) which is the equivalent of gen.send(val)
-    out("if ($gen.gi$sentvalue === Sk.builtin.none.none$ || " + iterable + ".constructor === Sk.builtin.generator) {");
-    out(    "$ret=", iterable, ".tp$iternext(true, $gen.gi$sentvalue);");
-    out("} else {");
-    var send = this.makeConstant("new Sk.builtin.str('send');");
-    // slow path -> get the send method of the non-generator iterator and call it
-    // throw anything other than a StopIteration
-    out(    "$ret=Sk.misceval.tryCatch(");
-    out(        "function(){");
-    out(            "return Sk.misceval.callsimOrSuspendArray(Sk.abstr.gattr(", iterable, ",", send, "), [$gen.gi$sentvalue]);},");
-    out(        "function (e) { ");
-    out(            "if (e instanceof Sk.builtin.StopIteration) { ");
-    out(                    iterable ,".gi$ret = e.$value;");
-                            // store the return value on the iterator
-                            // otherwise we lose it beause iterator code in skulpt relies on returning undefined;
-                            // one day maybe we can use the js .next protocol {value: ret, done: true} ;-)
-    out(                    "return undefined;"); 
-    out(            "} else { throw e; }");
-    out(        "}");
-    out(    ");");
-    out("}");
+    out("$ret = $gen.gi$stepYieldFrom();");
     this._checkSuspension(e);
-    out(retval, "=$ret;");
-    // if the iterator is done (undefined) and we still have an unused sent value, it will be in `[iterable].gi$ret`, so we grab it from there and move on from the `yield from` ("afterBlock")
-    out("if(", retval, "===undefined) {");
-    out(    "$gen.gi$sentvalue=$gen." + iterable + ".gi$ret;");
+    out("if($ret===undefined) {");
+    out(    "$ret = $gen.gi$finishYieldFrom();");
     out(    "$blk=", afterBlock, ";continue;");
     out("}");
-    out("return [/*resume*/", afterIter, ",/*ret*/", retval, "];");
+    out(`$blk = ${afterIter};`);
+    out(`return $gen.gi$yield((susp) => $saveSuspension(susp, '${this.filename}', $currLineNo, $currColNo), $ret);`);
     this.setBlock(afterBlock);
-    return "$gen.gi$sentvalue"; // will either be none if none sent, or the value retuned from gen.send(value)
+    return this._gr("yieldfrom", "$ret");
 };
 
 
@@ -1270,10 +1244,12 @@ Compiler.prototype.outputSuspensionHelpers = function (unit) {
 
     output +=  "try { $ret=susp.child.resume(); } catch(err) { if (!(err instanceof Sk.builtin.BaseException)) { err = new Sk.builtin.ExternalError(err); } err.traceback.push({lineno: $currLineNo, colno: $currColNo, filename: '"+this.filename+"'}); if($exc.length>0) { $err=err; $blk=$exc.pop(); } else { throw err; } }" +
                 "};";
+    output += "var $self = this;";
+    output += unit.ste.generator?"var $gen = $self;":"";
 
     output += "var $saveSuspension = function($child, $filename, $lineno, $colno) {" +
                 "var susp = new Sk.misceval.Suspension(); susp.child=$child;" +
-                "susp.resume=function(){"+unit.scopename+".$wakingSuspension=susp; return "+unit.scopename+"("+(unit.ste.generator?"$gen":"")+"); };" +
+                "susp.resume=function(){"+unit.scopename+".$wakingSuspension=susp; return "+unit.scopename+".call("+(unit.ste.generator?"$gen":"$self")+"); };" +
                 "susp.data=susp.child.data;susp.$blk=$blk;susp.$loc=$loc;susp.$gbl=$gbl;susp.$exc=$exc;susp.$err=$err;susp.$postfinally=$postfinally;" +
                 "susp.$filename=$filename;susp.$lineno=$lineno;susp.$colno=$colno;" +
                 "susp.optional=susp.child.optional;" +
@@ -1306,7 +1282,7 @@ Compiler.prototype.outputAllUnits = function () {
         unit = this.allUnits[j];
         ret += unit.prefixCode;
         ret += this.outputLocals(unit);
-        if (unit.doesSuspend) {
+        if (unit.doesSuspend || unit.ste.generator) {
             ret += this.outputSuspensionHelpers(unit);
         }
         ret += unit.varDeclsCode;
@@ -1452,15 +1428,8 @@ Compiler.prototype.cfor = function (s) {
 
     // get the iterator
     toiter = this.vexpr(s.iter);
-    if (this.u.ste.generator) {
-        // if we're in a generator, we have to store the iterator to a local
-        // so it's preserved (as we cross blocks here and assume it survives)
-        iter = "$loc." + this.gensym("iter");
-        out(iter, "=Sk.abstr.iter(", toiter, ");");
-    } else {
-        iter = this._gr("iter", "Sk.abstr.iter(", toiter, ")");
-        this.u.tempsToSave.push(iter); // Save it across suspensions
-    }
+    iter = this._gr("iter", "Sk.abstr.iter(", toiter, ")");
+    this.u.tempsToSave.push(iter); // Save it across suspensions
 
     this._jump(start);
 
@@ -1924,15 +1893,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     var containingHasFree;
     var frees;
     var argnamesarr = [];
-    var start;
-    var kw;
-    var maxargs;
-    var minargs;
     var id;
-    var argname;
-    var offset;
-    var cells;
-    var locals;
     var i;
     var funcArgs;
     var entryBlock;
@@ -1991,50 +1952,29 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     this.u.prefixCode = "var " + scopename + "=(function " + this.niceName(coname.v) + "$(";
 
     funcArgs = [];
-    if (isGenerator) {
-        // TODO make generators deal with arguments properly
-        if (kwarg) {
-            throw new Sk.builtin.SyntaxError(coname.v + "(): keyword arguments in generators not supported",
-                                             this.filename, n.lineno);
-        }
-        if (vararg) {
-            throw new Sk.builtin.SyntaxError(coname.v + "(): variable number of arguments in generators not supported",
-                                             this.filename, n.lineno);
-        }
-        funcArgs.push("$gen");
-    } else {
-        if (kwarg) {
-            funcArgs.push("$kwa");
-            this.u.tempsToSave.push("$kwa");
-        }
-        for (i = 0; args && i < args.args.length; ++i) {
-            funcArgs.push(this.nameop(args.args[i].arg, Sk.astnodes.Param));
-        }
-        for (i = 0; args && args.kwonlyargs && i < args.kwonlyargs.length; ++i) {
-            funcArgs.push(this.nameop(args.kwonlyargs[i].arg, Sk.astnodes.Param));
-        }
-        if (vararg) {
-            funcArgs.push(this.nameop(args.vararg.arg, Sk.astnodes.Param));
-        }
+    if (kwarg) {
+        funcArgs.push("$kwa");
+        this.u.tempsToSave.push("$kwa");
+    }
+    for (i = 0; args && i < args.args.length; ++i) {
+        funcArgs.push(this.nameop(args.args[i].arg, Sk.astnodes.Param));
+    }
+    for (i = 0; args && args.kwonlyargs && i < args.kwonlyargs.length; ++i) {
+        funcArgs.push(this.nameop(args.kwonlyargs[i].arg, Sk.astnodes.Param));
+    }
+    if (vararg) {
+        funcArgs.push(this.nameop(args.vararg.arg, Sk.astnodes.Param));
     }
     // Are we using the new fast-call mechanism, where the
     // function we define implements the tp$call interface?
-    // (Right now we haven't migrated generators because they're
-    // a mess, but if this works we can move everything over)
-    let fastCall = !isGenerator;
+    // Generators share normal function argument binding.
+    let fastCall = true;
 
     if (hasFree) {
-        if (!fastCall) {
-            funcArgs.push("$free");
-        }
         this.u.tempsToSave.push("$free");
     }
 
-    if (fastCall) {
-        this.u.prefixCode += "$posargs,$kwargs";
-    } else {
-        this.u.prefixCode += funcArgs.join(",");
-    }
+    this.u.prefixCode += "$posargs,$kwargs";
 
     this.u.prefixCode += "){";
 
@@ -2055,24 +1995,11 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     //
     // set up standard dicts/variables
     //
-    locals = "{}";
-    if (isGenerator) {
-        entryBlock = "$gen.gi$resumeat";
-        locals = "$gen.gi$locals";
-    }
-    // Reserve every local cell, even before its first assignment, so outer
-    // bindings with the same name cannot be found through the prototype.
-    cells = ",$cell={" + cellNames.map(name => name + ":undefined").join(",") + "}";
-    if (hasCell) {
-        if (isGenerator) {
-            cells = ",$cell=$gen.gi$cells";
-        }
-    }
 
     // note special usage of 'this' to avoid having to slice globals into
     // all function invocations in call
     // (fastcall doesn't need to do this, as 'this' is the func object)
-    this.u.varDeclsCode += "var $blk=" + entryBlock + ",$exc=[],$loc=" + locals + cells + ",$gbl=" +(fastCall?"this && this.func_globals":"this") + ((fastCall&&hasFree)?",$free=this && this.func_closure":"") + ",$err=undefined,$ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;";
+    this.u.varDeclsCode += "var $blk="+entryBlock+",$exc=[],$loc={},$cell={" + cellNames.map(name => name + ":undefined").join(",") + "},$gbl=this && this.func_globals" + (hasFree?",$free=this && this.func_closure":"") + ",$err=undefined,$ret=undefined,$postfinally=undefined,$currLineNo=undefined,$currColNo=undefined;";
     if (Sk.execLimit !== null) {
         this.u.varDeclsCode += "if (typeof Sk.execStart === 'undefined') {Sk.execStart = Date.now()}";
     }
@@ -2105,24 +2032,6 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         this.u.varDeclsCode += ";\n";
     }
 
-
-    // TODO update generators to do their arg checks in outside generated code,
-    // like functions do
-    //
-    // this could potentially get removed if generators would learn to deal with args, kw, kwargs, varargs
-    // initialize default arguments. we store the values of the defaults to
-    // this code object as .$defaults just below after we exit this scope.
-    //
-    if (isGenerator && defaults.length > 0) {
-        // defaults have to be "right justified" so if there's less defaults
-        // than args we offset to make them match up (we don't need another
-        // correlation in the ast)
-        offset = args.args.length - defaults.length;
-        for (i = 0; i < defaults.length; ++i) {
-            argname = this.nameop(args.args[i + offset].arg, Sk.astnodes.Param);
-            this.u.varDeclsCode += "if(" + argname + "===undefined)" + argname + "=" + scopename + ".$defaults[" + i + "];";
-        }
-    }
 
     //
     // copy all parameters that are also cells into the cells dict. this is so
@@ -2157,6 +2066,14 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
             let mangled = fixReserved(mangleName(this.u.private_, kwarg.arg).v);
             this.u.varDeclsCode += "$cell." + mangled + "=" + mangled + ";";
         }
+    }
+
+    // we've resolved the arguments now so we return a generator
+    // call new generator and then save the suspension
+    if (isGenerator) {
+        this.u.varDeclsCode += `$gen = new Sk.builtin.generator(${scopename}, this.$name, this.$qualname);
+        $gen.gi$setInitialSuspension((susp) => $saveSuspension(susp, '${this.filename}', $currLineNo, $currColNo));
+        return $gen;`
     }
 
     //
@@ -2228,9 +2145,6 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
         out(scopename, ".co_varnames=[];");
     }
 
-    if (isGenerator) {
-        out(scopename, ".co_cellvars=", JSON.stringify(cellNames), ";");
-    }
 
     //
     // Skulpt doesn't have "co_consts", so record the docstring (or
@@ -2248,9 +2162,7 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
     if (vararg) {
         out(scopename, ".co_varargs=1;");
     }
-    if (!isGenerator) {
-        out(scopename, ".co_fastcall=1;");
-    }
+    out(scopename, ".co_fastcall=1;");
 
     //
     // build either a 'function' or 'generator'. the function is just a simple
@@ -2277,35 +2189,23 @@ Compiler.prototype.buildcodeobj = function (n, coname, decorator_list, args, cal
             frees += ",$free";
         }
     }
-    if (isGenerator) {
-    // Keyword and variable arguments are not currently supported in generators.
-    // The call to pyCheckArgs assumes they can't be true.
-        if (args && args.args.length > 0) {
-            return this._gr("gener", "new Sk.builtins['function']((function(){var $origargs=Array.prototype.slice.call(arguments);Sk.builtin.pyCheckArgsLen(\"",
-                            coname.v, "\",arguments.length,", args.args.length - defaults.length, ",", args.args.length,
-                            ");return new Sk.builtins['generator'](", scopename, ",$gbl,$origargs", frees, ");}))");
-        } else {
-            return this._gr("gener", "new Sk.builtins['function']((function(){Sk.builtin.pyCheckArgsLen(\"", coname.v,
-                            "\",arguments.length,0,0);return new Sk.builtins['generator'](", scopename, ",$gbl,[]", frees, ");}))");
-        }
-    } else {
-        let funcobj;
-        if (decos.length > 0) {
-            out("$ret = new Sk.builtins['function'](", scopename, ",$gbl", frees, ");");
-            for (let decorator of decos.reverse()) {
-                out("$ret = Sk.misceval.callsimOrSuspendArray(", decorator, ",[$ret]);");
-                this._checkSuspension();
-            }
-            funcobj = this._gr("funcobj", "$ret");
-        } else {
-            funcobj = this._gr("funcobj", "new Sk.builtins['function'](", scopename, ",$gbl", frees, ")");
-        }
-        if (func_annotations) {
-            out(funcobj, ".func_annotations=", func_annotations, ";");
-        }
 
-        return funcobj;
+    let funcobj;
+    if (decos.length > 0) {
+        out("$ret = new Sk.builtins['function'](", scopename, ",$gbl", frees, ");");
+        for (let decorator of decos.reverse()) {
+            out("$ret = Sk.misceval.callsimOrSuspendArray(", decorator, ",[$ret]);");
+            this._checkSuspension();
+        }
+        funcobj = this._gr("funcobj", "$ret");
+    } else {
+        funcobj = this._gr("funcobj", "new Sk.builtins['function'](", scopename, ",$gbl", frees, ")");
     }
+    if (func_annotations) {
+        out(funcobj, ".func_annotations=", func_annotations, ";");
+    }
+    return funcobj;
+
 };
 
 
@@ -2455,12 +2355,13 @@ Compiler.prototype.cgenexpgen = function (generators, genIndex, elt) {
         // the outer most iterator is evaluated in the scope outside so we
         // have to evaluate it outside and store it into the generator as a
         // local, which we retrieve here.
-        iter = "$loc.$iter0";
+        iter = "$iter0";
     } else {
         toiter = this.vexpr(ge.iter);
-        iter = "$loc." + this.gensym("iter");
+        iter = this.gensym("iter");
         out(iter, "=", "Sk.abstr.iter(", toiter, ");");
     }
+    this.u.tempsToSave.push(iter);
     this._jump(start);
     this.setBlock(start);
 
@@ -2491,7 +2392,8 @@ Compiler.prototype.cgenexpgen = function (generators, genIndex, elt) {
         this.annotateSource(elt);
 
         velt = this.vexpr(elt);
-        out("return [", skip, "/*resume*/,", velt, "/*ret*/];");
+        out(`$blk=${skip};`);
+        out(`return $gen.gi$yield((susp) => $saveSuspension(susp, '${this.filename}', $currLineNo, $currColNo), ${velt});`);
         this.setBlock(skip);
     }
 
@@ -2516,7 +2418,7 @@ Compiler.prototype.cgenexp = function (e) {
     var gener = this._gr("gener", "Sk.misceval.callsimArray(", gen, ");");
     // stuff the outermost iterator into the generator after evaluating it
     // outside of the function. it's retrieved by the fixed name above.
-    out(gener, ".gi$locals.$iter0=Sk.abstr.iter(", this.vexpr(e.generators[0].iter), ");");
+    out(gener, ".curr$susp.$tmps.$iter0=Sk.abstr.iter(", this.vexpr(e.generators[0].iter), ");");
     return gener;
 };
 
@@ -2784,8 +2686,8 @@ Compiler.prototype.nameop = function (name, ctx, dataToStore) {
             optype = OP_DEREF;
             break;
         case Sk.SYMTAB_CONSTS.LOCAL:
-            // can't do FAST in generators or at module/class scope
-            if (this.u.ste.blockType === Sk.SYMTAB_CONSTS.FunctionBlock && !this.u.ste.generator) {
+            // Function locals use fast variables, including generators.
+            if (this.u.ste.blockType === Sk.SYMTAB_CONSTS.FunctionBlock) {
                 optype = OP_FAST;
             }
             break;
@@ -2808,7 +2710,7 @@ Compiler.prototype.nameop = function (name, ctx, dataToStore) {
     // in generator or at module scope, we need to store to $loc, rather that
     // to actual JS stack variables.
     mangledNoPre = mangled;
-    if (this.u.ste.generator || this.u.ste.blockType !== Sk.SYMTAB_CONSTS.FunctionBlock) {
+    if (this.u.ste.blockType !== Sk.SYMTAB_CONSTS.FunctionBlock) {
         mangled = "$loc." + mangled;
     } else if (optype === OP_FAST || optype === OP_NAME) {
         this.u.localnames.push(mangled);

--- a/src/generator.js
+++ b/src/generator.js
@@ -199,7 +199,7 @@ Sk.builtin.generator = Sk.abstr.buildIteratorClass("generator", {
             );
         },
         gi$throw(error, throwArgs) {
-            if (this.gi$closed || !this.gi$started) {
+            if (this.gi$closed) {
                 this.gi$closed = true;
                 this.curr$susp = null;
                 throw error;

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,115 +1,303 @@
 /**
- * @constructor
- * @param {Function} code javascript code object for the function
- * @param {Object} globals where this function was defined
- * @param {Object} args arguments to the original call (stored into locals for
- * the generator to reenter)
- * @param {Object=} closure dict of free variables
- * @param {Object=} closure2 another dict of free variables that will be
- * used as the prototype of 'closure'. there's 2 to simplify generated code (one is $free,
- * the other is $cell)
- *
- * co_varnames and co_name come from generated code, must access as dict.
+ * A Python generator owns a suspended compiled frame. Argument binding happens
+ * before construction; the compiler installs the initial frame suspension.
+ * scope is the compiled function, and name/qualname are Python function names.
  */
 Sk.builtin.generator = Sk.abstr.buildIteratorClass("generator", {
-    constructor: function generator(code, globals, args, closure, closure2) {
-        var i;
-        if (!code) {
-            return;
-        } // ctor hack
-
+    constructor: function generator(scope, name, qualname) {
         if (!(this instanceof Sk.builtin.generator)) {
             throw new TypeError("bad internal call to generator, use 'new'");
         }
 
-        this.func_code = code;
-        this.func_globals = globals || null;
-        this.gi$running = false;
-        this.gi$resumeat = 0;
-        this.gi$sentvalue = Sk.builtin.none.none$;
-        this.gi$locals = {};
-        this.gi$cells = {};
-        if (args.length > 0) {
-            // store arguments into locals because they have to be maintained
-            // too. 'fast' var lookups are locals in generator functions.
-            for (i = 0; i < code.co_varnames.length; ++i) {
-                this.gi$locals[code.co_varnames[i]] = args[i];
+        this.gi$scope = scope;
+        this.$name = name;
+        this.$qualname = qualname;
+        const susp = new Sk.misceval.Suspension();
+        const data = { type: "gen", send: Sk.builtin.none.none$, throw: null };
+        susp.resume = () => {
+            if (data.throw !== null) {
+                const error = data.throw;
+                data.throw = null;
+                throw error;
             }
-        }
-        for (const name of code["co_cellvars"] || []) {
-            this.gi$cells[name] = undefined;
-        }
-        if (closure2 !== undefined && closure2 !== closure) {
-            Object.setPrototypeOf(closure, closure2);
-        }
-        //print(JSON.stringify(closure));
-        this.func_closure = closure;
+            return data.send;
+        };
+        susp.data = data;
+        this.gi$ret = null;
+        this.gi$susp = susp;
+        this.gi$data = data;
+        this.curr$susp = null; // set inside the compile code
+        this.gi$running = false;
+        this.gi$yieldfrom = null;
+        this.gi$closed = false;
+        this.gi$started = false;
+        this.gi$delegationDone = false;
+        this.gi$delegationReturn = undefined;
     },
     slots: {
         $r() {
-            return new Sk.builtin.str("<generator object " + this.func_code.co_name.v + ">");
+            return new Sk.builtin.str("<generator object " + this.$name + ">");
         },
     },
-    iternext(canSuspend, yielded) {
-        var ret;
-        var args;
-        var self = this;
-        if (this.gi$running) {
-            throw new Sk.builtin.ValueError("generator already executing");
-        }
-        this["gi$running"] = true;
-        if (yielded === undefined) {
-            yielded = Sk.builtin.none.none$;
-        }
-        this["gi$sentvalue"] = yielded;
-
-        // note: functions expect 'this' to be globals to avoid having to
-        // slice/unshift onto the main args
-        args = [this];
-        if (this.func_closure) {
-            args.push(this.func_closure);
-        }
-        ret = this.func_code.apply(this.func_globals, args);
-        return (function finishIteration(ret) {
-            if (ret instanceof Sk.misceval.Suspension) {
-                if (canSuspend) {
-                    return new Sk.misceval.Suspension(finishIteration, ret);
-                } else {
-                    ret = Sk.misceval.retryOptionalSuspensionOrThrow(ret);
-                }
+    iternext(canSuspend, value) {
+        return this.gi$run(() => {
+            value = value === undefined ? Sk.builtin.none.none$ : value;
+            if (!this.gi$started && value !== Sk.builtin.none.none$ && !this.gi$closed) {
+                throw new Sk.builtin.TypeError("can't send non-None value to a just-started generator");
             }
-            //print("ret", JSON.stringify(ret));
-            self["gi$running"] = false;
-            Sk.asserts.assert(ret !== undefined);
-            if (Array.isArray(ret)) {
-                // returns a pair: resume target and yielded value
-                self["gi$resumeat"] = ret[0];
-                ret = ret[1];
-            } else {
-                // todo; StopIteration
-                self.gi$ret = ret;
-                return undefined;
-            }
-            //print("returning:", JSON.stringify(ret));
-            return ret;
-        })(ret);
+            this.gi$data.send = value;
+            return this.gi$resume();
+        }, canSuspend);
     },
     methods: {
         send: {
             $meth(value) {
                 return Sk.misceval.chain(this.tp$iternext(true, value), (ret) => {
                     if (ret === undefined) {
-                        const v = this.gi$ret;
-                        // this is a weird quirk - and only for printing purposes StopIteration(None) vs StopIteration()
-                        // .value ends up being None. But the repr prints the args we pass to StopIteration.
-                        // See tests in test_yield_from and search for StopIteration()
-                        throw v !== undefined && v !== Sk.builtin.none.none$ ? new Sk.builtin.StopIteration(v) : new Sk.builtin.StopIteration();
+                        throw new Sk.builtin.StopIteration(this.gi$ret);
                     }
                     return ret;
                 });
             },
             $flags: { OneArg: true },
             $doc: "send(arg) -> send 'arg' into generator,\nreturn next yielded value or raise StopIteration.",
+        },
+        throw: {
+            $meth(type, value, tb) {
+                const throwArgs = [type];
+                if (value !== undefined) { throwArgs.push(value); }
+                if (tb !== undefined) { throwArgs.push(tb); }
+                if (tb !== undefined && tb !== Sk.builtin.none.none$) {
+                    throw new Sk.builtin.NotImplementedError("generator.throw() with a traceback is not supported");
+                }
+                let exception;
+                if (type instanceof Sk.builtin.BaseException) {
+                    if (value !== undefined && value !== Sk.builtin.none.none$) {
+                        throw new Sk.builtin.TypeError("instance exception may not have a separate value");
+                    }
+                    exception = type;
+                } else if (type === Sk.builtin.BaseException || type.prototype instanceof Sk.builtin.BaseException) {
+                    const args = value === undefined || value === Sk.builtin.none.none$ ? [] :
+                        value instanceof Sk.builtin.tuple ? value.v : [value];
+                    exception = value instanceof type ? value : Sk.misceval.callsimOrSuspendArray(type, args);
+                } else {
+                    throw new Sk.builtin.TypeError("exceptions must be classes or instances deriving from BaseException");
+                }
+                return Sk.misceval.chain(exception, (error) => {
+                    if (!(error instanceof Sk.builtin.BaseException)) {
+                        throw new Sk.builtin.TypeError("exception constructor must return a BaseException instance");
+                    }
+                    return Sk.misceval.chain(this.gi$run(() => this.gi$throw(error, throwArgs), true), (ret) => {
+                        if (ret === undefined) {
+                            throw new Sk.builtin.StopIteration(this.gi$ret);
+                        }
+                        return ret;
+                    });
+                });
+            },
+            $flags: { MinArgs: 1, MaxArgs: 3 },
+            $doc: "throw(typ[,val[,tb]]) -> raise an exception at the suspended yield.",
+        },
+        close: {
+            $meth() {
+                return this.gi$run(() => Sk.misceval.tryCatch(
+                    () => Sk.misceval.chain(this.gi$throw(new Sk.builtin.GeneratorExit()), (ret) => {
+                        if (ret !== undefined) {
+                            throw new Sk.builtin.RuntimeError("generator ignored GeneratorExit");
+                        }
+                        return Sk.builtin.none.none$;
+                    }),
+                    (error) => {
+                        if (error instanceof Sk.builtin.GeneratorExit || error instanceof Sk.builtin.StopIteration) {
+                            return Sk.builtin.none.none$;
+                        }
+                        throw error;
+                    }
+                ), true);
+            },
+            $flags: { NoArgs: true },
+            $doc: "close() -> raise GeneratorExit inside the generator.",
+        },
+    },
+    getsets: {
+        __name__: {
+            $get() {
+                return new Sk.builtin.str(this.$name);
+            },
+            $set(v) {
+                if (!Sk.builtin.checkString(v)) {
+                    throw new Sk.builtin.TypeError("__name__ must be set to a string object");
+                }
+                this.$name = v.toString();
+            },
+        },
+        __qualname__: {
+            $get() {
+                return new Sk.builtin.str(this.$qualname);
+            },
+            $set(v) {
+                if (!Sk.builtin.checkString(v)) {
+                    throw new Sk.builtin.TypeError("__qualname__ must be set to a string object");
+                }
+                this.$qualname = v.toString();
+            },
+        },
+        gi_running: {
+            $get() {
+                return new Sk.builtin.bool(this.gi$running);
+            },
+        },
+        gi_yieldfrom: {
+            $get() {
+                return this.gi$yieldfrom || Sk.builtin.none.none$;
+            },
+        },
+    },
+    proto: {
+        gi$run(action, canSuspend) {
+            if (this.gi$running) {
+                throw new Sk.builtin.ValueError("generator already executing");
+            }
+            this.gi$running = true;
+            const result = Sk.misceval.tryCatch(action, (error) => { throw error; }, () => {
+                this.gi$running = false;
+            });
+            return canSuspend ? result : Sk.misceval.retryOptionalSuspensionOrThrow(result);
+        },
+        gi$resume() {
+            if (this.gi$closed) {
+                this.gi$ret = null;
+                return undefined;
+            }
+            this.gi$started = true;
+            return Sk.misceval.tryCatch(
+                () => Sk.misceval.chain(this.curr$susp.resume(), (ret) => {
+                    if (Array.isArray(ret)) {
+                        this.curr$susp = ret[0];
+                        return ret[1];
+                    }
+                    this.gi$ret = ret === Sk.builtin.none.none$ ? null : ret;
+                    this.gi$closed = true;
+                    this.curr$susp = null;
+                    return undefined;
+                }),
+                (error) => {
+                    this.gi$closed = true;
+                    this.curr$susp = null;
+                    this.gi$yieldfrom = null;
+                    if (error instanceof Sk.builtin.StopIteration) {
+                        if (!Sk.__future__.python3) {
+                            this.gi$ret = error.$value;
+                            return undefined;
+                        }
+                        const wrapped = new Sk.builtin.RuntimeError("generator raised StopIteration");
+                        wrapped.$cause = error;
+                        throw wrapped;
+                    }
+                    throw error;
+                }
+            );
+        },
+        gi$throw(error, throwArgs) {
+            if (this.gi$closed || !this.gi$started) {
+                this.gi$closed = true;
+                this.curr$susp = null;
+                throw error;
+            }
+            const inject = (exception) => {
+                this.gi$yieldfrom = null;
+                this.gi$data.throw = exception;
+                return this.gi$resume();
+            };
+            const delegate = this.gi$yieldfrom;
+            if (!delegate) {
+                return inject(error);
+            }
+            if (error instanceof Sk.builtin.GeneratorExit) {
+                // Close the delegate first, then inject GeneratorExit into the
+                // outer frame even when delegate.close() returns normally.
+                return Sk.misceval.chain(Sk.misceval.tryCatch(
+                    () => {
+                        const close = Sk.abstr.lookupAttr(delegate, new Sk.builtin.str("close"));
+                        return close === undefined ? undefined : Sk.misceval.callsimOrSuspendArray(close);
+                    },
+                    (closeError) => { error = closeError; }
+                ), () => inject(error));
+            }
+            return Sk.misceval.chain(Sk.misceval.tryCatch(
+                () => {
+                    const meth = Sk.abstr.lookupAttr(delegate, new Sk.builtin.str("throw"));
+                    if (meth === undefined) {
+                        return { error };
+                    }
+                    return Sk.misceval.chain(Sk.misceval.callsimOrSuspendArray(meth, throwArgs),
+                                             (value) => ({ value }));
+                },
+                (exception) => {
+                    if (exception instanceof Sk.builtin.StopIteration) {
+                        this.gi$delegationDone = true;
+                        this.gi$delegationReturn = exception.$value;
+                        return { done: true };
+                    }
+                    return { error: exception };
+                }
+            ), (result) => {
+                if (result.error) {
+                    return inject(result.error);
+                }
+                return result.done ? this.gi$resume() : result.value;
+            });
+        },
+
+        gi$makeSuspension(wrapSuspension) {
+            return wrapSuspension(this.gi$susp);
+        },
+        gi$setInitialSuspension(wrapSuspension) {
+            this.curr$susp = this.gi$makeSuspension(wrapSuspension);
+            return this;
+        },
+        gi$yield(wrapSuspension, value) {
+            return [this.gi$makeSuspension(wrapSuspension), value];
+        },
+        gi$startYieldFrom(iterable) {
+            this.gi$yieldfrom = Sk.abstr.iter(iterable);
+            this.gi$data.send = Sk.builtin.none.none$;
+        },
+        gi$stepYieldFrom() {
+            return Sk.misceval.tryCatch(() => {
+                if (this.gi$delegationDone) {
+                    return undefined;
+                }
+                if (this.gi$data.send === Sk.builtin.none.none$ || this.gi$yieldfrom.constructor === Sk.builtin.generator) {
+                    return this.gi$yieldfrom.tp$iternext(true, this.gi$data.send);
+                }
+                return Sk.misceval.tryCatch(
+                    () =>
+                        Sk.misceval.callsimOrSuspendArray(
+                            Sk.abstr.gattr(this.gi$yieldfrom, new Sk.builtin.str("send")),
+                            [this.gi$data.send]
+                        ),
+                    (e) => {
+                        if (e instanceof Sk.builtin.StopIteration) {
+                            this.gi$yieldfrom.gi$ret = e.$value;
+                            return undefined;
+                        }
+                        throw e;
+                    }
+                );
+            }, (error) => {
+                this.gi$yieldfrom = null;
+                throw error;
+            });
+        },
+        gi$finishYieldFrom() {
+            const yieldfrom = this.gi$yieldfrom;
+            const ret = this.gi$delegationDone ? this.gi$delegationReturn : yieldfrom.gi$ret;
+            this.gi$delegationDone = false;
+            this.gi$delegationReturn = undefined;
+            this.gi$yieldfrom = null;
+            this.gi$data.send = ret == null ? Sk.builtin.none.none$ : ret;
+            return this.gi$data.send;
         },
     },
 });

--- a/src/generator.js
+++ b/src/generator.js
@@ -149,7 +149,9 @@ Sk.builtin.generator = Sk.abstr.buildIteratorClass("generator", {
         },
         gi_yieldfrom: {
             $get() {
-                return this.gi$yieldfrom || Sk.builtin.none.none$;
+                // The delegate is visible while the frame is suspended at
+                // yield from, including during delegated throw/close calls.
+                return this.curr$susp && this.gi$yieldfrom || Sk.builtin.none.none$;
             },
         },
     },
@@ -170,8 +172,10 @@ Sk.builtin.generator = Sk.abstr.buildIteratorClass("generator", {
                 return undefined;
             }
             this.gi$started = true;
+            const frame = this.curr$susp;
+            this.curr$susp = null;
             return Sk.misceval.tryCatch(
-                () => Sk.misceval.chain(this.curr$susp.resume(), (ret) => {
+                () => Sk.misceval.chain(frame.resume(), (ret) => {
                     if (Array.isArray(ret)) {
                         this.curr$susp = ret[0];
                         return ret[1];

--- a/test/generator_suspensions.js
+++ b/test/generator_suspensions.js
@@ -1,0 +1,52 @@
+const assert = require("assert");
+const fs = require("fs");
+const load = require("../support/run/require-skulpt").requireSkulpt;
+load(false);
+const events = [];
+Sk.builtins.suspend_probe = new Sk.builtin.func(function (phase) {
+    events.push("start " + phase.v);
+    const suspension = new Sk.misceval.Suspension();
+    suspension.data = { type: "generator test" };
+    suspension.resume = () => {
+        assert.strictEqual(Sk.globals.g.gi$running, true);
+        assert.strictEqual(Sk.globals.child.gi$running, true);
+        events.push("finish " + phase.v);
+        return Sk.builtin.none.none$;
+    };
+    return suspension;
+});
+Sk.configure({ read: (file) => fs.readFileSync(file, "utf8"), __future__: Sk.python3 });
+const source = `
+def inner():
+    try:
+        suspend_probe('body')
+        try:
+            yield 1
+        except ValueError:
+            suspend_probe('throw')
+            yield 2
+    finally:
+        suspend_probe('close')
+child = inner()
+def outer():
+    yield from child
+g = outer()
+assert next(g) == 1
+assert not g.gi_running and not child.gi_running
+assert g.throw(ValueError) == 2
+assert not g.gi_running and not child.gi_running
+g.close()
+assert not g.gi_running and not child.gi_running
+assert list(g) == []
+`;
+let result = Sk.importMainWithBody("<generator suspension test>", false, source, true);
+while (result instanceof Sk.misceval.Suspension) {
+    assert.strictEqual(Sk.globals.g.gi$running, true);
+    assert.throws(() => Sk.globals.g.tp$iternext(true), (e) => e instanceof Sk.builtin.ValueError);
+    result = result.resume();
+}
+assert.deepStrictEqual(events, ["start body", "finish body", "start throw", "finish throw", "start close", "finish close"]);
+
+// Yield itself needs a saved frame even in synchronous compiled code.
+Sk.importMainWithBody("<synchronous generator test>", false, "def gen():\n    yield 42\nassert list(gen()) == [42]\n", false);
+console.log("Generator suspension tests passed");

--- a/test/unit3/test_generators.py
+++ b/test/unit3/test_generators.py
@@ -213,24 +213,6 @@ class TestPEP479(unittest.TestCase):
         self.assertEqual(str(e.exception), "generator raised StopIteration")
 
 
-    def test_stopiteration_wrapping_context(self):
-        def f():
-            raise StopIteration
-        def g():
-            yield f()
-
-        try:
-            next(g())
-        except RuntimeError as exc:
-            # self.assertIs(type(exc.__cause__), StopIteration)
-            # self.assertIs(type(exc.__context__), StopIteration)
-            # self.assertTrue(exc.__suppress_context__)
-            pass
-        else:
-            self.fail('__cause__, __context__, or __suppress_context__ '
-                      'were not properly set')
-
-
 class GeneratorProtocolTest(unittest.TestCase):
     def test_start_exhaustion_and_throw_arguments(self):
         entered = []
@@ -311,6 +293,18 @@ class GeneratorProtocolTest(unittest.TestCase):
         self.assertEqual(g.throw(ValueError("yield")), 42)
         self.assertEqual(g.throw(ValueError("return")), 99)
         self.assertIsNone(g.gi_yieldfrom)
+
+    def test_throw_stopiteration_before_start_and_after_close(self):
+        def gen():
+            yield 1
+        error = StopIteration("injected")
+        g = gen()
+        with self.assertRaises(RuntimeError) as caught:
+            g.throw(error)
+        self.assertIs(caught.exception.__cause__, error)
+        with self.assertRaises(StopIteration) as caught:
+            g.throw(error)
+        self.assertIs(caught.exception, error)
 
     def test_expression_temporaries_across_yields(self):
         def gen():

--- a/test/unit3/test_generators.py
+++ b/test/unit3/test_generators.py
@@ -331,5 +331,121 @@ class GeneratorProtocolTest(unittest.TestCase):
         self.assertEqual(list(g), [])
 
 
+
+
+class CPythonCoroutineTests(unittest.TestCase):
+    # CPython v3.7.9 Lib/test/test_generators.py: YieldFromTests and
+    # coroutine_tests. Doctests use unittest assertions here. gi_running and
+    # __name__ replace unsupported inspect state and gi_code introspection.
+    def test_generator_gi_yieldfrom(self):
+        def a():
+            self.assertTrue(gen_b.gi_running)
+            self.assertIsNone(gen_b.gi_yieldfrom)
+            yield
+            self.assertTrue(gen_b.gi_running)
+            self.assertIsNone(gen_b.gi_yieldfrom)
+
+        def b():
+            self.assertIsNone(gen_b.gi_yieldfrom)
+            yield from a()
+            self.assertIsNone(gen_b.gi_yieldfrom)
+            yield
+            self.assertIsNone(gen_b.gi_yieldfrom)
+
+        gen_b = b()
+        self.assertFalse(gen_b.gi_running)
+        self.assertIsNone(gen_b.gi_yieldfrom)
+
+        gen_b.send(None)
+        self.assertFalse(gen_b.gi_running)
+        self.assertEqual(gen_b.gi_yieldfrom.__name__, 'a')
+
+        gen_b.send(None)
+        self.assertFalse(gen_b.gi_running)
+        self.assertIsNone(gen_b.gi_yieldfrom)
+
+        [] = gen_b  # Exhaust generator
+        self.assertFalse(gen_b.gi_running)
+        self.assertIsNone(gen_b.gi_yieldfrom)
+
+
+    def test_augmented_assignment_yield(self):
+        def coroutine(seq):
+            count = 0
+            while count < 200:
+                count += yield
+                seq.append(count)
+        seq = []
+        c = coroutine(seq)
+        next(c)
+        for expected in ([10], [10, 20], [10, 20, 30]):
+            c.send(10)
+            self.assertEqual(seq, expected)
+        c.close()
+
+
+    def test_assignment_target_yields(self):
+        def f(d):
+            d[(yield "a")] = d[(yield "b")] = 27
+        data = [1, 2]
+        g = f(data)
+        self.assertEqual(g.send(None), "a")
+        self.assertEqual(data, [1, 2])
+        self.assertEqual(g.send(0), "b")
+        self.assertEqual(data, [27, 2])
+        with self.assertRaises(StopIteration):
+            g.send(1)
+        self.assertEqual(data, [27, 27])
+
+
+    def test_throw_normalization(self):
+        def f():
+            while True:
+                try:
+                    yield
+                except ValueError as v:
+                    yield v
+        cases = [(ValueError,), (ValueError("xyz"),),
+                 (ValueError, ValueError(1)), (ValueError, TypeError(1)),
+                 (ValueError, ValueError(1), None)]
+        for args in cases:
+            g = f()
+            next(g)
+            result = g.throw(*args)
+            self.assertIsInstance(result, ValueError)
+            if len(args) > 1:
+                if isinstance(args[1], ValueError):
+                    self.assertIs(result, args[1])
+                else:
+                    self.assertIs(result.args[0], args[1])
+            g.close()
+
+
+    def test_close_ignored_generatorexit(self):
+        def f():
+            try:
+                yield
+            except GeneratorExit:
+                yield "foo!"
+        g = f()
+        next(g)
+        with self.assertRaises(RuntimeError):
+            g.close()
+        g.close()
+
+
+    def test_error_during_close(self):
+        def f():
+            try:
+                yield
+            except GeneratorExit:
+                raise TypeError("fie!")
+        g = f()
+        next(g)
+        with self.assertRaises(TypeError) as caught:
+            g.close()
+        self.assertEqual(str(caught.exception), "fie!")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit3/test_generators.py
+++ b/test/unit3/test_generators.py
@@ -1,0 +1,341 @@
+# Selected CPython generator regressions. Frame introspection, pickling,
+# garbage-collection finalization and exception-context inspection are unsupported.
+import copy
+import unittest
+
+class GeneratorTest(unittest.TestCase):
+    def test_name(self):
+        def func():
+            yield 1
+
+        # check generator names
+        gen = func()
+        self.assertEqual(gen.__name__, "func")
+        # @TODO nested qualname
+        # self.assertEqual(gen.__qualname__,
+        #                  "GeneratorTest.test_name.<locals>.func")
+
+        # modify generator names
+        gen.__name__ = "name"
+        gen.__qualname__ = "qualname"
+        self.assertEqual(gen.__name__, "name")
+        self.assertEqual(gen.__qualname__, "qualname")
+
+        # generator names must be a string and cannot be deleted
+        self.assertRaises(TypeError, setattr, gen, '__name__', 123)
+        self.assertRaises(TypeError, setattr, gen, '__qualname__', 123)
+        self.assertRaises(TypeError, delattr, gen, '__name__')
+        self.assertRaises(TypeError, delattr, gen, '__qualname__')
+
+        # modify names of the function creating the generator
+        func.__qualname__ = "func_qualname"
+        func.__name__ = "func_name"
+        gen = func()
+        self.assertEqual(gen.__name__, "func_name")
+        self.assertEqual(gen.__qualname__, "func_qualname")
+
+        # unnamed generator
+        gen = (x for x in range(10))
+        self.assertEqual(gen.__name__,
+                         "<genexpr>")
+
+
+    def test_copy(self):
+        def f():
+            yield 1
+        g = f()
+        with self.assertRaises(TypeError):
+            copy.copy(g)
+
+
+class ExceptionTest(unittest.TestCase):
+    def test_except_throw(self):
+        def store_raise_exc_generator():
+            try:
+                # self.assertEqual(sys.exc_info()[0], None)
+                yield
+            except Exception as exc:
+                # exception raised by gen.throw(exc)
+                # self.assertEqual(sys.exc_info()[0], ValueError)
+                # self.assertIsNone(exc.__context__)
+                yield
+
+                # ensure that the exception is not lost
+                # self.assertEqual(sys.exc_info()[0], ValueError)
+                yield
+
+                # we should be able to raise back the ValueError
+                raise
+
+        make = store_raise_exc_generator()
+        next(make)
+
+        try:
+            raise ValueError()
+        except Exception as exc:
+            try:
+                make.throw(exc)
+            except Exception:
+                pass
+
+        next(make)
+        with self.assertRaises(ValueError) as cm:
+            next(make)
+
+
+    def test_except_next(self):
+        def gen():
+            # self.assertEqual(sys.exc_info()[0], ValueError)
+            yield "done"
+
+        g = gen()
+        try:
+            raise ValueError
+        except Exception:
+            self.assertEqual(next(g), "done")
+
+
+    def test_except_gen_except(self):
+        def gen():
+            try:
+                # self.assertEqual(sys.exc_info()[0], None)
+                yield
+                # we are called from "except ValueError:", TypeError must
+                # inherit ValueError in its context
+                raise TypeError()
+            except TypeError as exc: pass
+                # self.assertEqual(sys.exc_info()[0], TypeError)
+                # self.assertEqual(type(exc.__context__), ValueError)
+            # here we are still called from the "except ValueError:"
+            # self.assertEqual(sys.exc_info()[0], ValueError)
+            yield
+            # self.assertIsNone(sys.exc_info()[0])
+            yield "done"
+
+        g = gen()
+        next(g)
+        try:
+            raise ValueError
+        except Exception:
+            next(g)
+
+        self.assertEqual(next(g), "done")
+
+
+    def test_except_throw_exception_context(self):
+        def gen():
+            try:
+                try:
+                    # self.assertEqual(sys.exc_info()[0], None)
+                    yield
+                except ValueError:
+                    # we are called from "except ValueError:"
+                    # self.assertEqual(sys.exc_info()[0], ValueError)
+                    raise TypeError()
+            except Exception as exc: pass
+                # self.assertEqual(sys.exc_info()[0], TypeError)
+                # self.assertEqual(type(exc.__context__), ValueError)
+            # we are still called from "except ValueError:"
+            # self.assertEqual(sys.exc_info()[0], ValueError)
+            yield
+            # self.assertIsNone(sys.exc_info()[0])
+            yield "done"
+
+        g = gen()
+        next(g)
+        try:
+            raise ValueError
+        except Exception as exc:
+            g.throw(exc)
+
+        self.assertEqual(next(g), "done")
+
+
+    def test_stopiteration_error(self):
+        # See also PEP 479.
+
+        def gen():
+            raise StopIteration
+            yield
+
+        with self.assertRaises(RuntimeError) as e:
+            next(gen())
+        self.assertIn("raised StopIteration", repr(e.exception))
+
+
+    def test_tutorial_stopiteration(self):
+        # Raise StopIteration" stops the generator too:
+
+        def f():
+            yield 1
+            raise StopIteration
+            yield 2 # never reached
+
+        g = f()
+        self.assertEqual(next(g), 1)
+
+        with self.assertRaises(RuntimeError) as e:
+            next(g)
+        self.assertIn("raised StopIteration", repr(e.exception))
+
+
+    def test_return_tuple(self):
+        def g():
+            return (yield 1)
+
+        gen = g()
+        self.assertEqual(next(gen), 1)
+        with self.assertRaises(StopIteration) as cm:
+            gen.send((2,))
+        self.assertEqual(cm.exception.value, (2,))
+
+
+    def test_return_stopiteration(self):
+        def g():
+            return (yield 1)
+
+        gen = g()
+        self.assertEqual(next(gen), 1)
+        with self.assertRaises(StopIteration) as cm:
+            gen.send(StopIteration(2))
+        self.assertIsInstance(cm.exception.value, StopIteration)
+        self.assertEqual(cm.exception.value.value, 2)
+
+
+class TestPEP479(unittest.TestCase):
+    def test_stopiteration_wrapping(self):
+        def f():
+            raise StopIteration
+        def g():
+            yield f()
+        with self.assertRaises(RuntimeError) as e:
+            next(g())
+        self.assertEqual(str(e.exception), "generator raised StopIteration")
+
+
+    def test_stopiteration_wrapping_context(self):
+        def f():
+            raise StopIteration
+        def g():
+            yield f()
+
+        try:
+            next(g())
+        except RuntimeError as exc:
+            # self.assertIs(type(exc.__cause__), StopIteration)
+            # self.assertIs(type(exc.__context__), StopIteration)
+            # self.assertTrue(exc.__suppress_context__)
+            pass
+        else:
+            self.fail('__cause__, __context__, or __suppress_context__ '
+                      'were not properly set')
+
+
+class GeneratorProtocolTest(unittest.TestCase):
+    def test_start_exhaustion_and_throw_arguments(self):
+        entered = []
+        def gen():
+            entered.append(True)
+            try:
+                yield 1
+            except ValueError as error:
+                yield error.args
+        g = gen()
+        with self.assertRaises(TypeError):
+            g.send(9)
+        self.assertEqual(entered, [])
+        self.assertEqual(next(g), 1)
+        self.assertEqual(g.throw(ValueError, ("a", "b")), ("a", "b"))
+        self.assertEqual(list(g), [])
+        error = ValueError("closed")
+        with self.assertRaises(ValueError) as caught:
+            g.throw(error)
+        self.assertIs(caught.exception, error)
+        g = gen()
+        g.close()
+        self.assertEqual(list(g), [])
+        self.assertEqual(entered, [True])
+        with self.assertRaises(TypeError):
+            gen().throw(error, "extra")
+
+    def test_close_and_exception_state(self):
+        trace = []
+        def gen():
+            try:
+                try:
+                    yield 1
+                except ValueError:
+                    yield 2
+                    raise
+            finally:
+                trace.append("closed")
+        g = gen()
+        next(g)
+        self.assertEqual(g.throw(ValueError), 2)
+        with self.assertRaises(ValueError):
+            next(g)
+        self.assertEqual(trace, ["closed"])
+        g.close()
+        self.assertEqual(trace, ["closed"])
+
+    def test_argument_binding_and_laziness(self):
+        entered = []
+        def gen(a, *args, required, default=3, **kwargs):
+            entered.append(True)
+            yield a, args, required, default, kwargs
+        with self.assertRaises(TypeError):
+            gen(1)
+        self.assertEqual(entered, [])
+        g = gen(1, 2, required=4, extra=5)
+        self.assertEqual(entered, [])
+        self.assertEqual(next(g), (1, (2,), 4, 3, {"extra": 5}))
+
+    def test_delegate_throw_result_and_return(self):
+        class Delegate:
+            def __iter__(self):
+                return self
+            def __next__(self):
+                return 1
+            def throw(self, value):
+                if str(value) == "yield":
+                    return 42
+                raise StopIteration(99)
+        delegate = Delegate()
+        def gen():
+            result = yield from delegate
+            yield result
+        g = gen()
+        self.assertIsNone(g.gi_yieldfrom)
+        self.assertEqual(next(g), 1)
+        self.assertIs(g.gi_yieldfrom, delegate)
+        self.assertEqual(g.throw(ValueError("yield")), 42)
+        self.assertEqual(g.throw(ValueError("return")), 99)
+        self.assertIsNone(g.gi_yieldfrom)
+
+    def test_expression_temporaries_across_yields(self):
+        def gen():
+            yield (yield 1) + (yield 2)
+            yield [10, (yield 3), (yield 4)]
+        g = gen()
+        self.assertEqual(next(g), 1)
+        self.assertEqual(g.send(10), 2)
+        self.assertEqual(g.send(20), 30)
+        self.assertEqual(next(g), 3)
+        self.assertEqual(g.send(11), 4)
+        self.assertEqual(g.send(22), [10, 11, 22])
+
+    def test_pep479_cause(self):
+        error = StopIteration("unexpected")
+        def gen():
+            yield 1
+            raise error
+        g = gen()
+        next(g)
+        with self.assertRaises(RuntimeError) as caught:
+            next(g)
+        self.assertIs(caught.exception.__cause__, error)
+        self.assertEqual(list(g), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -405,5 +405,56 @@ class TestClassCell(unittest.TestCase):
         self.assertEqual(calls, ['Middle', 'Leaf'])
 
 
+class TestGeneratorCells(unittest.TestCase):
+    def test_cells_and_super_across_yields(self):
+        class Base:
+            def value(self):
+                return 10
+        class Child(Base):
+            def values(self):
+                count = 1
+                def update():
+                    nonlocal count
+                    count += 1
+                yield __class__, super().value(), count
+                update()
+                yield __class__, super().value(), count
+        self.assertEqual(list(Child().values()), [(Child, 10, 1), (Child, 10, 2)])
+
+    def test_unbound_cell_reservation(self):
+        value = 100
+        def gen():
+            def inner():
+                return value
+            yield inner
+            value = 2
+            yield inner
+        g = gen()
+        inner = next(g)
+        with self.assertRaises(NameError):
+            inner()
+        self.assertIs(next(g), inner)
+        self.assertEqual(inner(), 2)
+
+    def test_nonlocal_owner_across_generator_frames(self):
+        value = 1
+        def middle():
+            local = 5
+            def gen():
+                nonlocal value
+                yield local, value
+                value = 2
+                yield local, value
+                del value
+            return gen()
+        g = middle()
+        self.assertEqual(next(g), (5, 1))
+        self.assertEqual(next(g), (5, 2))
+        self.assertEqual(value, 2)
+        self.assertEqual(list(g), [])
+        with self.assertRaises(UnboundLocalError):
+            value
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit3/test_yield_from.py
+++ b/test/unit3/test_yield_from.py
@@ -104,42 +104,42 @@ class TestPEP380Operation(unittest.TestCase):
             "Finishing g1",
         ])
 
-    # def test_raising_exception_in_delegated_next_call(self):
-    #     """
-    #     Test raising exception in delegated next() call
-    #     """
-    #     trace = []
-    #     def g1():
-    #         try:
-    #             trace.append("Starting g1")
-    #             yield "g1 ham"
-    #             yield from g2()
-    #             yield "g1 eggs"
-    #         finally:
-    #             trace.append("Finishing g1")
-    #     def g2():
-    #         try:
-    #             trace.append("Starting g2")
-    #             yield "g2 spam"
-    #             raise ValueError("hovercraft is full of eels")
-    #             yield "g2 more spam"
-    #         finally:
-    #             trace.append("Finishing g2")
-    #     try:
-    #         for x in g1():
-    #             trace.append("Yielded %s" % (x,))
-    #     except ValueError as e:
-    #         self.assertEqual(e.args[0], "hovercraft is full of eels")
-    #     else:
-    #         self.fail("subgenerator failed to raise ValueError")
-    #     self.assertEqual(trace,[
-    #         "Starting g1",
-    #         "Yielded g1 ham",
-    #         "Starting g2",
-    #         "Yielded g2 spam",
-    #         "Finishing g2",
-    #         "Finishing g1",
-    #     ])
+    def test_raising_exception_in_delegated_next_call(self):
+        """
+        Test raising exception in delegated next() call
+        """
+        trace = []
+        def g1():
+            try:
+                trace.append("Starting g1")
+                yield "g1 ham"
+                yield from g2()
+                yield "g1 eggs"
+            finally:
+                trace.append("Finishing g1")
+        def g2():
+            try:
+                trace.append("Starting g2")
+                yield "g2 spam"
+                raise ValueError("hovercraft is full of eels")
+                yield "g2 more spam"
+            finally:
+                trace.append("Finishing g2")
+        try:
+            for x in g1():
+                trace.append("Yielded %s" % (x,))
+        except ValueError as e:
+            self.assertEqual(e.args[0], "hovercraft is full of eels")
+        else:
+            self.fail("subgenerator failed to raise ValueError")
+        self.assertEqual(trace,[
+            "Starting g1",
+            "Yielded g1 ham",
+            "Starting g2",
+            "Yielded g2 spam",
+            "Finishing g2",
+            "Finishing g1",
+        ])
 
     def test_delegation_of_send(self):
         """
@@ -226,120 +226,120 @@ class TestPEP380Operation(unittest.TestCase):
             "g2 received 2",
         ])
 
-    # def test_delegating_close(self):
-    #     """
-    #     Test delegating 'close'
-    #     """
-    #     trace = []
-    #     def g1():
-    #         try:
-    #             trace.append("Starting g1")
-    #             yield "g1 ham"
-    #             yield from g2()
-    #             yield "g1 eggs"
-    #         finally:
-    #             trace.append("Finishing g1")
-    #     def g2():
-    #         try:
-    #             trace.append("Starting g2")
-    #             yield "g2 spam"
-    #             yield "g2 more spam"
-    #         finally:
-    #             trace.append("Finishing g2")
-    #     g = g1()
-    #     for i in range(2):
-    #         x = next(g)
-    #         trace.append("Yielded %s" % (x,))
-    #     g.close()
-    #     self.assertEqual(trace,[
-    #         "Starting g1",
-    #         "Yielded g1 ham",
-    #         "Starting g2",
-    #         "Yielded g2 spam",
-    #         "Finishing g2",
-    #         "Finishing g1"
-    #     ])
+    def test_delegating_close(self):
+        """
+        Test delegating 'close'
+        """
+        trace = []
+        def g1():
+            try:
+                trace.append("Starting g1")
+                yield "g1 ham"
+                yield from g2()
+                yield "g1 eggs"
+            finally:
+                trace.append("Finishing g1")
+        def g2():
+            try:
+                trace.append("Starting g2")
+                yield "g2 spam"
+                yield "g2 more spam"
+            finally:
+                trace.append("Finishing g2")
+        g = g1()
+        for i in range(2):
+            x = next(g)
+            trace.append("Yielded %s" % (x,))
+        g.close()
+        self.assertEqual(trace,[
+            "Starting g1",
+            "Yielded g1 ham",
+            "Starting g2",
+            "Yielded g2 spam",
+            "Finishing g2",
+            "Finishing g1"
+        ])
 
-    # def test_handing_exception_while_delegating_close(self):
-    #     """
-    #     Test handling exception while delegating 'close'
-    #     """
-    #     trace = []
-    #     def g1():
-    #         try:
-    #             trace.append("Starting g1")
-    #             yield "g1 ham"
-    #             yield from g2()
-    #             yield "g1 eggs"
-    #         finally:
-    #             trace.append("Finishing g1")
-    #     def g2():
-    #         try:
-    #             trace.append("Starting g2")
-    #             yield "g2 spam"
-    #             yield "g2 more spam"
-    #         finally:
-    #             trace.append("Finishing g2")
-    #             raise ValueError("nybbles have exploded with delight")
-    #     try:
-    #         g = g1()
-    #         for i in range(2):
-    #             x = next(g)
-    #             trace.append("Yielded %s" % (x,))
-    #         g.close()
-    #     except ValueError as e:
-    #         self.assertEqual(e.args[0], "nybbles have exploded with delight")
-    #         self.assertIsInstance(e.__context__, GeneratorExit)
-    #     else:
-    #         self.fail("subgenerator failed to raise ValueError")
-    #     self.assertEqual(trace,[
-    #         "Starting g1",
-    #         "Yielded g1 ham",
-    #         "Starting g2",
-    #         "Yielded g2 spam",
-    #         "Finishing g2",
-    #         "Finishing g1",
-    #     ])
+    def test_handing_exception_while_delegating_close(self):
+        """
+        Test handling exception while delegating 'close'
+        """
+        trace = []
+        def g1():
+            try:
+                trace.append("Starting g1")
+                yield "g1 ham"
+                yield from g2()
+                yield "g1 eggs"
+            finally:
+                trace.append("Finishing g1")
+        def g2():
+            try:
+                trace.append("Starting g2")
+                yield "g2 spam"
+                yield "g2 more spam"
+            finally:
+                trace.append("Finishing g2")
+                raise ValueError("nybbles have exploded with delight")
+        try:
+            g = g1()
+            for i in range(2):
+                x = next(g)
+                trace.append("Yielded %s" % (x,))
+            g.close()
+        except ValueError as e:
+            self.assertEqual(e.args[0], "nybbles have exploded with delight")
+            # self.assertIsInstance(e.__context__, GeneratorExit)
+        else:
+            self.fail("subgenerator failed to raise ValueError")
+        self.assertEqual(trace,[
+            "Starting g1",
+            "Yielded g1 ham",
+            "Starting g2",
+            "Yielded g2 spam",
+            "Finishing g2",
+            "Finishing g1",
+        ])
 
-    # def test_delegating_throw(self):
-    #     """
-    #     Test delegating 'throw'
-    #     """
-    #     trace = []
-    #     def g1():
-    #         try:
-    #             trace.append("Starting g1")
-    #             yield "g1 ham"
-    #             yield from g2()
-    #             yield "g1 eggs"
-    #         finally:
-    #             trace.append("Finishing g1")
-    #     def g2():
-    #         try:
-    #             trace.append("Starting g2")
-    #             yield "g2 spam"
-    #             yield "g2 more spam"
-    #         finally:
-    #             trace.append("Finishing g2")
-    #     try:
-    #         g = g1()
-    #         for i in range(2):
-    #             x = next(g)
-    #             trace.append("Yielded %s" % (x,))
-    #         e = ValueError("tomato ejected")
-    #         g.throw(e)
-    #     except ValueError as e:
-    #         self.assertEqual(e.args[0], "tomato ejected")
-    #     else:
-    #         self.fail("subgenerator failed to raise ValueError")
-    #     self.assertEqual(trace,[
-    #         "Starting g1",
-    #         "Yielded g1 ham",
-    #         "Starting g2",
-    #         "Yielded g2 spam",
-    #         "Finishing g2",
-    #         "Finishing g1",
-    #     ])
+    def test_delegating_throw(self):
+        """
+        Test delegating 'throw'
+        """
+        trace = []
+        def g1():
+            try:
+                trace.append("Starting g1")
+                yield "g1 ham"
+                yield from g2()
+                yield "g1 eggs"
+            finally:
+                trace.append("Finishing g1")
+        def g2():
+            try:
+                trace.append("Starting g2")
+                yield "g2 spam"
+                yield "g2 more spam"
+            finally:
+                trace.append("Finishing g2")
+        try:
+            g = g1()
+            for i in range(2):
+                x = next(g)
+                trace.append("Yielded %s" % (x,))
+            e = ValueError("tomato ejected")
+            g.throw(e)
+        except ValueError as e:
+            self.assertEqual(e.args[0], "tomato ejected")
+        else:
+            self.fail("subgenerator failed to raise ValueError")
+        self.assertEqual(trace,[
+            "Starting g1",
+            "Yielded g1 ham",
+            "Starting g2",
+            "Yielded g2 spam",
+            "Finishing g2",
+            "Finishing g1",
+        ])
 
     def test_value_attribute_of_StopIteration_exception(self):
         """
@@ -460,86 +460,87 @@ class TestPEP380Operation(unittest.TestCase):
             "Yielded: 2",
         ])
 
-    # def test_delegation_of_close_to_non_generator(self):
-    #     """
-    #     Test delegation of close() to non-generator
-    #     """
-    #     trace = []
-    #     def g():
-    #         try:
-    #             trace.append("starting g")
-    #             yield from range(3)
-    #             trace.append("g should not be here")
-    #         finally:
-    #             trace.append("finishing g")
-    #     gi = g()
-    #     next(gi)
-    #     # with captured_stderr() as output:
-    #     #     gi.close()
-    #     self.assertEqual(output.getvalue(), '')
-    #     self.assertEqual(trace,[
-    #         "starting g",
-    #         "finishing g",
-    #     ])
+    def test_delegation_of_close_to_non_generator(self):
+        """
+        Test delegation of close() to non-generator
+        """
+        trace = []
+        def g():
+            try:
+                trace.append("starting g")
+                yield from range(3)
+                trace.append("g should not be here")
+            finally:
+                trace.append("finishing g")
+        gi = g()
+        next(gi)
+        # with captured_stderr() as output:
+        #     gi.close()
+        gi.close()
+        # self.assertEqual(output.getvalue(), '')
+        self.assertEqual(trace,[
+            "starting g",
+            "finishing g",
+        ])
 
-    # def test_delegating_throw_to_non_generator(self):
-    #     """
-    #     Test delegating 'throw' to non-generator
-    #     """
-    #     trace = []
-    #     def g():
-    #         try:
-    #             trace.append("Starting g")
-    #             yield from range(10)
-    #         finally:
-    #             trace.append("Finishing g")
-    #     try:
-    #         gi = g()
-    #         for i in range(5):
-    #             x = next(gi)
-    #             trace.append("Yielded %s" % (x,))
-    #         e = ValueError("tomato ejected")
-    #         gi.throw(e)
-    #     except ValueError as e:
-    #         self.assertEqual(e.args[0],"tomato ejected")
-    #     else:
-    #         self.fail("subgenerator failed to raise ValueError")
-    #     self.assertEqual(trace,[
-    #         "Starting g",
-    #         "Yielded 0",
-    #         "Yielded 1",
-    #         "Yielded 2",
-    #         "Yielded 3",
-    #         "Yielded 4",
-    #         "Finishing g",
-    #     ])
+    def test_delegating_throw_to_non_generator(self):
+        """
+        Test delegating 'throw' to non-generator
+        """
+        trace = []
+        def g():
+            try:
+                trace.append("Starting g")
+                yield from range(10)
+            finally:
+                trace.append("Finishing g")
+        try:
+            gi = g()
+            for i in range(5):
+                x = next(gi)
+                trace.append("Yielded %s" % (x,))
+            e = ValueError("tomato ejected")
+            gi.throw(e)
+        except ValueError as e:
+            self.assertEqual(e.args[0],"tomato ejected")
+        else:
+            self.fail("subgenerator failed to raise ValueError")
+        self.assertEqual(trace,[
+            "Starting g",
+            "Yielded 0",
+            "Yielded 1",
+            "Yielded 2",
+            "Yielded 3",
+            "Yielded 4",
+            "Finishing g",
+        ])
 
-    # def test_attempting_to_send_to_non_generator(self):
-    #     """
-    #     Test attempting to send to non-generator
-    #     """
-    #     trace = []
-    #     def g():
-    #         try:
-    #             trace.append("starting g")
-    #             yield from range(3)
-    #             trace.append("g should not be here")
-    #         finally:
-    #             trace.append("finishing g")
-    #     try:
-    #         gi = g()
-    #         next(gi)
-    #         for x in range(3):
-    #             y = gi.send(42)
-    #             trace.append("Should not have yielded: %s" % (y,))
-    #     except AttributeError as e:
-    #         self.assertIn("send", e.args[0])
-    #     else:
-    #         self.fail("was able to send into non-generator")
-    #     self.assertEqual(trace,[
-    #         "starting g",
-    #         "finishing g",
-    #     ])
+    def test_attempting_to_send_to_non_generator(self):
+        """
+        Test attempting to send to non-generator
+        """
+        trace = []
+        def g():
+            try:
+                trace.append("starting g")
+                yield from range(3)
+                trace.append("g should not be here")
+            finally:
+                trace.append("finishing g")
+        try:
+            gi = g()
+            next(gi)
+            for x in range(3):
+                y = gi.send(42)
+                trace.append("Should not have yielded: %s" % (y,))
+        except AttributeError as e:
+            self.assertIn("send", e.args[0])
+        else:
+            self.fail("was able to send into non-generator")
+        self.assertEqual(trace,[
+            "starting g",
+            "finishing g",
+        ])
 
     def test_broken_getattr_handling(self):
         """
@@ -561,10 +562,10 @@ class TestPEP380Operation(unittest.TestCase):
             self.assertEqual(next(gi), 1)
             gi.send(1)
 
-        # with self.assertRaises(ZeroDivisionError):
-        #     gi = g()
-        #     self.assertEqual(next(gi), 1)
-        #     gi.throw(AttributeError)
+        with self.assertRaises(ZeroDivisionError):
+            gi = g()
+            self.assertEqual(next(gi), 1)
+            gi.throw(AttributeError)
 
         # with support.catch_unraisable_exception() as cm:
         #     gi = g()
@@ -627,48 +628,48 @@ class TestPEP380Operation(unittest.TestCase):
             "g2: about to yield from g1",
         ])
 
-    # def test_returning_value_from_delegated_throw(self):
-    #     """
-    #     Test returning value from delegated 'throw'
-    #     """
-    #     trace = []
-    #     def g1():
-    #         try:
-    #             trace.append("Starting g1")
-    #             yield "g1 ham"
-    #             yield from g2()
-    #             yield "g1 eggs"
-    #         finally:
-    #             trace.append("Finishing g1")
-    #     def g2():
-    #         try:
-    #             trace.append("Starting g2")
-    #             yield "g2 spam"
-    #             yield "g2 more spam"
-    #         except LunchError:
-    #             trace.append("Caught LunchError in g2")
-    #             yield "g2 lunch saved"
-    #             yield "g2 yet more spam"
-    #     class LunchError(Exception):
-    #         pass
-    #     g = g1()
-    #     for i in range(2):
-    #         x = next(g)
-    #         trace.append("Yielded %s" % (x,))
-    #     e = LunchError("tomato ejected")
-    #     g.throw(e)
-    #     for x in g:
-    #         trace.append("Yielded %s" % (x,))
-    #     self.assertEqual(trace,[
-    #         "Starting g1",
-    #         "Yielded g1 ham",
-    #         "Starting g2",
-    #         "Yielded g2 spam",
-    #         "Caught LunchError in g2",
-    #         "Yielded g2 yet more spam",
-    #         "Yielded g1 eggs",
-    #         "Finishing g1",
-    #     ])
+    def test_returning_value_from_delegated_throw(self):
+        """
+        Test returning value from delegated 'throw'
+        """
+        trace = []
+        def g1():
+            try:
+                trace.append("Starting g1")
+                yield "g1 ham"
+                yield from g2()
+                yield "g1 eggs"
+            finally:
+                trace.append("Finishing g1")
+        def g2():
+            try:
+                trace.append("Starting g2")
+                yield "g2 spam"
+                yield "g2 more spam"
+            except LunchError:
+                trace.append("Caught LunchError in g2")
+                yield "g2 lunch saved"
+                yield "g2 yet more spam"
+        class LunchError(Exception):
+            pass
+        g = g1()
+        for i in range(2):
+            x = next(g)
+            trace.append("Yielded %s" % (x,))
+        e = LunchError("tomato ejected")
+        g.throw(e)
+        for x in g:
+            trace.append("Yielded %s" % (x,))
+        self.assertEqual(trace,[
+            "Starting g1",
+            "Yielded g1 ham",
+            "Starting g2",
+            "Yielded g2 spam",
+            "Caught LunchError in g2",
+            "Yielded g2 yet more spam",
+            "Yielded g1 eggs",
+            "Finishing g1",
+        ])
 
     def test_next_and_return_with_value(self):
         """
@@ -759,202 +760,203 @@ class TestPEP380Operation(unittest.TestCase):
             'f caught StopIteration(StopIteration(3))'
         ])
 
-    # def test_catching_exception_from_subgen_and_returning(self):
-    #     """
-    #     Test catching an exception thrown into a
-    #     subgenerator and returning a value
-    #     """
-    #     def inner():
-    #         try:
-    #             yield 1
-    #         except ValueError:
-    #             trace.append("inner caught ValueError")
-    #         return value
+    def test_catching_exception_from_subgen_and_returning(self):
+        """
+        Test catching an exception thrown into a
+        subgenerator and returning a value
+        """
+        def inner():
+            try:
+                yield 1
+            except ValueError:
+                trace.append("inner caught ValueError")
+            return value
 
-    #     def outer():
-    #         v = yield from inner()
-    #         trace.append("inner returned %r to outer" % (v,))
-    #         yield v
+        def outer():
+            v = yield from inner()
+            trace.append("inner returned %r to outer" % (v,))
+            yield v
 
-    #     for value in 2, (2,), StopIteration(2):
-    #         trace = []
-    #         g = outer()
-    #         trace.append(next(g))
-    #         trace.append(repr(g.throw(ValueError)))
-    #         self.assertEqual(trace, [
-    #             1,
-    #             "inner caught ValueError",
-    #             "inner returned %r to outer" % (value,),
-    #             repr(value),
-    #         ])
+        for value in 2, (2,), StopIteration(2):
+            trace = []
+            g = outer()
+            trace.append(next(g))
+            trace.append(repr(g.throw(ValueError)))
+            self.assertEqual(trace, [
+                1,
+                "inner caught ValueError",
+                "inner returned %r to outer" % (value,),
+                repr(value),
+            ])
 
-    # def test_throwing_GeneratorExit_into_subgen_that_returns(self):
-    #     """
-    #     Test throwing GeneratorExit into a subgenerator that
-    #     catches it and returns normally.
-    #     """
-    #     trace = []
-    #     def f():
-    #         try:
-    #             trace.append("Enter f")
-    #             yield
-    #             trace.append("Exit f")
-    #         except GeneratorExit:
-    #             return
-    #     def g():
-    #         trace.append("Enter g")
-    #         yield from f()
-    #         trace.append("Exit g")
-    #     try:
-    #         gi = g()
-    #         next(gi)
-    #         gi.throw(GeneratorExit)
-    #     except GeneratorExit:
-    #         pass
-    #     else:
-    #         self.fail("subgenerator failed to raise GeneratorExit")
-    #     self.assertEqual(trace,[
-    #         "Enter g",
-    #         "Enter f",
-    #     ])
+    def test_throwing_GeneratorExit_into_subgen_that_returns(self):
+        """
+        Test throwing GeneratorExit into a subgenerator that
+        catches it and returns normally.
+        """
+        trace = []
+        def f():
+            try:
+                trace.append("Enter f")
+                yield
+                trace.append("Exit f")
+            except GeneratorExit:
+                return
+        def g():
+            trace.append("Enter g")
+            yield from f()
+            trace.append("Exit g")
+        try:
+            gi = g()
+            next(gi)
+            gi.throw(GeneratorExit)
+        except GeneratorExit:
+            pass
+        else:
+            self.fail("subgenerator failed to raise GeneratorExit")
+        self.assertEqual(trace,[
+            "Enter g",
+            "Enter f",
+        ])
 
-    # def test_throwing_GeneratorExit_into_subgenerator_that_yields(self):
-    #     """
-    #     Test throwing GeneratorExit into a subgenerator that
-    #     catches it and yields.
-    #     """
-    #     trace = []
-    #     def f():
-    #         try:
-    #             trace.append("Enter f")
-    #             yield
-    #             trace.append("Exit f")
-    #         except GeneratorExit:
-    #             yield
-    #     def g():
-    #         trace.append("Enter g")
-    #         yield from f()
-    #         trace.append("Exit g")
-    #     try:
-    #         gi = g()
-    #         next(gi)
-    #         gi.throw(GeneratorExit)
-    #     except RuntimeError as e:
-    #         self.assertEqual(e.args[0], "generator ignored GeneratorExit")
-    #     else:
-    #         self.fail("subgenerator failed to raise GeneratorExit")
-    #     self.assertEqual(trace,[
-    #         "Enter g",
-    #         "Enter f",
-    #     ])
+    def test_throwing_GeneratorExit_into_subgenerator_that_yields(self):
+        """
+        Test throwing GeneratorExit into a subgenerator that
+        catches it and yields.
+        """
+        trace = []
+        def f():
+            try:
+                trace.append("Enter f")
+                yield
+                trace.append("Exit f")
+            except GeneratorExit:
+                yield
+        def g():
+            trace.append("Enter g")
+            yield from f()
+            trace.append("Exit g")
+        try:
+            gi = g()
+            next(gi)
+            gi.throw(GeneratorExit)
+        except RuntimeError as e:
+            self.assertEqual(e.args[0], "generator ignored GeneratorExit")
+        else:
+            self.fail("subgenerator failed to raise GeneratorExit")
+        self.assertEqual(trace,[
+            "Enter g",
+            "Enter f",
+        ])
 
-    # def test_throwing_GeneratorExit_into_subgen_that_raises(self):
-    #     """
-    #     Test throwing GeneratorExit into a subgenerator that
-    #     catches it and raises a different exception.
-    #     """
-    #     trace = []
-    #     def f():
-    #         try:
-    #             trace.append("Enter f")
-    #             yield
-    #             trace.append("Exit f")
-    #         except GeneratorExit:
-    #             raise ValueError("Vorpal bunny encountered")
-    #     def g():
-    #         trace.append("Enter g")
-    #         yield from f()
-    #         trace.append("Exit g")
-    #     try:
-    #         gi = g()
-    #         next(gi)
-    #         gi.throw(GeneratorExit)
-    #     except ValueError as e:
-    #         self.assertEqual(e.args[0], "Vorpal bunny encountered")
-    #         self.assertIsInstance(e.__context__, GeneratorExit)
-    #     else:
-    #         self.fail("subgenerator failed to raise ValueError")
-    #     self.assertEqual(trace,[
-    #         "Enter g",
-    #         "Enter f",
-    #     ])
+    def test_throwing_GeneratorExit_into_subgen_that_raises(self):
+        """
+        Test throwing GeneratorExit into a subgenerator that
+        catches it and raises a different exception.
+        """
+        trace = []
+        def f():
+            try:
+                trace.append("Enter f")
+                yield
+                trace.append("Exit f")
+            except GeneratorExit:
+                raise ValueError("Vorpal bunny encountered")
+        def g():
+            trace.append("Enter g")
+            yield from f()
+            trace.append("Exit g")
+        try:
+            gi = g()
+            next(gi)
+            gi.throw(GeneratorExit)
+        except ValueError as e:
+            self.assertEqual(e.args[0], "Vorpal bunny encountered")
+            # self.assertIsInstance(e.__context__, GeneratorExit)
+        else:
+            self.fail("subgenerator failed to raise ValueError")
+        self.assertEqual(trace,[
+            "Enter g",
+            "Enter f",
+        ])
 
     def test_yield_from_empty(self):
         def g():
             yield from ()
         self.assertRaises(StopIteration, next, g())
 
-    # def test_delegating_generators_claim_to_be_running(self):
-    #     # Check with basic iteration
-    #     def one():
-    #         yield 0
-    #         yield from two()
-    #         yield 3
-    #     def two():
-    #         yield 1
-    #         try:
-    #             yield from g1
-    #         except ValueError:
-    #             pass
-    #         yield 2
-    #     g1 = one()
-    #     self.assertEqual(list(g1), [0, 1, 2, 3])
-    #     # Check with send
-    #     g1 = one()
-    #     res = [next(g1)]
-    #     try:
-    #         while True:
-    #             res.append(g1.send(42))
-    #     except StopIteration:
-    #         pass
-    #     self.assertEqual(res, [0, 1, 2, 3])
-    #     # Check with throw
-    #     class MyErr(Exception):
-    #         pass
-    #     def one():
-    #         try:
-    #             yield 0
-    #         except MyErr:
-    #             pass
-    #         yield from two()
-    #         try:
-    #             yield 3
-    #         except MyErr:
-    #             pass
-    #     def two():
-    #         try:
-    #             yield 1
-    #         except MyErr:
-    #             pass
-    #         try:
-    #             yield from g1
-    #         except ValueError:
-    #             pass
-    #         try:
-    #             yield 2
-    #         except MyErr:
-    #             pass
-    #     g1 = one()
-    #     res = [next(g1)]
-    #     try:
-    #         while True:
-    #             res.append(g1.throw(MyErr))
-    #     except StopIteration:
-    #         pass
-    #     # Check with close
-    #     class MyIt(object):
-    #         def __iter__(self):
-    #             return self
-    #         def __next__(self):
-    #             return 42
-    #         def close(self_):
-    #             self.assertTrue(g1.gi_running)
-    #             self.assertRaises(ValueError, next, g1)
-    #     def one():
-    #         yield from MyIt()
-    #     g1 = one()
-    #     next(g1)
-    #     g1.close()
+    def test_delegating_generators_claim_to_be_running(self):
+        # Check with basic iteration
+        def one():
+            yield 0
+            yield from two()
+            yield 3
+        def two():
+            yield 1
+            try:
+                yield from g1
+            except ValueError:
+                pass
+            yield 2
+        g1 = one()
+        self.assertEqual(list(g1), [0, 1, 2, 3])
+        # Check with send
+        g1 = one()
+        res = [next(g1)]
+        try:
+            while True:
+                res.append(g1.send(42))
+        except StopIteration:
+            pass
+        self.assertEqual(res, [0, 1, 2, 3])
+        # Check with throw
+        # global MyErr
+        class MyErr(Exception):
+            pass
+        def one():
+            try:
+                yield 0
+            except MyErr:
+                pass
+            yield from two()
+            try:
+                yield 3
+            except MyErr:
+                pass
+        def two():
+            try:
+                yield 1
+            except MyErr:
+                pass
+            try:
+                yield from g1
+            except ValueError:
+                pass
+            try:
+                yield 2
+            except MyErr:
+                pass
+        g1 = one()
+        res = [next(g1)]
+        try:
+            while True:
+                res.append(g1.throw(MyErr))
+        except StopIteration:
+            pass
+        # Check with close
+        class MyIt(object):
+            def __iter__(self):
+                return self
+            def __next__(self):
+                return 42
+            def close(self_):
+                self.assertTrue(g1.gi_running)
+                self.assertRaises(ValueError, next, g1)
+        def one():
+            yield from MyIt()
+        g1 = one()
+        next(g1)
+        g1.close()
 
     # # def test_delegator_is_visible_to_debugger(self):
     #     # def call_stack():

--- a/test/unit3/test_yield_from.py
+++ b/test/unit3/test_yield_from.py
@@ -951,6 +951,7 @@ class TestPEP380Operation(unittest.TestCase):
                 return 42
             def close(self_):
                 self.assertTrue(g1.gi_running)
+                self.assertIs(g1.gi_yieldfrom, self_)
                 self.assertRaises(ValueError, next, g1)
         def one():
             yield from MyIt()


### PR DESCRIPTION
Generators preserve their compiled frame through Skulpt suspensions, including local variables, expression temporaries, exception handlers and finally state. They share ordinary function argument binding, enabling varargs, keyword arguments and decorators without a separate generator wrapper.

Completes send/throw/close and yield-from delegation for the supported generator protocol. Running-state guards survive external suspensions; delegated throw preserves original arguments and handles yielded and returned values. Python 3 applies PEP 479, while Python 2 retains its prior termination behavior. The class-cell and nonlocal semantics from #1602 are preserved.

This is layer 3 of the work split from #1306, based on #1604. #1306 contains only the contextlib layer. Focused human review of the compiler/frame and delegation paths is recommended.

Validation: selected CPython 3.7 generator and coroutine cases, 31 delegation tests, cell/super regressions, and JavaScript tests using real suspensions. The imported CPython gi_yieldfrom test exposed and now covers delegate visibility during frame execution. Dormant doctests were selectively converted into executable tests. Full development and optimized suites pass on the completed stack.

Compatibility: a non-None traceback argument to throw is explicitly unsupported. Frame introspection, automatic garbage-collection finalization and async generators are outside this change. Performance of the new frame representation has not been benchmarked.

Merge after the exception layer; retarget to master and rerun CI first.

Stack and merge order: #1602 → #1603 → #1604 → #1605 → #1306.
