### PR TITLE
fix: unwind exception handlers before finally cleanup

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -1168,12 +1168,14 @@ Compiler.prototype.popContinueBlock = function () {
     this.u.continueBlocks.pop();
 };
 
+// This compiler-time stack describes lexical nesting. Generated $exc entries are
+// runtime exception targets; return/break/continue can pop them without changing
+// the compiler stack needed to compile the remaining statements in the scope.
 Compiler.prototype.pushExceptionHandlerBlock = function (blk, isFinally) {
     Sk.asserts.assert(blk >= 0 && blk < this.u.blocknum);
     Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
     const excBlock = { blk, isFinally, breakDepth: this.u.breakBlocks.length };
     this.u.exceptionHandlerBlocks.push(excBlock);
-    return excBlock;
 };
 
 Compiler.prototype.popExceptionHandlerBlock = function () {
@@ -1181,9 +1183,10 @@ Compiler.prototype.popExceptionHandlerBlock = function () {
 };
 
 Compiler.prototype.closeOutExceptionHandlersAndMaybeJumpToFinally = function(continuingOrBreaking, valueOfPostFinally) {
-    // We are emitting code for a continue, break, or return. We need to close out
-    // all of the exception handlers between us and either the loop we're in or the function scope.
-    // They're all stored in excBlocks
+    // Emit runtime unwinding without changing the compiler's lexical stack.
+    // Return leaves every handler; break/continue leave only handlers inside
+    // their loop. Pop each handler before running cleanup so cleanup exceptions
+    // reach an enclosing handler instead of re-entering the same cleanup.
 
     const myBreakDepth = continuingOrBreaking ? this.u.breakBlocks.length : 0;
     const excBlocks = this.u.exceptionHandlerBlocks;
@@ -1197,20 +1200,20 @@ Compiler.prototype.closeOutExceptionHandlersAndMaybeJumpToFinally = function(con
             }
             // jump to the body of the finally block
             out("$blk=",excBlock.blk,";continue;");
-            // When it's done executing, the finally body will call closeOutExceptionHandlers()
-            // to continue down the chain of exception handlers.
+            // outputFinallyCascade resumes unwinding after this cleanup body.
+            // Its handler has left the compiler stack by then.
             return false;
         }
     }
