### PR TITLE
Fix compiler-generated symbols when Sk is frozen

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -1,7 +1,8 @@
 /** @param {...*} x */
 var out;
 
-Sk.gensymcount = 0;
+// Keep the counter off Sk so compilation works when the public object is frozen.
+var gensymcount = 0;
 
 /**
  * @constructor
@@ -118,7 +119,7 @@ Compiler.prototype.annotateSource = function (ast) {
 Compiler.prototype.gensym = function (hint) {
     hint = hint || "";
     hint = "$" + hint;
-    hint += Sk.gensymcount++;
+    hint += gensymcount++;
     return hint;
 };
 
@@ -3087,7 +3088,7 @@ Sk.compile = function (source, filename, mode, canSuspend) {
 Sk.exportSymbol("Sk.compile", Sk.compile);
 
 Sk.resetCompiler = function () {
-    Sk.gensymcount = 0;
+    gensymcount = 0;
 };
 
 Sk.exportSymbol("Sk.resetCompiler", Sk.resetCompiler);


### PR DESCRIPTION
## Summary

Move the compiler generated-symbol counter off the public `Sk` object and keep it in the compiler module closure. `Sk.resetCompiler()` still resets the counter.

## Why

When Safari freezes `Sk`, incrementing `Sk.gensymcount` no longer changes its value. The compiler then reuses generated JavaScript names, which causes collisions and failures in larger codebases.

## Testing

- `NODE_OPTIONS=--openssl-legacy-provider npm run devbuild`
- `node test/testunit.js --python3 --module skulpt_bugs` (11 passed)
- Compiled two comprehensions after `Object.freeze(Sk)` and verified that the generated symbol names remain distinct

## Performance

Following the `field.py` benchmark used in #1143, I ran eight alternating fresh Node processes per revision with the development build on Node 26.7.0.

| Measurement | `master` | This PR | Change |
| --- | ---: | ---: | ---: |
| Mean process CPU time | 1667.5 ms | 1667.0 ms | -0.03% |
| Mean wall time | 1371.5 ms | 1369.6 ms | -0.14% |

V8 reported fast properties for `Sk` after the benchmark on both revisions. The number of own enumerable properties changed from 90 to 89. No performance regression was measurable.