-    // After calling this code, the caller must emit a jump/return to the eventual destination. It will be ignored if we've already
-    // jumped to a finally block, or it will fall through efficiently to it if all we did was pop off an exception from the stack.
+    // True means execution falls through: the caller must emit the final
+    // jump/return. False means we emitted a jump to cleanup instead.
     return true;
 };
 
 
 Compiler.prototype.setupExcept = function (eb) {
     out("$exc.push(", eb, ");");
-    return this.pushExceptionHandlerBlock(eb, false);
+    this.pushExceptionHandlerBlock(eb, false);
 };
 
 Compiler.prototype.endExcept = function () {
@@ -1219,8 +1222,10 @@ Compiler.prototype.endExcept = function () {
 };
 
 Compiler.prototype.setupFinally = function (finallyBody, excHandler) {
+    // try/finally uses a separate exception entry to save the error for re-raising.
+    // Return/break/continue enter finallyBody directly with $postfinally set.
     out("$exc.push(", excHandler , ");");
-    return this.pushExceptionHandlerBlock(finallyBody, true);
+    this.pushExceptionHandlerBlock(finallyBody, true);
 };
 
 Compiler.prototype.endFinally = function () {
@@ -1559,7 +1564,7 @@ Compiler.prototype.craise = function (s) {
     }
 };
 
-Compiler.prototype.outputFinallyCascade = function (thisFinally) {
+Compiler.prototype.outputFinallyCascade = function () {
 
     // What do we do when we're done executing a 'finally' block?
     // Normally you just fall off the end. If we're 'return'ing,
@@ -1601,7 +1606,6 @@ Compiler.prototype.ctry = function (s) {
     var n = s.handlers.length;
 
     var finalBody, finalExceptionHandler, finalExceptionToReRaise;
-    var thisFinally;
 
     if (s.finalbody) {
         finalBody = this.newBlock("finalbody");
@@ -1609,7 +1613,7 @@ Compiler.prototype.ctry = function (s) {
         finalExceptionToReRaise = this._gr("finally_reraise", "undefined");
 
         this.u.tempsToSave.push(finalExceptionToReRaise);
-        thisFinally = this.setupFinally(finalBody, finalExceptionHandler);
+        this.setupFinally(finalBody, finalExceptionHandler);
     }
 
     // Create a block for each except clause
@@ -1686,7 +1690,7 @@ Compiler.prototype.ctry = function (s) {
         // to re-raise, we raise it.
         out("if(",finalExceptionToReRaise,"!==undefined) { throw ",finalExceptionToReRaise,";}");
 
-        this.outputFinallyCascade(thisFinally);
+        this.outputFinallyCascade();
         // Else, we continue from here.
     }
 };
@@ -1695,7 +1699,6 @@ Compiler.prototype.cwith = function (s, itemIdx) {
     var mgr, exit, value, exception;
     var exceptionHandler = this.newBlock("withexh"), tidyUp = this.newBlock("withtidyup");
     var carryOn = this.newBlock("withcarryon");
-    var thisFinallyBlock;
 
     // NB this does not *quite* match the semantics in PEP 343, which
     // specifies "exit = type(mgr).__exit__" rather than getattr()ing,
@@ -1720,7 +1723,7 @@ Compiler.prototype.cwith = function (s, itemIdx) {
     value = this._gr("value", "$ret");
 
     // try:
-    thisFinallyBlock = this.setupFinally(tidyUp, tidyUp);
+    this.setupFinally(tidyUp, tidyUp);
     this.setupExcept(exceptionHandler);
 
     //    VAR = value
@@ -1738,13 +1741,17 @@ Compiler.prototype.cwith = function (s, itemIdx) {
         this.vseqstmt(s.body);
     }
 
+    // Leave both compiler scopes before compiling __exit__: neither handler
+    // covers cleanup. These calls also emit the pops for normal fallthrough.
     this.endExcept();
-    this.endFinally(); // Note that this "finally" doesn't cover the exception handler
+    this.endFinally();
     this._jump(tidyUp);
 
     // except:
     this.setBlock(exceptionHandler);
-    out("$exc.pop();"); // skip "finally" handler
+    // Exception dispatch already popped the except target. Remove only the
+    // runtime finally target here; both compiler entries were removed above.
+    out("$exc.pop();");
 
     //   if not exit(*sys.exc_info()):
     //     raise
@@ -1756,14 +1763,13 @@ Compiler.prototype.cwith = function (s, itemIdx) {
     // finally: (kinda. NB that this is a "finally" that doesn't run in the
     //           exception case!)
     this.setBlock(tidyUp);
-    this.popExceptionHandlerBlock();
 
     //   exit(None, None, None)
     out("$ret = Sk.misceval.callsimOrSuspendArray(",exit,",[Sk.builtin.none.none$,Sk.builtin.none.none$,Sk.builtin.none.none$]);");
     this._checkSuspension(s);
     // Ignore $ret.
 
-    this.outputFinallyCascade(thisFinallyBlock);
+    this.outputFinallyCascade();
 
     this._jump(carryOn);
 
@@ -2501,7 +2507,6 @@ Compiler.prototype.ccontinue = function (s) {
     if (this.u.continueBlocks.length == 0) {
         throw new Sk.builtin.SyntaxError("'continue' outside loop", this.filename, s.lineno);
     }
-    // todo; continue out of exception blocks?
     const gotoBlock = this.u.continueBlocks[this.u.continueBlocks.length - 1];
     Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
     this.closeOutExceptionHandlersAndMaybeJumpToFinally(true, "{isBreak:true,gotoBlock:"+gotoBlock+"}");

--- a/src/compile.js
+++ b/src/compile.js
@@ -1146,6 +1146,7 @@ Compiler.prototype.newBlock = function (name) {
     this.u.blocks[ret]._next = null;
     return ret;
 };
+
 Compiler.prototype.setBlock = function (n) {
     Sk.asserts.assert(n >= 0 && n < this.u.blocknum);
     this.u.curblock = n;
@@ -1166,27 +1167,6 @@ Compiler.prototype.pushContinueBlock = function (n) {
 Compiler.prototype.popContinueBlock = function () {
     this.u.continueBlocks.pop();
 };
-/*
-Compiler.prototype.pushExceptBlock = function (n) {
-    Sk.asserts.assert(n >= 0 && n < this.u.blocknum);
-    this.u.exceptBlocks.push(n);
-};
-Compiler.prototype.popExceptBlock = function () {
-    this.u.exceptBlocks.pop();
-};
-
-Compiler.prototype.pushFinallyBlock = function (n) {
-    Sk.asserts.assert(n >= 0 && n < this.u.blocknum);
-    Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
-    this.u.finallyBlocks.push({blk: n, breakDepth: this.u.breakBlocks.length});
-};
-Compiler.prototype.popFinallyBlock = function () {
-    this.u.finallyBlocks.pop();
-};
-Compiler.prototype.peekFinallyBlock = function() {
-    return (this.u.finallyBlocks.length > 0) ? this.u.finallyBlocks[this.u.finallyBlocks.length-1] : undefined;
-};
-*/
 
 Compiler.prototype.pushExceptionHandlerBlock = function (blk, isFinally) {
     Sk.asserts.assert(blk >= 0 && blk < this.u.blocknum);
@@ -1576,52 +1556,6 @@ Compiler.prototype.craise = function (s) {
     } else {
         // re-raise
         out("throw $err;");
-    }
-};
-
-Compiler.prototype.outputFinallyCascade = function (thisFinally) {
-    var nextFinally;
-
-    // What do we do when we're done executing a 'finally' block?
-    // Normally you just fall off the end. If we're 'return'ing,
-    // 'continue'ing or 'break'ing, $postfinally tells us what to do.
-    //
-    // But we might be in a nested pair of 'finally' blocks. If so, we need
-    // to work out whether to jump to the outer finally block.
-    //
-    // (NB we do NOT deal with re-raising exceptions here. That's handled
-    // elsewhere, because 'with' does special things with exceptions.)
-
-    if (this.u.finallyBlocks.length == 0) {
-        // No nested 'finally' block. Easy.
-        out("if($postfinally!==undefined) { if ($postfinally.returning) { return $postfinally.returning; } else { $blk=$postfinally.gotoBlock; $postfinally=undefined; continue; } }");
-    } else {
-
-        // OK, we're nested. Do we jump straight to the outer 'finally' block?
-        // Depends on how we got here here.
-
-        // Normal execution ($postfinally===undefined)? No, we're done here.
-
-        // Returning ($postfinally.returning)? Yes, we want to execute all the
-        // 'finally' blocks on the way out.
-
-        // Breaking ($postfinally.isBreak)? It depends. Is the outer 'finally'
-        // block inside or outside the loop we're breaking out of? We compare
-        // its breakDepth to ours to find out. If we're at the same breakDepth,
-        // we're both inside the innermost loop, so we both need to execute.
-        // ('continue' is the same thing as 'break' for us)
-
-        nextFinally = this.peekFinallyBlock();
-
-        out("if($postfinally!==undefined) {",
-            "if ($postfinally.returning",
-            (nextFinally.breakDepth == thisFinally.breakDepth) ? "|| $postfinally.isBreak" : "", ") {",
-
-            "$blk=",nextFinally.blk,";continue;",
-            "} else {",
-            "$blk=$postfinally.gotoBlock;$postfinally=undefined;continue;",
-            "}",
-            "}");
     }
 };
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -2568,7 +2568,7 @@ Compiler.prototype.ccontinue = function (s) {
         throw new Sk.builtin.SyntaxError("'continue' outside loop", this.filename, s.lineno);
     }
     // todo; continue out of exception blocks?
-    gotoBlock = this.u.continueBlocks[this.u.continueBlocks.length - 1];
+    const gotoBlock = this.u.continueBlocks[this.u.continueBlocks.length - 1];
     Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
     this.closeOutExceptionHandlersAndMaybeJumpToFinally(true, "{isBreak:true,gotoBlock:"+gotoBlock+"}");
     this._jump(gotoBlock);
@@ -2578,7 +2578,7 @@ Compiler.prototype.cbreak = function(s) {
     if (this.u.breakBlocks.length === 0) {
         throw new Sk.builtin.SyntaxError("'break' outside loop", this.filename, s.lineno);
     }
-    gotoBlock = this.u.breakBlocks[this.u.breakBlocks.length - 1];
+    const gotoBlock = this.u.breakBlocks[this.u.breakBlocks.length - 1];
     this.closeOutExceptionHandlersAndMaybeJumpToFinally(true, "{isBreak:true,gotoBlock:"+gotoBlock+"}");
     this._jump(gotoBlock);
 };

--- a/src/compile.js
+++ b/src/compile.js
@@ -72,9 +72,8 @@ function CompilerUnit () {
     this.breakBlocks = [];
     // stack of where to go on a continue
     this.continueBlocks = [];
-    this.exceptBlocks = [];
-    // state of where to go on a return
-    this.finallyBlocks = [];
+    // stack of exception handlers to resolve when returning/breaking/continuing
+    this.exceptionHandlerBlocks = [];
 }
 
 CompilerUnit.prototype.activateScope = function () {
@@ -1167,7 +1166,7 @@ Compiler.prototype.pushContinueBlock = function (n) {
 Compiler.prototype.popContinueBlock = function () {
     this.u.continueBlocks.pop();
 };
-
+/*
 Compiler.prototype.pushExceptBlock = function (n) {
     Sk.asserts.assert(n >= 0 && n < this.u.blocknum);
     this.u.exceptBlocks.push(n);
@@ -1187,14 +1186,66 @@ Compiler.prototype.popFinallyBlock = function () {
 Compiler.prototype.peekFinallyBlock = function() {
     return (this.u.finallyBlocks.length > 0) ? this.u.finallyBlocks[this.u.finallyBlocks.length-1] : undefined;
 };
+*/
+
+Compiler.prototype.pushExceptionHandlerBlock = function(blk, isFinally) {
+    Sk.asserts.assert(blk >= 0 && blk < this.u.blocknum);
+    Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
+    const excBlock = {blk, isFinally, breakDepth: this.u.breakBlocks.length};
+    this.u.exceptionHandlerBlocks.push(excBlock);
+    return excBlock;
+}
+
+Compiler.prototype.popExceptionHandlerBlock = function() {
+    this.u.exceptionHandlerBlocks.pop();
+}
+
+Compiler.prototype.closeOutExceptionHandlersAndMaybeJumpToFinally = function(continuingOrBreaking, valueOfPostFinally) {
+    // We are emitting code for a continue, break, or return. We need to close out
+    // all of the exception handlers between us and either the loop we're in or the function scope.
+    // They're all stored in excBlocks
+
+    const myBreakDepth = continuingOrBreaking ? this.u.breakBlocks.length : 0;
+    const excBlocks = this.u.exceptionHandlerBlocks;
+
+    for (let excBlkIdx = excBlocks.length - 1; excBlkIdx >= 0 && excBlocks[excBlkIdx].breakDepth >= myBreakDepth; excBlkIdx--) {
+        const excBlock = excBlocks[excBlkIdx];
+        out("$exc.pop();");
+        if (excBlock.isFinally) {
+            if (valueOfPostFinally !== undefined) {
+                out("$postfinally=", valueOfPostFinally, ";");
+            }
+            // jump to the body of the finally block
+            out("$blk=",excBlock.blk,";continue;");
+            // When it's done executing, the finally body will call closeOutExceptionHandlers()
+            // to continue down the chain of exception handlers.
+            return false;
+        }
+    }
+    // After calling this code, the caller must emit a jump/return to the eventual destination. It will be ignored if we've already
+    // jumped to a finally block, or it will fall through efficiently to it if all we did was pop off an exception from the stack.
+    return true;
+}
+
 
 Compiler.prototype.setupExcept = function (eb) {
     out("$exc.push(", eb, ");");
-    //this.pushExceptBlock(eb);
+    return this.pushExceptionHandlerBlock(eb, false);
 };
 
 Compiler.prototype.endExcept = function () {
     out("$exc.pop();");
+    this.popExceptionHandlerBlock();
+};
+
+Compiler.prototype.setupFinally = function (eb) {
+    out("$exc.push(", eb, ");");
+    return this.pushExceptionHandlerBlock(eb, true);
+};
+
+Compiler.prototype.endFinally = function () {
+    out("$exc.pop();");
+    this.popExceptionHandlerBlock();
 };
 
 Compiler.prototype.outputLocals = function (unit) {
@@ -1574,6 +1625,36 @@ Compiler.prototype.outputFinallyCascade = function (thisFinally) {
     }
 };
 
+Compiler.prototype.outputFinallyCascade = function (thisFinally) {
+
+    // What do we do when we're done executing a 'finally' block?
+    // Normally you just fall off the end. If we're 'return'ing,
+    // 'continue'ing or 'break'ing, $postfinally tells us what to do.
+    //
+    // But we might still be inside one or more nested try: blocks, so we
+    // need to clear the exception stack and/or jump to an outer finally block.
+    // We use the same logic as continue/break/return here, although we have
+    // to generate both cases because we don't know until runtime whether this
+    // is a break/continue or a return.
+    //
+    // (NB we do NOT deal with re-raising exceptions here. That's handled
+    // elsewhere, because 'with' does special things with exceptions.)
+
+    out("if($postfinally!==undefined) {",
+          "if($postfinally.returning) {");
+
+    if(this.closeOutExceptionHandlersAndMaybeJumpToFinally(false)) {
+        out("return $postfinally.returning;")
+    }
+
+    out(  "} else {");
+    if (this.closeOutExceptionHandlersAndMaybeJumpToFinally(true)) {
+        out("$blk=$postfinally.gotoBlock;$postfinally=undefined;continue;")
+    }
+    out(  "}",
+        "}");
+};
+
 Compiler.prototype.ctry = function (s) {
     var check;
     var next;
@@ -1594,9 +1675,7 @@ Compiler.prototype.ctry = function (s) {
         finalExceptionToReRaise = this._gr("finally_reraise", "undefined");
 
         this.u.tempsToSave.push(finalExceptionToReRaise);
-        this.pushFinallyBlock(finalBody);
-        thisFinally = this.peekFinallyBlock();
-        this.setupExcept(finalExceptionHandler);
+        thisFinally = this.setupFinally(finalBody);
     }
 
     // Create a block for each except clause
@@ -1657,7 +1736,7 @@ Compiler.prototype.ctry = function (s) {
     this.setBlock(end);
     // End of the try/catch/else segment
     if (s.finalbody) {
-        this.endExcept();
+        this.endFinally();
 
         this._jump(finalBody);
 
@@ -1668,7 +1747,7 @@ Compiler.prototype.ctry = function (s) {
         this._jump(finalBody);
 
         this.setBlock(finalBody);
-        this.popFinallyBlock();
+        this.popExceptionHandlerBlock();
         this.vseqstmt(s.finalbody);
         // If finalbody executes normally, AND we have an exception
         // to re-raise, we raise it.
@@ -1708,8 +1787,7 @@ Compiler.prototype.cwith = function (s, itemIdx) {
     value = this._gr("value", "$ret");
 
     // try:
-    this.pushFinallyBlock(tidyUp);
-    thisFinallyBlock = this.u.finallyBlocks[this.u.finallyBlocks.length-1];
+    thisFinallyBlock = this.setupFinally(tidyUp);
     this.setupExcept(exceptionHandler);
 
     //    VAR = value
@@ -1728,10 +1806,12 @@ Compiler.prototype.cwith = function (s, itemIdx) {
     }
 
     this.endExcept();
+    this.endFinally(); // Note that this "finally" doesn't cover the exception handler
     this._jump(tidyUp);
 
     // except:
     this.setBlock(exceptionHandler);
+    out("$exc.pop()"); // skip "finally" handler
 
     //   if not exit(*sys.exc_info()):
     //     raise
@@ -1743,7 +1823,7 @@ Compiler.prototype.cwith = function (s, itemIdx) {
     // finally: (kinda. NB that this is a "finally" that doesn't run in the
     //           exception case!)
     this.setBlock(tidyUp);
-    this.popFinallyBlock();
+    this.popExceptionHandlerBlock();
 
     //   exit(None, None, None)
     out("$ret = Sk.misceval.callsimOrSuspendArray(",exit,",[Sk.builtin.none.none$,Sk.builtin.none.none$,Sk.builtin.none.none$]);");
@@ -2485,33 +2565,24 @@ Compiler.prototype.cclass = function (s) {
 };
 
 Compiler.prototype.ccontinue = function (s) {
-    var nextFinally = this.peekFinallyBlock(), gotoBlock;
     if (this.u.continueBlocks.length == 0) {
         throw new Sk.builtin.SyntaxError("'continue' outside loop", this.filename, s.lineno);
     }
-    // todo; continue out of exception blocks
+    // todo; continue out of exception blocks?
     gotoBlock = this.u.continueBlocks[this.u.continueBlocks.length - 1];
     Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
-    if (nextFinally && nextFinally.breakDepth == this.u.continueBlocks.length) {
-        out("$postfinally={isBreak:true,gotoBlock:",gotoBlock,"};");
-    } else {
-        this._jump(gotoBlock);
-    }
+    this.closeOutExceptionHandlersAndMaybeJumpToFinally(true, "{isBreak:true,gotoBlock:"+gotoBlock+"}");
+    this._jump(gotoBlock);
 };
 
-Compiler.prototype.cbreak = function (s) {
-    var nextFinally = this.peekFinallyBlock(), gotoBlock;
-
+Compiler.prototype.cbreak = function(s) {
     if (this.u.breakBlocks.length === 0) {
         throw new Sk.builtin.SyntaxError("'break' outside loop", this.filename, s.lineno);
     }
     gotoBlock = this.u.breakBlocks[this.u.breakBlocks.length - 1];
-    if (nextFinally && nextFinally.breakDepth == this.u.breakBlocks.length) {
-        out("$postfinally={isBreak:true,gotoBlock:",gotoBlock,"};");
-    } else {
-        this._jump(gotoBlock);
-    }
-};
+    this.closeOutExceptionHandlersAndMaybeJumpToFinally(true, "{isBreak:true,gotoBlock:"+gotoBlock+"}");
+    this._jump(gotoBlock);
+}
 
 /**
  * compiles a statement
@@ -2554,12 +2625,8 @@ Compiler.prototype.vstmt = function (s, class_for_super) {
                 throw new Sk.builtin.SyntaxError("'return' outside function", this.filename, s.lineno);
             }
             val = s.value ? this.vexpr(s.value) : "Sk.builtin.none.none$";
-            if (this.u.finallyBlocks.length == 0) {
-                out("return ", val, ";");
-            } else {
-                out("$postfinally={returning:",val,"};");
-                this._jump(this.peekFinallyBlock().blk);
-            }
+            this.closeOutExceptionHandlersAndMaybeJumpToFinally(false, "{returning:"+val+"}");
+            out("return ", val, ";");
             break;
         case Sk.astnodes.Delete:
             this.vseqexpr(s.targets);

--- a/src/compile.js
+++ b/src/compile.js
@@ -1238,9 +1238,9 @@ Compiler.prototype.endExcept = function () {
     this.popExceptionHandlerBlock();
 };
 
-Compiler.prototype.setupFinally = function (eb) {
-    out("$exc.push(", eb, ");");
-    return this.pushExceptionHandlerBlock(eb, true);
+Compiler.prototype.setupFinally = function (finallyBody, excHandler) {
+    out("$exc.push(", excHandler , ");");
+    return this.pushExceptionHandlerBlock(finallyBody, true);
 };
 
 Compiler.prototype.endFinally = function () {
@@ -1675,7 +1675,7 @@ Compiler.prototype.ctry = function (s) {
         finalExceptionToReRaise = this._gr("finally_reraise", "undefined");
 
         this.u.tempsToSave.push(finalExceptionToReRaise);
-        thisFinally = this.setupFinally(finalBody);
+        thisFinally = this.setupFinally(finalBody, finalExceptionHandler);
     }
 
     // Create a block for each except clause
@@ -1747,7 +1747,6 @@ Compiler.prototype.ctry = function (s) {
         this._jump(finalBody);
 
         this.setBlock(finalBody);
-        this.popExceptionHandlerBlock();
         this.vseqstmt(s.finalbody);
         // If finalbody executes normally, AND we have an exception
         // to re-raise, we raise it.
@@ -1787,7 +1786,7 @@ Compiler.prototype.cwith = function (s, itemIdx) {
     value = this._gr("value", "$ret");
 
     // try:
-    thisFinallyBlock = this.setupFinally(tidyUp);
+    thisFinallyBlock = this.setupFinally(tidyUp, tidyUp);
     this.setupExcept(exceptionHandler);
 
     //    VAR = value

--- a/src/compile.js
+++ b/src/compile.js
@@ -1188,17 +1188,17 @@ Compiler.prototype.peekFinallyBlock = function() {
 };
 */
 
-Compiler.prototype.pushExceptionHandlerBlock = function(blk, isFinally) {
+Compiler.prototype.pushExceptionHandlerBlock = function (blk, isFinally) {
     Sk.asserts.assert(blk >= 0 && blk < this.u.blocknum);
     Sk.asserts.assert(this.u.breakBlocks.length === this.u.continueBlocks.length);
-    const excBlock = {blk, isFinally, breakDepth: this.u.breakBlocks.length};
+    const excBlock = { blk, isFinally, breakDepth: this.u.breakBlocks.length };
     this.u.exceptionHandlerBlocks.push(excBlock);
     return excBlock;
-}
+};
 
-Compiler.prototype.popExceptionHandlerBlock = function() {
+Compiler.prototype.popExceptionHandlerBlock = function () {
     this.u.exceptionHandlerBlocks.pop();
-}
+};
 
 Compiler.prototype.closeOutExceptionHandlersAndMaybeJumpToFinally = function(continuingOrBreaking, valueOfPostFinally) {
     // We are emitting code for a continue, break, or return. We need to close out
@@ -1225,7 +1225,7 @@ Compiler.prototype.closeOutExceptionHandlersAndMaybeJumpToFinally = function(con
     // After calling this code, the caller must emit a jump/return to the eventual destination. It will be ignored if we've already
     // jumped to a finally block, or it will fall through efficiently to it if all we did was pop off an exception from the stack.
     return true;
-}
+};
 
 
 Compiler.prototype.setupExcept = function (eb) {
@@ -1644,12 +1644,12 @@ Compiler.prototype.outputFinallyCascade = function (thisFinally) {
           "if($postfinally.returning) {");
 
     if(this.closeOutExceptionHandlersAndMaybeJumpToFinally(false)) {
-        out("return $postfinally.returning;")
+        out("return $postfinally.returning;");
     }
 
     out(  "} else {");
     if (this.closeOutExceptionHandlersAndMaybeJumpToFinally(true)) {
-        out("$blk=$postfinally.gotoBlock;$postfinally=undefined;continue;")
+        out("$blk=$postfinally.gotoBlock;$postfinally=undefined;continue;");
     }
     out(  "}",
         "}");
@@ -1811,7 +1811,7 @@ Compiler.prototype.cwith = function (s, itemIdx) {
 
     // except:
     this.setBlock(exceptionHandler);
-    out("$exc.pop()"); // skip "finally" handler
+    out("$exc.pop();"); // skip "finally" handler
 
     //   if not exit(*sys.exc_info()):
     //     raise
@@ -2582,7 +2582,7 @@ Compiler.prototype.cbreak = function(s) {
     gotoBlock = this.u.breakBlocks[this.u.breakBlocks.length - 1];
     this.closeOutExceptionHandlersAndMaybeJumpToFinally(true, "{isBreak:true,gotoBlock:"+gotoBlock+"}");
     this._jump(gotoBlock);
-}
+};
 
 /**
  * compiles a statement

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -15,42 +15,6 @@ class B(A):
     def __init__(self, foo):
         super().__init__(foo)
 
-i = 0
-def foo():
-    global i
-    try:
-        return
-    finally:
-        i += 1
-        raise Exception("foo")
-
-
-def foo2():
-    global i
-    while i < 5:
-        try:
-            try: pass
-            finally: break
-        except:
-            pass
-    i += 1
-    raise Exception("foo")
-
-
-class Foo:
-    def __enter__(self):
-        return self
-    def __exit__(self, *args):
-        global i
-        i += 1
-        raise Exception("foo")
-
-
-def foo3():
-    with Foo():
-        return
-
-
 
 class Meta(type):
     def __call__(cls, *args, **kws):
@@ -491,22 +455,122 @@ class TestGeneratorCells(unittest.TestCase):
         with self.assertRaises(UnboundLocalError):
             value
 
-    def test_finally_raises(self):
-        def helper(fn):
-            global i
+
+class TestFinallyControlFlow(unittest.TestCase):
+    def test_finally_reraises(self):
+        error = ValueError("original")
+
+        def run():
             try:
-                fn()
-            except Exception:
+                raise error
+            finally:
                 pass
-            self.assertEqual(i, 1)
-            i = 0
+        with self.assertRaises(ValueError) as caught:
+            run()
+        self.assertIs(caught.exception, error)
 
-        helper(foo)
-        helper(foo2)
-        helper(foo3)
+    def test_return_finally_raises_once(self):
+        calls = []
 
+        def run():
+            try:
+                return
+            finally:
+                calls.append("finally")
+                raise ValueError("cleanup")
+        self.assertRaises(ValueError, run)
+        self.assertEqual(calls, ["finally"])
 
+    def test_break_finally_removes_except_handler(self):
+        calls = []
 
+        def run():
+            for _ in range(2):
+                try:
+                    try:
+                        pass
+                    finally:
+                        break
+                except ValueError:
+                    calls.append("stale handler")
+            calls.append("after loop")
+            raise ValueError("after loop")
+        self.assertRaises(ValueError, run)
+        self.assertEqual(calls, ["after loop"])
+
+    def test_with_exit_raises_once_on_return(self):
+        calls = []
+
+        class Manager:
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                calls.append("exit")
+                raise ValueError("exit")
+
+        def run():
+            with Manager():
+                return
+        self.assertRaises(ValueError, run)
+        self.assertEqual(calls, ["exit"])
+
+    def test_with_preserves_enclosing_finally(self):
+        # Extend CPython test_with.NonLocalFlowControlTestCase.testWithReturn
+        # to check cleanup outside the context manager as well.
+        calls = []
+
+        class Manager:
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                calls.append("exit")
+
+        def run():
+            try:
+                with Manager():
+                    pass
+                return 42
+            finally:
+                calls.append("finally")
+        self.assertEqual(run(), 42)
+        self.assertEqual(calls, ["exit", "finally"])
+
+    def test_continue_preserves_handler_outside_loop(self):
+        calls = []
+        try:
+            for i in range(2):
+                try:
+                    try:
+                        continue
+                    finally:
+                        calls.append(i)
+                except ValueError:
+                    calls.append("stale handler")
+            raise ValueError("after loop")
+        except ValueError:
+            calls.append("outer handler")
+        self.assertEqual(calls, [0, 1, "outer handler"])
+
+    def test_nested_with_return_cleanup_order(self):
+        calls = []
+
+        class Manager:
+            def __init__(self, name):
+                self.name = name
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                calls.append(self.name)
+
+        def run():
+            try:
+                with Manager("outer"), Manager("inner"):
+                    return 42
+            finally:
+                calls.append("finally")
+
+        self.assertEqual(run(), 42)
+        self.assertEqual(calls, ["inner", "outer", "finally"])
 
 
 if __name__ == "__main__":

--- a/test/unit3/test_skulpt_bugs.py
+++ b/test/unit3/test_skulpt_bugs.py
@@ -15,6 +15,42 @@ class B(A):
     def __init__(self, foo):
         super().__init__(foo)
 
+i = 0
+def foo():
+    global i
+    try:
+        return
+    finally:
+        i += 1
+        raise Exception("foo")
+
+
+def foo2():
+    global i
+    while i < 5:
+        try:
+            try: pass
+            finally: break
+        except:
+            pass
+    i += 1
+    raise Exception("foo")
+
+
+class Foo:
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        global i
+        i += 1
+        raise Exception("foo")
+
+
+def foo3():
+    with Foo():
+        return
+
+
 
 class Meta(type):
     def __call__(cls, *args, **kws):
@@ -454,6 +490,23 @@ class TestGeneratorCells(unittest.TestCase):
         self.assertEqual(list(g), [])
         with self.assertRaises(UnboundLocalError):
             value
+
+    def test_finally_raises(self):
+        def helper(fn):
+            global i
+            try:
+                fn()
+            except Exception:
+                pass
+            self.assertEqual(i, 1)
+            i = 0
+
+        helper(foo)
+        helper(foo2)
+        helper(foo3)
+
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`return`, `break`, and `continue` can leave exception handlers active after leaving a `try` or `with` block. If cleanup then raises, execution can jump back into that same cleanup.

The compiler now tracks `except` and `finally` handlers in nesting order and removes each runtime handler before running its cleanup. Separate entries into `finally` handle exceptions and pending returns or loop jumps. Context-manager cleanup also preserves enclosing handlers.

Rebased from https://github.com/meredydd/skulpt/pull/16, with a follow-up fixing an extra handler pop and adding regression coverage. Stacked on #1605 because it changes the same compiler code for context managers and generator suspensions.

Validation:

- Development and production builds passed using `NODE_OPTIONS=--openssl-legacy-provider` on Node 26.
- Full `npm test` passed: 465 Python 2 tests, 2,964 Python 3 tests, and suspension checks.
- Seven regressions passed on CPython 3.12, covering exception propagation, cleanup running once, loop boundaries, and nested `with` cleanup order.
- `npm run dist` returned 0, but the final docs copy reported `ENOTDIR` for `doc/static/debugger`.
